### PR TITLE
test/query: parameterize LDBC + TPC-H expected counts by fixture; enable [ldbc][count] in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -73,6 +73,12 @@ jobs:
           # store, failing the build. TBB_STRICT=OFF disables -Werror in
           # oneTBB's own targets (warnings still print). macOS uses
           # AppleClang which doesn't emit this warning.
+          #
+          # TURBOLYNX_{LDBC,TPCH}_FIXTURE_MINI=ON: compile the [ldbc] /
+          # [tpch] tests with the SF0.003 / SF0.01 mini fixture counts
+          # instead of the SF1 defaults, since CI loads the committed
+          # mini fixtures (test/data/{ldbc,tpch}-mini/). Local SF1
+          # development omits these flags.
           cmake -GNinja \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_PYTHON=ON \
@@ -81,6 +87,8 @@ jobs:
             -DBUILD_UNITTESTS=ON \
             -DTBB_TEST=OFF \
             -DTBB_STRICT=OFF \
+            -DTURBOLYNX_LDBC_FIXTURE_MINI=ON \
+            -DTURBOLYNX_TPCH_FIXTURE_MINI=ON \
             -DPython3_EXECUTABLE="$(which python)" \
             -B build-portable
 
@@ -102,12 +110,17 @@ jobs:
         # a follow-up cleanup before they can run in CI.
         run: ./build-portable/test/query/query_test "[tpch]~[broken-mini]~[stress]" --tpch-path /tmp/tpch-mini-ws
 
-      - name: Load LDBC SF0.003 mini fixture (smoke check only)
-        # PR scope: just verify the fixture + load script work end-to-end on
-        # both OSes. The [ldbc] test cases hardcode SF1 row counts and will
-        # be migrated to SF0.003 in a follow-up PR; once that lands we can
-        # add the matching `query_test "[ldbc]..."` invocation here.
+      - name: Load LDBC SF0.003 mini fixture
         run: bash scripts/load-ldbc-mini.sh build-portable /tmp/ldbc-mini-ws
+
+      - name: Run LDBC [count] tests on mini fixture
+        # `[ldbc][count]` matches all 30 count cases (Catch2 selects tests
+        # whose tag list contains every tag in the filter). The few cases
+        # tagged `[!mayfail]` won't fail the suite if they regress; they
+        # reflect known-flaky areas pre-migration. Other LDBC categories
+        # (filter, traversal, IS/IC, robustness) need per-test count or
+        # ID-rewrite migration and land in follow-up PRs.
+        run: ./build-portable/test/query/query_test "[ldbc][count]" --ldbc-path /tmp/ldbc-mini-ws
 
       - name: Build Python wheel
         run: bash tools/pythonpkg/scripts/build_wheel.sh build-portable

--- a/scripts/load-ldbc-mini.sh
+++ b/scripts/load-ldbc-mini.sh
@@ -32,10 +32,10 @@ mkdir -p "$WS"
 
 "$TURBOLYNX" import \
     --workspace "$WS" \
-    --nodes Person       "$DATA/dynamic/Person.csv" \
-    --nodes Comment      "$DATA/dynamic/Comment.csv" \
-    --nodes Post         "$DATA/dynamic/Post.csv" \
-    --nodes Forum        "$DATA/dynamic/Forum.csv" \
+    --nodes Person          "$DATA/dynamic/Person.csv" \
+    --nodes Comment:Message "$DATA/dynamic/Comment.csv" \
+    --nodes Post:Message    "$DATA/dynamic/Post.csv" \
+    --nodes Forum           "$DATA/dynamic/Forum.csv" \
     --nodes Organisation "$DATA/static/Organisation.csv" \
     --nodes Place        "$DATA/static/Place.csv" \
     --nodes Tag          "$DATA/static/Tag.csv" \

--- a/test/query/CMakeLists.txt
+++ b/test/query/CMakeLists.txt
@@ -66,6 +66,21 @@ target_compile_definitions(query_test PRIVATE
     TURBOLYNX_REPO_ROOT="${CMAKE_SOURCE_DIR}"
 )
 
+# Mini-fixture switches. When set, the LDBC and TPC-H test sources
+# (and the integrity probes in query_test_main.cpp) compile with the
+# expected counts for the small mini fixtures committed under
+# test/data/ldbc-mini/ and test/data/tpch-mini/, instead of SF1/SF1
+# values. CI sets these so the suite runs against the committed
+# fixtures; leave unset for local SF1 development workflows.
+option(TURBOLYNX_LDBC_FIXTURE_MINI "Compile LDBC tests for the SF0.003 mini fixture" OFF)
+option(TURBOLYNX_TPCH_FIXTURE_MINI "Compile TPC-H tests for the SF0.01 mini fixture" OFF)
+if(TURBOLYNX_LDBC_FIXTURE_MINI)
+    target_compile_definitions(query_test PRIVATE TURBOLYNX_LDBC_FIXTURE_MINI=1)
+endif()
+if(TURBOLYNX_TPCH_FIXTURE_MINI)
+    target_compile_definitions(query_test PRIVATE TURBOLYNX_TPCH_FIXTURE_MINI=1)
+endif()
+
 # DB paths can be set at cmake time or passed at runtime
 # via --ldbc-path / --tpch-path / --oss-path.
 set(TURBOLYNX_LDBC_PATH "" CACHE PATH "Path to LDBC SF1 database for query tests")

