### PR TITLE
Fix macOS build: wrap WAL fdatasync with fsync fallback

### DIFF
--- a/src/include/common/fdatasync.hpp
+++ b/src/include/common/fdatasync.hpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// common/fdatasync.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <unistd.h>
+
+namespace duckdb {
+
+// Cross-platform equivalent of POSIX fdatasync(2). On macOS, where
+// fdatasync is not declared, falls back to fsync(2). Note that on macOS
+// this only flushes the OS page cache to the drive — it does NOT flush
+// the drive's own write cache. Strict "data on media" durability on
+// macOS additionally requires fcntl(fd, F_FULLFSYNC); tracked separately.
+inline int Fdatasync(int fd) {
+#if defined(__APPLE__)
+    return ::fsync(fd);
+#else
+    return ::fdatasync(fd);
+#endif
+}
+
+} // namespace duckdb

--- a/src/storage/wal.cpp
+++ b/src/storage/wal.cpp
@@ -10,6 +10,7 @@
 #include "storage/delta_store.hpp"
 #include "common/checksum.hpp"
 #include "common/exception.hpp"
+#include "common/fdatasync.hpp"
 #include "spdlog/spdlog.h"
 
 #include <cerrno>
@@ -104,7 +105,7 @@ void WALWriter::WriteHeader() {
         p += n;
         remaining -= (size_t)n;
     }
-    if (::fdatasync(fd_) != 0) {
+    if (Fdatasync(fd_) != 0) {
         int err = errno;
         if (err == EIO) {
             throw FatalException("[WAL] fdatasync(%s) returned EIO after header", path_);
@@ -210,7 +211,7 @@ void WALWriter::CommitEntry() {
     //    metadata we don't need (mtime), so it's cheaper than fsync. EIO
     //    from fsync is unrecoverable — per the fsyncgate discussion the
     //    dirty pages are gone and retrying won't help.
-    if (::fdatasync(fd_) != 0) {
+    if (Fdatasync(fd_) != 0) {
         int err = errno;
         if (err == EIO) {
             throw FatalException("[WAL] fdatasync(%s) returned EIO — data may be lost", path_);
@@ -344,7 +345,7 @@ void WALWriter::Flush() {
     // common case. Keep it as an explicit sync for defensive callers and in
     // case future code adds unsynced writes.
     if (fd_ < 0) return;
-    if (::fdatasync(fd_) != 0) {
+    if (Fdatasync(fd_) != 0) {
         int err = errno;
         if (err == EIO) {
             throw FatalException("[WAL] fdatasync(%s) returned EIO", path_);


### PR DESCRIPTION
## Summary

- Restores the macOS `build-portable` build, which fails at HEAD because `src/storage/wal.cpp` calls Linux-only `::fdatasync(fd)` directly. Closes #65.
- Adds a small cross-platform helper `duckdb::Fdatasync(int fd)` in `src/include/common/fdatasync.hpp` that falls back to `::fsync(fd)` on Apple platforms and stays as `::fdatasync(fd)` on Linux.
- Routes the three call sites in `wal.cpp` (header write, per-entry commit, `Flush`) through the new helper. Error-message strings and surrounding control flow are unchanged.

## Why

`fdatasync(2)` is a Linux-specific syscall that is not declared by macOS's `<unistd.h>`. AppleClang therefore fails with `error: no member named 'fdatasync' in the global namespace` at three call sites. The helper is a minimal one-liner-per-platform shim that keeps the Linux semantics intact while letting the macOS portable build go green.

## Notes for reviewers

- **Durability semantic on macOS is intentionally weaker than Linux for now.** `fsync(2)` on macOS flushes the OS page cache to the drive, but does **not** flush the drive's internal write cache. Strict "data on media" durability on macOS requires `fcntl(fd, F_FULLFSYNC)`, which is significantly slower (often 10×+) and is what SQLite's `PRAGMA fullfsync` and PostgreSQL's `wal_sync_method = fsync_writethrough` provide as opt-in knobs. Adding an equivalent opt-in switch is a separate, larger change (it requires either runtime config plumbing — currently mostly stubbed in `ClientConfig` — or a new compile-time macro in the same vein as `TURBOLYNX_PORTABLE_DISK_IO`). I'll file a follow-up issue to track that; this PR keeps scope tight to "make the macOS build compile again."
- Helper is placed in `common/` rather than `wal.hpp` because the same Linux-only-`fdatasync` issue will recur for any future durable-write code paths (checkpoint files, mappings, etc.).
- Naming: `duckdb::Fdatasync` (PascalCase, matching the existing DuckDB-derived convention like `GetConfig`); namespace separation distinguishes it from libc's `::fdatasync`.

## Test plan

- [x] `cmake --build build-portable` succeeds on macOS x86_64 (AppleClang 17.0). Previously failed at `src/storage/wal.cpp:107/213/347`; now compiles and links `libturbolynx.dylib` and `tools/turbolynx` cleanly.
- [ ] Linux build unaffected (helper compiles to the same `::fdatasync` call). CI / a Linux reviewer can confirm.
- [ ] No behavioral change expected for existing tests; the helper preserves return value / errno semantics.