--- a/test/query/helpers/ldbc_expected_counts.hpp
+++ b/test/query/helpers/ldbc_expected_counts.hpp
@@ -1,0 +1,93 @@
+// LDBC SNB expected vertex / edge counts.
+//
+// Two fixture sizes are supported by the same test sources:
+//
+//   * SF1     — the legacy benchmark fixture, loaded externally via
+//               `scripts/load-ldbc.sh`. This is the default selection.
+//               Values are the originals previously hard-coded in
+//               `test_ldbc_count.cpp` ("verified against Neo4j 5.24.0").
+//   * SF0.003 — the committed mini fixture under `test/data/ldbc-mini/`,
+//               loaded via `scripts/load-ldbc-mini.sh` and used by CI.
+//               Selected by `cmake -DTURBOLYNX_LDBC_FIXTURE_MINI=ON`.
+//               Values were verified against Neo4j 5 with the same
+//               fixture loaded via `neo4j-admin database import`.
+
+#pragma once
+#include <cstdint>
+
+namespace ldbc {
+
+#ifdef TURBOLYNX_LDBC_FIXTURE_MINI
+// SF0.003 mini fixture — Neo4j-verified.
+inline constexpr int64_t PERSON_COUNT       = 50;
+inline constexpr int64_t COMMENT_COUNT      = 790;
+inline constexpr int64_t POST_COUNT         = 3385;
+inline constexpr int64_t FORUM_COUNT        = 400;
+inline constexpr int64_t TAG_COUNT          = 16080;
+inline constexpr int64_t TAGCLASS_COUNT     = 71;
+inline constexpr int64_t PLACE_COUNT        = 1460;
+inline constexpr int64_t ORGANISATION_COUNT = 7955;
+
+inline constexpr int64_t KNOWS_COUNT                = 88;
+inline constexpr int64_t HAS_CREATOR_COMMENT_COUNT  = 790;
+inline constexpr int64_t HAS_CREATOR_POST_COUNT     = 3385;
+inline constexpr int64_t LIKES_COMMENT_COUNT        = 228;
+inline constexpr int64_t LIKES_POST_COUNT           = 421;
+inline constexpr int64_t CONTAINER_OF_COUNT         = 3385;
+inline constexpr int64_t REPLY_OF_POST_COUNT        = 411;
+inline constexpr int64_t REPLY_OF_COMMENT_COUNT     = 379;
+inline constexpr int64_t HAS_TAG_COMMENT_COUNT      = 847;
+inline constexpr int64_t HAS_TAG_POST_COUNT         = 214;
+inline constexpr int64_t HAS_TAG_FORUM_COUNT        = 1606;
+inline constexpr int64_t HAS_TYPE_COUNT             = 16080;
+inline constexpr int64_t IS_PART_OF_COUNT           = 1454;
+
+// Multi-partition vertex / edge counts (Comment + Post both have the
+// :Message label per the load script's `--nodes Comment:Message` /
+// `--nodes Post:Message` flags).
+inline constexpr int64_t MESSAGE_COUNT               = 4175;
+inline constexpr int64_t HAS_CREATOR_MESSAGE_COUNT   = 4175;
+inline constexpr int64_t LIKES_MESSAGE_COUNT         = 649;
+inline constexpr int64_t HAS_TAG_MESSAGE_COUNT       = 1061;
+inline constexpr int64_t IS_LOCATED_IN_MESSAGE_COUNT = 4175;
+inline constexpr int64_t IS_LOCATED_IN_TOTAL_COUNT   = 12180;
+
+#else
+// SF1 (full) — original values, Neo4j 5.24.0 verified.
+inline constexpr int64_t PERSON_COUNT       = 9892;
+inline constexpr int64_t COMMENT_COUNT      = 2052169;
+inline constexpr int64_t POST_COUNT         = 1003605;
+inline constexpr int64_t FORUM_COUNT        = 90492;
+inline constexpr int64_t TAG_COUNT          = 16080;
+inline constexpr int64_t TAGCLASS_COUNT     = 71;
+inline constexpr int64_t PLACE_COUNT        = 1460;
+inline constexpr int64_t ORGANISATION_COUNT = 7955;
+
+inline constexpr int64_t KNOWS_COUNT                = 180623;
+inline constexpr int64_t HAS_CREATOR_COMMENT_COUNT  = 2052169;
+inline constexpr int64_t HAS_CREATOR_POST_COUNT     = 1003605;
+inline constexpr int64_t LIKES_COMMENT_COUNT        = 1438418;
+inline constexpr int64_t LIKES_POST_COUNT           = 751677;
+inline constexpr int64_t CONTAINER_OF_COUNT         = 1003605;
+inline constexpr int64_t REPLY_OF_POST_COUNT        = 1011420;
+inline constexpr int64_t REPLY_OF_COMMENT_COUNT     = 1040749;
+inline constexpr int64_t HAS_TAG_COMMENT_COUNT      = 2698393;
+inline constexpr int64_t HAS_TAG_POST_COUNT         = 713258;
+inline constexpr int64_t HAS_TAG_FORUM_COUNT        = 309766;
+inline constexpr int64_t HAS_TYPE_COUNT             = 16080;
+inline constexpr int64_t IS_PART_OF_COUNT           = 1454;
+
+inline constexpr int64_t MESSAGE_COUNT               = 3055774;
+inline constexpr int64_t HAS_CREATOR_MESSAGE_COUNT   = 3055774;
+inline constexpr int64_t LIKES_MESSAGE_COUNT         = 2190095;
+inline constexpr int64_t HAS_TAG_MESSAGE_COUNT       = 3411651;
+inline constexpr int64_t IS_LOCATED_IN_MESSAGE_COUNT = 3055774;
+inline constexpr int64_t IS_LOCATED_IN_TOTAL_COUNT   = 3073621;
+#endif
+
+// Strict lower bound for the [bug-a2] count(*) regression: count(*) on
+// a no-label MATCH must exceed the largest single-label count we already
+// pin (Person). Same expression on both fixtures.
+inline constexpr int64_t COUNT_STAR_LOWER_BOUND = PERSON_COUNT;
+
+}  // namespace ldbc

--- a/test/query/helpers/tpch_expected_counts.hpp
+++ b/test/query/helpers/tpch_expected_counts.hpp
@@ -1,0 +1,82 @@
+// TPC-H expected per-query row counts and vertex cardinalities.
+//
+// Two fixture sizes are supported by the same test sources:
+//
+//   * SF1     — the legacy benchmark fixture, loaded externally via
+//               `scripts/load-tpch.sh`. Default selection. Counts are
+//               the originals previously hard-coded in
+//               `test_tpch_correctness.cpp` ("DuckDB reference CSVs").
+//   * SF0.01  — the committed mini fixture under `test/data/tpch-mini/`,
+//               loaded via `scripts/load-tpch-mini.sh` and used by CI.
+//               Selected by `cmake -DTURBOLYNX_TPCH_FIXTURE_MINI=ON`.
+//               Counts measured on the committed fixture against the
+//               engine that introduced this fixture (consistent for
+//               regression detection — when individual queries are
+//               cross-validated with DuckDB, swap the literal here).
+
+#pragma once
+#include <cstdint>
+
+namespace tpch {
+
+#ifdef TURBOLYNX_TPCH_FIXTURE_MINI
+// SF0.01 mini fixture (test/data/tpch-mini/).
+// Q1, Q3, Q5, Q6, Q7, Q9, Q10, Q11, Q14, Q15, Q19 currently SIGSEGV
+// inside the engine on this fixture (issue #69) and are wrapped with
+// `TPCH_TEST_BROKEN_MINI` in the test file — no expected count needed.
+inline constexpr int64_t Q2  = 5;
+inline constexpr int64_t Q4  = 5;
+inline constexpr int64_t Q8  = 2;
+inline constexpr int64_t Q12 = 2;
+inline constexpr int64_t Q13 = 32;
+inline constexpr int64_t Q16 = 315;
+inline constexpr int64_t Q17 = 1;
+inline constexpr int64_t Q18 = 0;  // predicate `sum(l_quantity) > 300` filters all rows at SF0.01
+inline constexpr int64_t Q20 = 2;
+inline constexpr int64_t Q21 = 1;
+inline constexpr int64_t Q22 = 7;
+
+// Vertex counts for the SF0.01 integrity probe.
+inline constexpr int64_t LINEITEM_COUNT = 60175;
+inline constexpr int64_t ORDERS_COUNT   = 15000;
+inline constexpr int64_t CUSTOMER_COUNT = 1500;
+inline constexpr int64_t SUPPLIER_COUNT = 100;
+inline constexpr int64_t PART_COUNT     = 2000;
+inline constexpr int64_t NATION_COUNT   = 25;
+inline constexpr int64_t REGION_COUNT   = 5;
+#else
+// SF1 (full benchmark) — DuckDB-reference verified.
+inline constexpr int64_t Q1  = 4;
+inline constexpr int64_t Q2  = 100;
+inline constexpr int64_t Q3  = 10;
+inline constexpr int64_t Q4  = 5;
+inline constexpr int64_t Q5  = 5;
+inline constexpr int64_t Q6  = 1;
+inline constexpr int64_t Q7  = 4;
+inline constexpr int64_t Q8  = 2;
+inline constexpr int64_t Q9  = 175;
+inline constexpr int64_t Q10 = 20;
+inline constexpr int64_t Q11 = 925;
+inline constexpr int64_t Q12 = 2;
+inline constexpr int64_t Q13 = 42;
+inline constexpr int64_t Q14 = 1;
+inline constexpr int64_t Q15 = 1;
+inline constexpr int64_t Q16 = 18354;
+inline constexpr int64_t Q17 = 1;
+inline constexpr int64_t Q18 = 9;
+inline constexpr int64_t Q19 = 1;
+inline constexpr int64_t Q20 = 165;
+inline constexpr int64_t Q21 = 100;
+inline constexpr int64_t Q22 = 7;
+
+// Vertex counts for the SF1 integrity probe.
+inline constexpr int64_t LINEITEM_COUNT = 6001215;
+inline constexpr int64_t ORDERS_COUNT   = 1500000;
+inline constexpr int64_t CUSTOMER_COUNT = 150000;
+inline constexpr int64_t SUPPLIER_COUNT = 10000;
+inline constexpr int64_t PART_COUNT     = 200000;
+inline constexpr int64_t NATION_COUNT   = 25;
+inline constexpr int64_t REGION_COUNT   = 5;
+#endif
+
+}  // namespace tpch

--- a/test/query/query_test_main.cpp
+++ b/test/query/query_test_main.cpp
@@ -1,6 +1,8 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 #include "helpers/query_runner.hpp"
+#include "helpers/ldbc_expected_counts.hpp"
+#include "helpers/tpch_expected_counts.hpp"
 
 #include <string>
 #include <vector>
@@ -84,35 +86,32 @@ void disconnect_active_runner() {
     disconnect_active_runner_impl();
 }
 
-// Expected LDBC vertex counts for the SF0.003 mini fixture committed
-// at test/data/ldbc-mini/ (loaded via scripts/load-ldbc-mini.sh). The
-// fixture is what CI loads and what the [ldbc] tests run against.
-// Tag/TagClass/Organisation/Place are constant across scale factors
-// (LDBC SNB definition).
+// Expected vertex counts for the LDBC and TPC-H integrity probes.
+// Both sets pull from cmake-selected helper headers — the same
+// `*_FIXTURE_MINI` define that gates the test files below also picks
+// the right values here, so the integrity message stays accurate
+// regardless of which fixture (full SF1/SF1, mini SF0.003/SF0.01) the
+// caller loads.
 struct ExpectedCount { const char* label; const char* query; int64_t expected; };
 static const ExpectedCount LDBC_CHECKS[] = {
-    {"Person",       "MATCH (n:Person) RETURN count(n)",       50},
-    {"Comment",      "MATCH (n:Comment) RETURN count(n)",      790},
-    {"Post",         "MATCH (n:Post) RETURN count(n)",         3385},
-    {"Forum",        "MATCH (n:Forum) RETURN count(n)",        400},
-    {"Tag",          "MATCH (n:Tag) RETURN count(n)",          16080},
-    {"TagClass",     "MATCH (n:TagClass) RETURN count(n)",     71},
-    {"Organisation", "MATCH (n:Organisation) RETURN count(n)", 7955},
-    {"Place",        "MATCH (n:Place) RETURN count(n)",        1460},
+    {"Person",       "MATCH (n:Person) RETURN count(n)",       ldbc::PERSON_COUNT},
+    {"Comment",      "MATCH (n:Comment) RETURN count(n)",      ldbc::COMMENT_COUNT},
+    {"Post",         "MATCH (n:Post) RETURN count(n)",         ldbc::POST_COUNT},
+    {"Forum",        "MATCH (n:Forum) RETURN count(n)",        ldbc::FORUM_COUNT},
+    {"Tag",          "MATCH (n:Tag) RETURN count(n)",          ldbc::TAG_COUNT},
+    {"TagClass",     "MATCH (n:TagClass) RETURN count(n)",     ldbc::TAGCLASS_COUNT},
+    {"Organisation", "MATCH (n:Organisation) RETURN count(n)", ldbc::ORGANISATION_COUNT},
+    {"Place",        "MATCH (n:Place) RETURN count(n)",        ldbc::PLACE_COUNT},
 };
 
-// Expected TPC-H vertex counts for the SF0.01 mini fixture committed
-// at test/data/tpch-mini/ (loaded via scripts/load-tpch-mini.sh). The
-// fixture is what CI loads and what the [tpch] tests run against.
-// NATION/REGION are constant across scale factors.
 static const ExpectedCount TPCH_CHECKS[] = {
-    {"LINEITEM", "MATCH (n:LINEITEM) RETURN count(n)", 60175},
-    {"ORDERS",   "MATCH (n:ORDERS) RETURN count(n)",   15000},
-    {"CUSTOMER", "MATCH (n:CUSTOMER) RETURN count(n)", 1500},
-    {"SUPPLIER", "MATCH (n:SUPPLIER) RETURN count(n)", 100},
-    {"PART",     "MATCH (n:PART) RETURN count(n)",     2000},
-    {"NATION",   "MATCH (n:NATION) RETURN count(n)",   25},
-    {"REGION",   "MATCH (n:REGION) RETURN count(n)",   5},
+    {"LINEITEM", "MATCH (n:LINEITEM) RETURN count(n)", tpch::LINEITEM_COUNT},
+    {"ORDERS",   "MATCH (n:ORDERS) RETURN count(n)",   tpch::ORDERS_COUNT},
+    {"CUSTOMER", "MATCH (n:CUSTOMER) RETURN count(n)", tpch::CUSTOMER_COUNT},
+    {"SUPPLIER", "MATCH (n:SUPPLIER) RETURN count(n)", tpch::SUPPLIER_COUNT},
+    {"PART",     "MATCH (n:PART) RETURN count(n)",     tpch::PART_COUNT},
+    {"NATION",   "MATCH (n:NATION) RETURN count(n)",   tpch::NATION_COUNT},
+    {"REGION",   "MATCH (n:REGION) RETURN count(n)",   tpch::REGION_COUNT},
 };
 
 // Expected OSS supply-chain fixture vertex counts

--- a/test/query/test_ldbc_count.cpp
+++ b/test/query/test_ldbc_count.cpp
@@ -1,8 +1,16 @@
 // Stage 1 — Node / Edge count smoke tests
-// All expected values verified against Neo4j 5.24.0 with LDBC SF1.
+//
+// Two fixture sizes are supported by the same source file. The
+// expected counts are pulled from `helpers/ldbc_expected_counts.hpp`,
+// which selects between the SF1 (default) and SF0.003 (mini) values
+// based on the `TURBOLYNX_LDBC_FIXTURE_MINI` cmake define. SF1 values
+// were verified against Neo4j 5.24.0 originally; SF0.003 values were
+// verified against Neo4j 5 with the same `test/data/ldbc-mini/`
+// fixture loaded via `neo4j-admin database import`.
 
 #include "catch.hpp"
 #include "helpers/query_runner.hpp"
+#include "helpers/ldbc_expected_counts.hpp"
 
 extern std::string g_ldbc_path;
 extern bool g_skip_requested;
@@ -22,7 +30,7 @@ extern qtest::QueryRunner* get_ldbc_runner();
 
 TEST_CASE("Person count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (p:Person) RETURN count(p)") == 9892);
+    REQUIRE(qr->count("MATCH (p:Person) RETURN count(p)") == ldbc::PERSON_COUNT);
 }
 
 TEST_CASE("MPV count(*) — no-label MATCH", "[ldbc][count][bug-a2]") {
@@ -30,48 +38,48 @@ TEST_CASE("MPV count(*) — no-label MATCH", "[ldbc][count][bug-a2]") {
     // Pre-fix this aborted in ORCA's normalizer because column pruning over
     // a multi-vertex-partition NodeScan + count(*) collapsed every branch's
     // ProjectColumnar to NULL. The regression is "plans + executes without
-    // aborting"; the exact total is left unpinned to avoid coupling to LDBC
-    // SF1 vertex totals — we just sanity-check it strictly exceeds the
-    // largest single-label count we already verify (Person == 9892).
+    // aborting"; the exact total is left unpinned to avoid coupling to a
+    // specific scale factor — we just sanity-check it strictly exceeds the
+    // largest single-label count we already verify (Person).
     auto rows = qr->run("MATCH (n) RETURN count(*) AS cnt",
                         {qtest::ColType::INT64});
     REQUIRE(rows.size() == 1);
-    CHECK(rows[0].int64_at(0) > 9892);
+    CHECK(rows[0].int64_at(0) > ldbc::COUNT_STAR_LOWER_BOUND);
 }
 
 TEST_CASE("Comment count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (c:Comment) RETURN count(c)") == 2052169);
+    REQUIRE(qr->count("MATCH (c:Comment) RETURN count(c)") == ldbc::COMMENT_COUNT);
 }
 
 TEST_CASE("Post count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (p:Post) RETURN count(p)") == 1003605);
+    REQUIRE(qr->count("MATCH (p:Post) RETURN count(p)") == ldbc::POST_COUNT);
 }
 
 TEST_CASE("Forum count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (f:Forum) RETURN count(f)") == 90492);
+    REQUIRE(qr->count("MATCH (f:Forum) RETURN count(f)") == ldbc::FORUM_COUNT);
 }
 
 TEST_CASE("Tag count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (t:Tag) RETURN count(t)") == 16080);
+    REQUIRE(qr->count("MATCH (t:Tag) RETURN count(t)") == ldbc::TAG_COUNT);
 }
 
 TEST_CASE("TagClass count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (tc:TagClass) RETURN count(tc)") == 71);
+    REQUIRE(qr->count("MATCH (tc:TagClass) RETURN count(tc)") == ldbc::TAGCLASS_COUNT);
 }
 
 TEST_CASE("Place count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (pl:Place) RETURN count(pl)") == 1460);
+    REQUIRE(qr->count("MATCH (pl:Place) RETURN count(pl)") == ldbc::PLACE_COUNT);
 }
 
 TEST_CASE("Organisation count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (o:Organisation) RETURN count(o)") == 7955);
+    REQUIRE(qr->count("MATCH (o:Organisation) RETURN count(o)") == ldbc::ORGANISATION_COUNT);
 }
 
 // ---------------------------------------------------------------------------
@@ -80,67 +88,67 @@ TEST_CASE("Organisation count", "[ldbc][count]") {
 
 TEST_CASE("KNOWS count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN count(r)") == 180623);
+    REQUIRE(qr->count("MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN count(r)") == ldbc::KNOWS_COUNT);
 }
 
 TEST_CASE("HAS_CREATOR (Comment->Person) count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (a:Comment)-[r:HAS_CREATOR]->(b:Person) RETURN count(r)") == 2052169);
+    REQUIRE(qr->count("MATCH (a:Comment)-[r:HAS_CREATOR]->(b:Person) RETURN count(r)") == ldbc::HAS_CREATOR_COMMENT_COUNT);
 }
 
 TEST_CASE("HAS_CREATOR (Post->Person) count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (a:Post)-[r:HAS_CREATOR]->(b:Person) RETURN count(r)") == 1003605);
+    REQUIRE(qr->count("MATCH (a:Post)-[r:HAS_CREATOR]->(b:Person) RETURN count(r)") == ldbc::HAS_CREATOR_POST_COUNT);
 }
 
 TEST_CASE("LIKES (Person->Comment) count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (a:Person)-[r:LIKES]->(b:Comment) RETURN count(r)") == 1438418);
+    REQUIRE(qr->count("MATCH (a:Person)-[r:LIKES]->(b:Comment) RETURN count(r)") == ldbc::LIKES_COMMENT_COUNT);
 }
 
 TEST_CASE("LIKES (Person->Post) count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (a:Person)-[r:LIKES]->(b:Post) RETURN count(r)") == 751677);
+    REQUIRE(qr->count("MATCH (a:Person)-[r:LIKES]->(b:Post) RETURN count(r)") == ldbc::LIKES_POST_COUNT);
 }
 
 TEST_CASE("CONTAINER_OF count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (a:Forum)-[r:CONTAINER_OF]->(b:Post) RETURN count(r)") == 1003605);
+    REQUIRE(qr->count("MATCH (a:Forum)-[r:CONTAINER_OF]->(b:Post) RETURN count(r)") == ldbc::CONTAINER_OF_COUNT);
 }
 
 TEST_CASE("REPLY_OF (Comment->Post) count", "[ldbc][count][!mayfail]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (a:Comment)-[r:REPLY_OF]->(b:Post) RETURN count(r)") == 1011420);
+    REQUIRE(qr->count("MATCH (a:Comment)-[r:REPLY_OF]->(b:Post) RETURN count(r)") == ldbc::REPLY_OF_POST_COUNT);
 }
 
 TEST_CASE("REPLY_OF (Comment->Comment) count", "[ldbc][count][!mayfail]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (a:Comment)-[r:REPLY_OF]->(b:Comment) RETURN count(r)") == 1040749);
+    REQUIRE(qr->count("MATCH (a:Comment)-[r:REPLY_OF]->(b:Comment) RETURN count(r)") == ldbc::REPLY_OF_COMMENT_COUNT);
 }
 
 TEST_CASE("HAS_TAG (Comment->Tag) count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (a:Comment)-[r:HAS_TAG]->(b:Tag) RETURN count(r)") == 2698393);
+    REQUIRE(qr->count("MATCH (a:Comment)-[r:HAS_TAG]->(b:Tag) RETURN count(r)") == ldbc::HAS_TAG_COMMENT_COUNT);
 }
 
 TEST_CASE("HAS_TAG (Post->Tag) count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (a:Post)-[r:HAS_TAG]->(b:Tag) RETURN count(r)") == 713258);
+    REQUIRE(qr->count("MATCH (a:Post)-[r:HAS_TAG]->(b:Tag) RETURN count(r)") == ldbc::HAS_TAG_POST_COUNT);
 }
 
 TEST_CASE("HAS_TAG (Forum->Tag) count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (a:Forum)-[r:HAS_TAG]->(b:Tag) RETURN count(r)") == 309766);
+    REQUIRE(qr->count("MATCH (a:Forum)-[r:HAS_TAG]->(b:Tag) RETURN count(r)") == ldbc::HAS_TAG_FORUM_COUNT);
 }
 
 TEST_CASE("HAS_TYPE count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (a:Tag)-[r:HAS_TYPE]->(b:TagClass) RETURN count(r)") == 16080);
+    REQUIRE(qr->count("MATCH (a:Tag)-[r:HAS_TYPE]->(b:TagClass) RETURN count(r)") == ldbc::HAS_TYPE_COUNT);
 }
 
 TEST_CASE("IS_PART_OF count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (a:Place)-[r:IS_PART_OF]->(b:Place) RETURN count(r)") == 1454);
+    REQUIRE(qr->count("MATCH (a:Place)-[r:IS_PART_OF]->(b:Place) RETURN count(r)") == ldbc::IS_PART_OF_COUNT);
 }
 
 // ---------------------------------------------------------------------------
@@ -149,7 +157,7 @@ TEST_CASE("IS_PART_OF count", "[ldbc][count]") {
 
 TEST_CASE("Message count", "[ldbc][count][mpv][!mayfail]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count("MATCH (m:Message) RETURN count(m)") == 3055774);
+    REQUIRE(qr->count("MATCH (m:Message) RETURN count(m)") == ldbc::MESSAGE_COUNT);
 }
 
 // ---------------------------------------------------------------------------
@@ -159,32 +167,31 @@ TEST_CASE("Message count", "[ldbc][count][mpv][!mayfail]") {
 TEST_CASE("HAS_CREATOR (Message->Person) count", "[ldbc][count][mpe]") {
     SKIP_IF_NO_DB();
     REQUIRE(qr->count(
-        "MATCH (m:Message)-[r:HAS_CREATOR]->(p:Person) RETURN count(r)") == 3055774);
+        "MATCH (m:Message)-[r:HAS_CREATOR]->(p:Person) RETURN count(r)") == ldbc::HAS_CREATOR_MESSAGE_COUNT);
 }
 
 TEST_CASE("LIKES (Person->Message) count", "[ldbc][count][mpe]") {
     SKIP_IF_NO_DB();
     REQUIRE(qr->count(
-        "MATCH (p:Person)-[r:LIKES]->(m:Message) RETURN count(r)") == 2190095);
+        "MATCH (p:Person)-[r:LIKES]->(m:Message) RETURN count(r)") == ldbc::LIKES_MESSAGE_COUNT);
 }
 
 TEST_CASE("HAS_TAG (Message->Tag) count", "[ldbc][count][mpe]") {
     SKIP_IF_NO_DB();
     REQUIRE(qr->count(
-        "MATCH (m:Message)-[r:HAS_TAG]->(t:Tag) RETURN count(r)") == 3411651);
+        "MATCH (m:Message)-[r:HAS_TAG]->(t:Tag) RETURN count(r)") == ldbc::HAS_TAG_MESSAGE_COUNT);
 }
 
 TEST_CASE("IS_LOCATED_IN (Message->Place) count", "[ldbc][count][mpe]") {
     SKIP_IF_NO_DB();
     REQUIRE(qr->count(
-        "MATCH (m:Message)-[r:IS_LOCATED_IN]->(pl:Place) RETURN count(r)") == 3055774);
+        "MATCH (m:Message)-[r:IS_LOCATED_IN]->(pl:Place) RETURN count(r)") == ldbc::IS_LOCATED_IN_MESSAGE_COUNT);
 }
 
-// Person(9892) + Comment(2052169) + Post(1003605) + Organisation(7955) = 3073621
 TEST_CASE("IS_LOCATED_IN total count", "[ldbc][count][mpe]") {
     SKIP_IF_NO_DB();
     REQUIRE(qr->count(
-        "MATCH (a)-[r:IS_LOCATED_IN]->(b:Place) RETURN count(r)") == 3073621);
+        "MATCH (a)-[r:IS_LOCATED_IN]->(b:Place) RETURN count(r)") == ldbc::IS_LOCATED_IN_TOTAL_COUNT);
 }
 
 // ---------------------------------------------------------------------------
@@ -200,8 +207,8 @@ TEST_CASE("IS_LOCATED_IN total count", "[ldbc][count][mpe]") {
 TEST_CASE("count(*) on triangle pattern runs without assertion",
           "[ldbc][count][regression]") {
     SKIP_IF_NO_DB();
-    // The exact query does not need to have a non-zero answer on SF1 — what
-    // matters is that the pipeline completes without hitting the
+    // The exact query does not need to have a non-zero answer at any scale —
+    // what matters is that the pipeline completes without hitting the
     // `!types.empty()` assertion at data_chunk.cpp:40. We just require a
     // single row (the count scalar) to come back.
     auto r = qr->run(

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -1,26 +1,27 @@
 // Stage 9 — TPC-H query tests
 //
-// Reads Cypher queries from benchmark/tpch/sf1/q*.cql and verifies
-// result row counts against pre-computed expected values for the
-// loaded fixture.
+// Reads Cypher queries from `benchmark/tpch/sf1/q*.cql` and verifies
+// result row counts against `helpers/tpch_expected_counts.hpp`, which
+// dispatches between the SF1 (default) and SF0.01 (mini) values based
+// on the `TURBOLYNX_TPCH_FIXTURE_MINI` cmake define.
 //
 // Two fixture sizes are supported:
-//   * SF0.01  — the committed mini fixture under test/data/tpch-mini/.
-//                Used by CI (loaded via scripts/load-tpch-mini.sh).
-//                Most queries pass; a number of them currently SIGSEGV
-//                inside the engine and are tagged [.broken-mini] so
-//                they're hidden from the default [tpch] run. Tracked
-//                in issue #69.
-//   * SF1     — the full benchmark workspace (loaded via
-//                scripts/load-tpch.sh). Selected via the cmake-time
-//                option -DTURBOLYNX_TPCH_FIXTURE_SF1=ON; defaults to
-//                SF0.01.
+//   * SF1     — the legacy benchmark fixture, loaded externally via
+//                `scripts/load-tpch.sh`. Default selection. SF1 expected
+//                counts come from DuckDB-generated reference CSVs.
+//   * SF0.01  — the committed mini fixture under `test/data/tpch-mini/`,
+//                loaded via `scripts/load-tpch-mini.sh`. CI uses this.
+//                Eleven of the 22 queries currently SIGSEGV at this
+//                scale (issue #69) and are wrapped with the
+//                `TPCH_TEST_BROKEN_MINI` macro / `[broken-mini]` tag so
+//                they don't tear down the rest of the run.
 //
 // The path to the .cql query files is resolved at compile time via
 // the TURBOLYNX_REPO_ROOT define injected by CMakeLists.txt.
 
 #include "catch.hpp"
 #include "helpers/query_runner.hpp"
+#include "helpers/tpch_expected_counts.hpp"
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -46,9 +47,6 @@ struct DeltaGuard {
     if (!qr) { FAIL("Cannot open DB: " << g_tpch_path); return; } \
     DeltaGuard _delta_guard(qr)
 
-// Path to the .cql query files. TURBOLYNX_REPO_ROOT is set at cmake time
-// (test/query/CMakeLists.txt) so the test binary stays self-contained
-// regardless of the current working directory.
 #ifndef TURBOLYNX_REPO_ROOT
 #error "TURBOLYNX_REPO_ROOT must be defined by the build system"
 #endif
@@ -72,7 +70,7 @@ TEST_CASE("TPC-H Q" #qnum, "[tpch][q" #qnum "]") { \
         std::string query = readFile(QUERY_DIR + "q" #qnum ".cql"); \
         REQUIRE(!query.empty()); \
         auto r = qr->run(query.c_str(), {}); \
-        size_t exp = expected_rows; \
+        size_t exp = (size_t)(expected_rows); \
         if (exp > 0) { \
             CHECK(r.size() == exp); \
         } \
@@ -81,13 +79,9 @@ TEST_CASE("TPC-H Q" #qnum, "[tpch][q" #qnum "]") { \
     } \
 }
 
-// Macro for a query that SIGSEGVs inside the engine on the SF0.01
-// mini fixture. Tagged [broken-mini] so CI can exclude it via
-// `[tpch]~[broken-mini]`; otherwise the SIGSEGV would tear down the
-// rest of the test run. To probe its current state during a fix:
-//   ./query_test "[broken-mini]" --tpch-path /path/to/ws
-// When the underlying engine bug is fixed, replace the macro use with
-// `TPCH_TEST(qnum, <SF0.01 row count>)`.
+// SF0.01-only macro for queries that SIGSEGV inside the engine on the
+// mini fixture. Tagged `[broken-mini]` so the CI filter excludes them.
+// When the underlying engine bug is fixed, replace with `TPCH_TEST(qnum, ...)`.
 #define TPCH_TEST_BROKEN_MINI(qnum, issue) \
 TEST_CASE("TPC-H Q" #qnum " (broken on SF0.01, issue " issue ")", \
           "[tpch][q" #qnum "][broken-mini]") { \
@@ -100,27 +94,19 @@ TEST_CASE("TPC-H Q" #qnum " (broken on SF0.01, issue " issue ")", \
     FAIL("Query no longer crashes — replace TPCH_TEST_BROKEN_MINI with TPCH_TEST"); \
 }
 
-// Expected row counts on the committed SF0.01 mini fixture
-// (test/data/tpch-mini/), measured against the engine at the commit
-// that introduced this fixture. Eleven queries currently crash with
-// SIGSEGV inside the engine and are deferred via TPCH_TEST_BROKEN_MINI;
-// see issue #69.
-
-// Passing on SF0.01 mini fixture
-TPCH_TEST(2, 5)
-TPCH_TEST(4, 5)
-TPCH_TEST(8, 2)
-TPCH_TEST(12, 2)
-TPCH_TEST(13, 32)
-TPCH_TEST(16, 315)
-TPCH_TEST(17, 1)
-TPCH_TEST(18, 0)   // SF0.01: predicate `sum(l_quantity) > 300` filters all rows; SF1 returns 9.
-TPCH_TEST(20, 2)
-TPCH_TEST(21, 1)
-TPCH_TEST(22, 7)
-
-// SIGSEGV on SF0.01 mini fixture (DECIMAL arithmetic in aggregates is
-// the strongest suspect — most failing queries match this shape).
+#ifdef TURBOLYNX_TPCH_FIXTURE_MINI
+// SF0.01 mini fixture: 11 passing queries + 11 broken-mini.
+TPCH_TEST(2,  tpch::Q2)
+TPCH_TEST(4,  tpch::Q4)
+TPCH_TEST(8,  tpch::Q8)
+TPCH_TEST(12, tpch::Q12)
+TPCH_TEST(13, tpch::Q13)
+TPCH_TEST(16, tpch::Q16)
+TPCH_TEST(17, tpch::Q17)
+TPCH_TEST(18, tpch::Q18)
+TPCH_TEST(20, tpch::Q20)
+TPCH_TEST(21, tpch::Q21)
+TPCH_TEST(22, tpch::Q22)
 TPCH_TEST_BROKEN_MINI(1,  "#69")
 TPCH_TEST_BROKEN_MINI(3,  "#69")
 TPCH_TEST_BROKEN_MINI(5,  "#69")
@@ -132,3 +118,28 @@ TPCH_TEST_BROKEN_MINI(11, "#69")
 TPCH_TEST_BROKEN_MINI(14, "#69")
 TPCH_TEST_BROKEN_MINI(15, "#69")
 TPCH_TEST_BROKEN_MINI(19, "#69")
+#else
+// SF1 (full benchmark): all 22 queries exercised.
+TPCH_TEST(1,  tpch::Q1)
+TPCH_TEST(2,  tpch::Q2)
+TPCH_TEST(3,  tpch::Q3)
+TPCH_TEST(4,  tpch::Q4)
+TPCH_TEST(5,  tpch::Q5)
+TPCH_TEST(6,  tpch::Q6)
+TPCH_TEST(7,  tpch::Q7)
+TPCH_TEST(8,  tpch::Q8)
+TPCH_TEST(9,  tpch::Q9)
+TPCH_TEST(10, tpch::Q10)
+TPCH_TEST(11, tpch::Q11)
+TPCH_TEST(12, tpch::Q12)
+TPCH_TEST(13, tpch::Q13)
+TPCH_TEST(14, tpch::Q14)
+TPCH_TEST(15, tpch::Q15)
+TPCH_TEST(16, tpch::Q16)
+TPCH_TEST(17, tpch::Q17)
+TPCH_TEST(18, tpch::Q18)
+TPCH_TEST(19, tpch::Q19)
+TPCH_TEST(20, tpch::Q20)
+TPCH_TEST(21, tpch::Q21)
+TPCH_TEST(22, tpch::Q22)
+#endif


### PR DESCRIPTION
## Summary

PRs [#70](https://github.com/turbolynx-dslab/TurboLynx/pull/70) and [#71](https://github.com/turbolynx-dslab/TurboLynx/pull/71) overwrote the SF1 / SF1 expected row counts in the query tests with mini-fixture (SF0.01 / SF0.003) values. That broke the local SF1 dev workflow — devs loading the full benchmark workspaces would see all the migrated tests fail with the wrong expectation. This PR restores SF1 support **alongside** the mini-fixture support, by parameterizing the expected counts at compile time.

* New `test/query/helpers/{ldbc,tpch}_expected_counts.hpp` headers expose `ldbc::*` / `tpch::*` constants. The two value sets are gated by `#ifdef TURBOLYNX_{LDBC,TPCH}_FIXTURE_MINI`.
* `test_ldbc_count.cpp` and `test_tpch_correctness.cpp` are rewritten to consume the constants — no literal scale-coupled numbers left in the test bodies.
* `query_test_main.cpp`'s LDBC / TPC-H integrity probes also pull from the headers.
* `test/query/CMakeLists.txt` adds two cmake options (`TURBOLYNX_LDBC_FIXTURE_MINI`, `TURBOLYNX_TPCH_FIXTURE_MINI`), default OFF.
* CI workflow turns both options ON when configuring cmake, since CI loads the committed mini fixtures.
* `scripts/load-ldbc-mini.sh` is fixed to assign the `:Message` multi-label to Comment + Post (`--nodes Comment:Message` / `--nodes Post:Message`) so MPV/MPE queries resolve. Without it, `MATCH (m:Message) ...` errored out as "Invalid Input Error: There is no vertex with the given label".
* CI gains a new `Run LDBC [count] tests on mini fixture` step now that the 30 cases pass cleanly at SF0.003.

## Verification

LDBC SF0.003 values were verified against **Neo4j 5** with the same `test/data/ldbc-mini/` fixture loaded via `neo4j-admin database import`. All 21 single-label / single-edge counts match between TurboLynx and Neo4j, plus the 5 `:Message` MPV/MPE counts after the multi-label load fix. Local run on the mini fixture:

```
$ ./build-portable/test/query/query_test "[ldbc][count]" --ldbc-path /tmp/ldbc-mini-final
[OK] LDBC SF0.003 mini fixture integrity verified
All tests passed (33 assertions in 30 test cases)
```

TPC-H SF0.01 expected row counts are the engine-derived smoke-grade values from #70 — the 11 queries that currently SIGSEGV on the mini fixture stay marked `TPCH_TEST_BROKEN_MINI` (issue #69). When each underlying engine bug is fixed, the broken-mini wrapper flips back to a normal `TPCH_TEST(qnum, tpch::QN)` and the cmake-conditional value pair in the helper header is the only place the row count needs maintaining.

## Why this matters

Before: SF1 dev workflow was silently broken after #70 / #71. The migrated tests would fail with confusing "expected 50, got 9892" diffs against a freshly-loaded SF1 workspace.

After: same source compiles to the right expectations for whichever fixture you have on disk. Devs add `-DTURBOLYNX_LDBC_FIXTURE_MINI=ON` (or just trust CI) when working against the small fixture; default cmake build keeps the SF1 numbers wired in.

## Notes for reviewers

- **Methodology — Neo4j as oracle.** Per-query Neo4j Docker setup (image `neo4j:5`, mounted local volume, `neo4j-admin database import full neo4j --delimiter='|' ...`) was used to derive the SF0.003 expectations. The Neo4j-side workflow lives in the maintainer's local environment, not the repo; we just commit the verified literals.
- **Type-difference safety.** The 30 count tests assert pure integer counts — Neo4j's DATETIME / BOOLEAN vs TurboLynx's DATE_EPOCHMS / INT difference doesn't surface here. Categories that compare datetime / boolean values (IS, IC, functions) need per-test value-conversion when they migrate; deferred to follow-up PRs.
- **Other LDBC categories deferred.** `[ldbc][functions]`, `[ldbc][traversal]`, `[ldbc][filter]`, `[ldbc][robustness]`, `[ldbc][is]`, `[ldbc][ic]` need per-test work (some have SF1-specific Person IDs hardcoded into queries — they can't run as-is on SF0.003 even with new expected values). Each lands as its own follow-up PR.
- **CRUD remains excluded** from the SF0.003 testing path entirely, per earlier discussion.

## Test plan

- [ ] Both matrix jobs (ubuntu-latest, macos-latest) reach `Run LDBC [count] tests on mini fixture` and pass 30/30.
- [ ] No regression in TPC-H mini run (still 11 passing + 11 broken-mini).
- [ ] `git grep '== 9892'` returns nothing in `test/query/` (literals migrated).