### PR TITLE
test/query: enable [ldbc][filter] on SF0.003 mini fixture in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -130,20 +130,21 @@ jobs:
         # and were Neo4j-verified on the SF0.003 fixture.
         run: ./build-portable/test/query/query_test "[ldbc][traversal]" --ldbc-path /tmp/ldbc-mini-ws
 
+      - name: Run LDBC [filter] tests on mini fixture
+        # `[ldbc][filter]` exercises property filters, UNWIND, scalar
+        # functions, map literals, ordered aggregation, paths, reduce,
+        # XOR, and string predicates against fixture-pinned sample
+        # Person/Forum/Tag/path constants (Neo4j-verified on SF0.003).
+        run: ./build-portable/test/query/query_test "[ldbc][filter]" --ldbc-path /tmp/ldbc-mini-ws
+
       - name: Run LDBC [func] tests on mini fixture
-        # `[ldbc][func]~[filter]` exercises Cypher meta/string/math
-        # functions (labels, type, keys, properties, random, setseed,
-        # string +, =~ regex) against a fixture-pinned sample Person
-        # (id=14 → "Hossein Forouhar"). The `~[filter]` exclusion
-        # drops cases that also carry `[filter]` — those still
-        # hardcode the SF1 Person id 933 and need separate ID-rewrite
-        # migration in a future PR. The two `[!mayfail]` cases for
-        # labels()/keys(node) track issue #73 (empty-string return on
-        # the mini fixture). Mini-only string-concat / regex probes
-        # use exact-match assertions; SF1 dev runs fall back to
-        # substring/structural checks since per-person literals
-        # aren't pinned for that scale.
-        run: ./build-portable/test/query/query_test "[ldbc][func]~[filter]" --ldbc-path /tmp/ldbc-mini-ws
+        # `[ldbc][func]` exercises Cypher meta/string/math functions
+        # (labels, type, keys, properties, random, setseed, string +,
+        # =~ regex). Now that the `[filter]` cases have been
+        # parameterized, the `~[filter]` exclusion is no longer
+        # needed. The two `[!mayfail]` cases for labels()/keys(node)
+        # track issue #73 (empty-string return on the mini fixture).
+        run: ./build-portable/test/query/query_test "[ldbc][func]" --ldbc-path /tmp/ldbc-mini-ws
 
       - name: Build Python wheel
         run: bash tools/pythonpkg/scripts/build_wheel.sh build-portable

--- a/test/query/helpers/ldbc_expected_counts.hpp
+++ b/test/query/helpers/ldbc_expected_counts.hpp
@@ -126,6 +126,66 @@ inline constexpr TravTagCount TRAV_TOP5_TAG_BY_MESSAGE[] = {
     {"Franz_Kafka",    14}, {"Jacques_Chirac", 11}
 };
 
+// ---- Filter test expected values (SAMPLE_PERSON 14 properties) ----
+inline constexpr const char* SAMPLE_PERSON_FIRST_NAME    = "Hossein";
+inline constexpr const char* SAMPLE_PERSON_LAST_NAME     = "Forouhar";
+inline constexpr const char* SAMPLE_PERSON_GENDER        = "male";
+inline constexpr int64_t     SAMPLE_PERSON_BIRTHDAY_MS   = 447811200000LL;
+inline constexpr const char* SAMPLE_PERSON_LOCATION_IP   = "77.245.239.11";
+inline constexpr const char* SAMPLE_PERSON_BROWSER       = "Firefox";
+inline constexpr int64_t     SAMPLE_PERSON_CITY_ID       = 1166;
+inline constexpr const char* SAMPLE_PERSON_CITY_NAME     = "Tehran";
+
+// SAMPLE_PERSON outgoing/likes counts (separate from
+// TRAV_KNOWS_FRIENDS_OF_SAMPLE_PERSON: that one is the *undirected*
+// distinct friend count; this is the one-way outgoing edge count).
+inline constexpr int64_t SAMPLE_PERSON_OUTGOING_KNOWS  = 3;
+inline constexpr int64_t SAMPLE_PERSON_LIKED_COMMENTS  = 4;
+inline constexpr int64_t SAMPLE_PERSON_LIKED_POSTS     = 8;
+inline constexpr int64_t SAMPLE_PERSON_LIKED_MESSAGES  = 12;
+
+// SAMPLE_PERSON's first interest tag in alphabetical order.
+// We pin only the first 4 chars because the full tag name varies and
+// the test only needs to verify ordered head() correctness.
+inline constexpr const char* SAMPLE_PERSON_FIRST_INTEREST_PREFIX = "2_Be";
+
+// String predicate fragments derived from SAMPLE_PERSON_FIRST_NAME ("Hossein").
+inline constexpr const char* SAMPLE_PERSON_NAME_STARTS_MATCH   = "Ho";   // STARTS WITH true
+inline constexpr const char* SAMPLE_PERSON_NAME_STARTS_NOMATCH = "Jo";   // STARTS WITH false
+inline constexpr const char* SAMPLE_PERSON_NAME_ENDS_MATCH     = "in";   // ENDS WITH true
+inline constexpr const char* SAMPLE_PERSON_NAME_CONTAINS_MATCH = "ss";   // CONTAINS true
+
+// Sample Forum: first row of TRAV_TOP5_FORUM_BY_POST (all five tie at
+// cnt=20 on this fixture, see PR #75 caveat).
+inline constexpr int64_t SAMPLE_FORUM_ID         = 137438953609LL;
+inline constexpr int64_t SAMPLE_FORUM_POST_COUNT = 20;
+
+// Sample Tag for HAS_TAG count tests: top tag by post/message count
+// on this fixture (Genghis_Khan has zero connections at SF0.003).
+inline constexpr const char* SAMPLE_TAG_NAME              = "Hannibal";
+inline constexpr int64_t     SAMPLE_TAG_POST_COUNT        = 17;
+inline constexpr int64_t     SAMPLE_TAG_MESSAGE_COUNT     = 33;
+
+// Sample second Person used by UNWIND-with-MATCH lookup (paired with
+// SAMPLE_PERSON_ID). Ordered by firstName ASC the row order is
+// "Hossein" (id=14) then "Jan" (id=16).
+inline constexpr int64_t     SECOND_SAMPLE_PERSON_ID         = 16;
+inline constexpr const char* SECOND_SAMPLE_PERSON_FIRST_NAME = "Jan";
+
+// Sample Country names that exist in SF0.003 (Place catalog is shared
+// across scales, but the load script does not tag :Country sub-labels,
+// so we keep the test on the parent :Place label).
+inline constexpr const char* SAMPLE_COUNTRY_NAME_1 = "Laos";
+inline constexpr const char* SAMPLE_COUNTRY_NAME_2 = "Scotland";
+
+// Path test endpoints — Person 14 -> Person 16 has 7 shortest paths
+// of length 3. allShortestPaths returning exactly 7 makes a sharp
+// regression check on the path enumeration.
+inline constexpr int64_t SAMPLE_PATH_SRC_ID        = 14;
+inline constexpr int64_t SAMPLE_PATH_DEST_ID       = 16;
+inline constexpr int64_t SAMPLE_PATH_LEN           = 3;
+inline constexpr int64_t SAMPLE_PATH_NUM_ALL_SHORTEST = 7;
+
 #else
 // SF1 (full) — original values, Neo4j 5.24.0 verified.
 inline constexpr int64_t PERSON_COUNT       = 9892;
@@ -218,6 +278,51 @@ inline constexpr TravTagCount TRAV_TOP5_TAG_BY_MESSAGE[] = {
     {"Muammar_Gaddafi",    12003}, {"Imelda_Marcos",  9571},
     {"Genghis_Khan",        8982}
 };
+
+// ---- Filter test expected values (SF1, Neo4j 5.24.0 verified) ----
+inline constexpr const char* SAMPLE_PERSON_FIRST_NAME    = "Mahinda";
+inline constexpr const char* SAMPLE_PERSON_LAST_NAME     = "Perera";
+inline constexpr const char* SAMPLE_PERSON_GENDER        = "male";
+inline constexpr int64_t     SAMPLE_PERSON_BIRTHDAY_MS   = 628646400000LL;
+inline constexpr const char* SAMPLE_PERSON_LOCATION_IP   = "119.235.7.103";
+inline constexpr const char* SAMPLE_PERSON_BROWSER       = "Firefox";
+inline constexpr int64_t     SAMPLE_PERSON_CITY_ID       = 1353;
+inline constexpr const char* SAMPLE_PERSON_CITY_NAME     = "Kelaniya";
+
+inline constexpr int64_t SAMPLE_PERSON_OUTGOING_KNOWS  = 5;
+inline constexpr int64_t SAMPLE_PERSON_LIKED_COMMENTS  = 12;
+inline constexpr int64_t SAMPLE_PERSON_LIKED_POSTS     = 5;
+inline constexpr int64_t SAMPLE_PERSON_LIKED_MESSAGES  = 17;
+
+inline constexpr const char* SAMPLE_PERSON_FIRST_INTEREST_PREFIX = "1962";
+
+inline constexpr const char* SAMPLE_PERSON_NAME_STARTS_MATCH   = "Ma";   // "Mahinda" STARTS WITH "Ma"
+inline constexpr const char* SAMPLE_PERSON_NAME_STARTS_NOMATCH = "Jo";
+inline constexpr const char* SAMPLE_PERSON_NAME_ENDS_MATCH     = "da";   // "Mahinda" ENDS WITH "da"
+inline constexpr const char* SAMPLE_PERSON_NAME_CONTAINS_MATCH = "ah";   // "Mahinda" CONTAINS "ah"
+
+inline constexpr int64_t SAMPLE_FORUM_ID         = 77644;
+inline constexpr int64_t SAMPLE_FORUM_POST_COUNT = 1208;
+
+inline constexpr const char* SAMPLE_TAG_NAME          = "Genghis_Khan";
+inline constexpr int64_t     SAMPLE_TAG_POST_COUNT    = 3715;
+inline constexpr int64_t     SAMPLE_TAG_MESSAGE_COUNT = 8982;
+
+inline constexpr int64_t     SECOND_SAMPLE_PERSON_ID         = 2199023262543LL;
+inline constexpr const char* SECOND_SAMPLE_PERSON_FIRST_NAME = "Samir";
+
+inline constexpr const char* SAMPLE_COUNTRY_NAME_1 = "Laos";
+inline constexpr const char* SAMPLE_COUNTRY_NAME_2 = "Scotland";
+
+// Path endpoints kept from the legacy SF1 test source. SF1 uses two
+// dest persons (one with a single shortest path, one with seven) — we
+// pin the seven-path dest here since both shortestPath and
+// allShortestPaths probes work against it.
+inline constexpr int64_t SAMPLE_PATH_SRC_ID           = 17592186055119LL;
+inline constexpr int64_t SAMPLE_PATH_DEST_ID          = 10995116282665LL;
+inline constexpr int64_t SAMPLE_PATH_LEN              = 3;
+inline constexpr int64_t SAMPLE_PATH_NUM_ALL_SHORTEST = 7;
+
 #endif
 
 // Strict lower bound for the [bug-a2] count(*) regression: count(*) on

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -1,8 +1,14 @@
 // Stage 2 — Property filter + 1-hop traversal
-// All expected values verified against Neo4j 5.24.0 with LDBC SF1.
+//
+// Two fixture sizes are supported via `helpers/ldbc_expected_counts.hpp`,
+// which dispatches between SF1 (default) and SF0.003 (mini, set with
+// `cmake -DTURBOLYNX_LDBC_FIXTURE_MINI=ON`). All SF0.003 expected
+// values are Neo4j-verified against the committed mini fixture.
 
 #include "catch.hpp"
 #include "helpers/query_runner.hpp"
+#include "helpers/ldbc_expected_counts.hpp"
+#include <string>
 
 extern std::string g_ldbc_path;
 extern bool g_skip_requested;
@@ -16,128 +22,136 @@ extern qtest::QueryRunner* get_ldbc_runner();
     auto* qr = get_ldbc_runner(); \
     if (!qr) { FAIL("Cannot open DB: " << g_ldbc_path); return; }
 
-TEST_CASE("Person 933 firstName/lastName", "[ldbc][filter]") {
+static std::string sample_person_id_str() {
+    return std::to_string(ldbc::SAMPLE_PERSON_ID);
+}
+
+TEST_CASE("Sample person firstName/lastName", "[ldbc][filter]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person) WHERE p.id = 933 "
-        "RETURN p.firstName, p.lastName",
+    auto q = "MATCH (p:Person) WHERE p.id = " + sample_person_id_str() +
+             " RETURN p.firstName, p.lastName";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::STRING, qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].str_at(0) == "Mahinda");
-    CHECK(r[0].str_at(1) == "Perera");
+    CHECK(r[0].str_at(0) == ldbc::SAMPLE_PERSON_FIRST_NAME);
+    CHECK(r[0].str_at(1) == ldbc::SAMPLE_PERSON_LAST_NAME);
 }
 
-TEST_CASE("Person 933 outgoing KNOWS count", "[ldbc][filter]") {
+TEST_CASE("Sample person outgoing KNOWS count", "[ldbc][filter]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count(
-        "MATCH (p:Person {id: 933})-[:KNOWS]->(friend:Person) "
-        "RETURN count(friend)") == 5);
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:KNOWS]->(friend:Person) RETURN count(friend)";
+    REQUIRE(qr->count(q.c_str()) == ldbc::SAMPLE_PERSON_OUTGOING_KNOWS);
 }
 
-TEST_CASE("Person 933 IS_LOCATED_IN City", "[ldbc][filter]") {
+// `:City` is a sub-label SF1's load script tags but `load-ldbc-mini.sh`
+// does not (Place.csv has a `type` column but the mini loader keeps them
+// all as `:Place`). We test :Place on both fixtures and gate the :City
+// probe on SF1 only.
+#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
+TEST_CASE("Sample person IS_LOCATED_IN City", "[ldbc][filter]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933})-[:IS_LOCATED_IN]->(pl:City) "
-        "RETURN pl.id, pl.name",
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:IS_LOCATED_IN]->(pl:City) RETURN pl.id, pl.name";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 1353);
-    CHECK(r[0].str_at(1) == "Kelaniya");
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_CITY_ID);
+    CHECK(r[0].str_at(1) == ldbc::SAMPLE_PERSON_CITY_NAME);
 }
+#endif
 
 // Parent-label UNION: :Place = City + Country + Continent.
-// Person IS_LOCATED_IN always targets a City, so result is the same.
-TEST_CASE("Person 933 IS_LOCATED_IN Place", "[ldbc][filter]") {
+// Person IS_LOCATED_IN always targets a City.
+TEST_CASE("Sample person IS_LOCATED_IN Place", "[ldbc][filter]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933})-[:IS_LOCATED_IN]->(pl:Place) "
-        "RETURN pl.id, pl.name",
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:IS_LOCATED_IN]->(pl:Place) RETURN pl.id, pl.name";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 1353);
-    CHECK(r[0].str_at(1) == "Kelaniya");
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_CITY_ID);
+    CHECK(r[0].str_at(1) == ldbc::SAMPLE_PERSON_CITY_NAME);
 }
 
-TEST_CASE("Person 933 properties", "[ldbc][filter]") {
+TEST_CASE("Sample person properties", "[ldbc][filter]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "RETURN p.gender, p.birthday, p.locationIP, p.browserUsed",
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+             "RETURN p.gender, p.birthday, p.locationIP, p.browserUsed";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::STRING, qtest::ColType::INT64,
          qtest::ColType::STRING, qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].str_at(0) == "male");
-    CHECK(r[0].int64_at(1) == 628646400000LL);
-    CHECK(r[0].str_at(2) == "119.235.7.103");
-    CHECK(r[0].str_at(3) == "Firefox");
+    CHECK(r[0].str_at(0) == ldbc::SAMPLE_PERSON_GENDER);
+    CHECK(r[0].int64_at(1) == ldbc::SAMPLE_PERSON_BIRTHDAY_MS);
+    CHECK(r[0].str_at(2) == ldbc::SAMPLE_PERSON_LOCATION_IP);
+    CHECK(r[0].str_at(3) == ldbc::SAMPLE_PERSON_BROWSER);
 }
 
-TEST_CASE("Comment 1236950581249 creator", "[ldbc][filter]") {
+TEST_CASE("Sample comment creator", "[ldbc][filter]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (c:Comment)-[:HAS_CREATOR]->(p:Person) "
-        "WHERE c.id = 1236950581249 "
-        "RETURN p.id, p.firstName",
+    auto q = "MATCH (c:Comment)-[:HAS_CREATOR]->(p:Person) "
+             "WHERE c.id = " + std::to_string(ldbc::SAMPLE_COMMENT_ID) + " "
+             "RETURN p.id, p.firstName";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 10995116284808LL);
-    CHECK(r[0].str_at(1) == "Andrei");
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_COMMENT_CREATOR_ID);
+    CHECK(r[0].str_at(1) == ldbc::SAMPLE_COMMENT_CREATOR_FIRSTNAME);
 }
 
-TEST_CASE("Forum 77644 post count", "[ldbc][filter]") {
+TEST_CASE("Sample forum post count", "[ldbc][filter]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count(
-        "MATCH (f:Forum)-[:CONTAINER_OF]->(p:Post) WHERE f.id = 77644 "
-        "RETURN count(p)") == 1208);
+    auto q = "MATCH (f:Forum)-[:CONTAINER_OF]->(p:Post) "
+             "WHERE f.id = " + std::to_string(ldbc::SAMPLE_FORUM_ID) + " "
+             "RETURN count(p)";
+    REQUIRE(qr->count(q.c_str()) == ldbc::SAMPLE_FORUM_POST_COUNT);
 }
 
-TEST_CASE("Post count with Tag Genghis_Khan", "[ldbc][filter]") {
+TEST_CASE("Post count with sample tag", "[ldbc][filter]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count(
-        "MATCH (p:Post)-[:HAS_TAG]->(t:Tag) WHERE t.name = 'Genghis_Khan' "
-        "RETURN count(p)") == 3715);
+    auto q = std::string("MATCH (p:Post)-[:HAS_TAG]->(t:Tag) WHERE t.name = '") +
+             ldbc::SAMPLE_TAG_NAME + "' RETURN count(p)";
+    REQUIRE(qr->count(q.c_str()) == ldbc::SAMPLE_TAG_POST_COUNT);
 }
 
-TEST_CASE("Person 933 liked Comments count", "[ldbc][filter]") {
+TEST_CASE("Sample person liked Comments count", "[ldbc][filter]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count(
-        "MATCH (p:Person {id: 933})-[:LIKES]->(c:Comment) "
-        "RETURN count(c)") == 12);
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:LIKES]->(c:Comment) RETURN count(c)";
+    REQUIRE(qr->count(q.c_str()) == ldbc::SAMPLE_PERSON_LIKED_COMMENTS);
 }
 
-TEST_CASE("Person 933 liked Posts count", "[ldbc][filter]") {
+TEST_CASE("Sample person liked Posts count", "[ldbc][filter]") {
     SKIP_IF_NO_DB();
-    REQUIRE(qr->count(
-        "MATCH (p:Person {id: 933})-[:LIKES]->(po:Post) "
-        "RETURN count(po)") == 5);
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:LIKES]->(po:Post) RETURN count(po)";
+    REQUIRE(qr->count(q.c_str()) == ldbc::SAMPLE_PERSON_LIKED_POSTS);
 }
 
 // ---------------------------------------------------------------------------
 // Multi-partition vertex/edge tests (M28 — :Message = Comment + Post)
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Person 933 Messages via HAS_CREATOR count", "[ldbc][filter][mpe]") {
+TEST_CASE("Sample person Messages via HAS_CREATOR count", "[ldbc][filter][mpe]") {
     SKIP_IF_NO_DB();
-    // Person 933 authored 57 comments + 313 posts = 370 messages
-    REQUIRE(qr->count(
-        "MATCH (:Person {id: 933})<-[:HAS_CREATOR]-(m:Message) "
-        "RETURN count(m)") == 370);
+    auto q = "MATCH (:Person {id: " + sample_person_id_str() +
+             "})<-[:HAS_CREATOR]-(m:Message) RETURN count(m)";
+    REQUIRE(qr->count(q.c_str()) == ldbc::TRAV_MESSAGES_AUTHORED_BY_SAMPLE_PERSON);
 }
 
-TEST_CASE("Person 933 liked Messages count", "[ldbc][filter][mpe]") {
+TEST_CASE("Sample person liked Messages count", "[ldbc][filter][mpe]") {
     SKIP_IF_NO_DB();
-    // Person 933 liked 12 comments + 5 posts = 17 messages
-    REQUIRE(qr->count(
-        "MATCH (p:Person {id: 933})-[:LIKES]->(m:Message) "
-        "RETURN count(m)") == 17);
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:LIKES]->(m:Message) RETURN count(m)";
+    REQUIRE(qr->count(q.c_str()) == ldbc::SAMPLE_PERSON_LIKED_MESSAGES);
 }
 
-TEST_CASE("Message count with Tag Genghis_Khan", "[ldbc][filter][mpe]") {
+TEST_CASE("Message count with sample tag", "[ldbc][filter][mpe]") {
     SKIP_IF_NO_DB();
-    // Genghis_Khan tag: Comment HAS_TAG 5267 + Post HAS_TAG 3715 = 8982
-    REQUIRE(qr->count(
-        "MATCH (m:Message)-[:HAS_TAG]->(t:Tag) WHERE t.name = 'Genghis_Khan' "
-        "RETURN count(m)") == 8982);
+    auto q = std::string("MATCH (m:Message)-[:HAS_TAG]->(t:Tag) WHERE t.name = '") +
+             ldbc::SAMPLE_TAG_NAME + "' RETURN count(m)";
+    REQUIRE(qr->count(q.c_str()) == ldbc::SAMPLE_TAG_MESSAGE_COUNT);
 }
 
 // ============================================================
@@ -146,36 +160,32 @@ TEST_CASE("Message count with Tag Genghis_Khan", "[ldbc][filter][mpe]") {
 
 TEST_CASE("UNWIND literal list", "[ldbc][filter][unwind]") {
     SKIP_IF_NO_DB();
-    // Basic: UNWIND a constant list. Use count to verify row count,
-    // then check individual values with string type.
     REQUIRE(qr->count("UNWIND [1, 2, 3] AS x RETURN count(x)") == 3);
     REQUIRE(qr->count("UNWIND [10, 20, 30] AS x RETURN sum(x)") == 60);
 }
 
 TEST_CASE("UNWIND with MATCH filter", "[ldbc][filter][unwind]") {
     SKIP_IF_NO_DB();
-    // UNWIND list of IDs, then use each to look up a Person
-    auto r = qr->run(
-        "UNWIND [933, 2199023262543] AS pid "
-        "MATCH (p:Person) WHERE p.id = pid "
-        "RETURN p.firstName ORDER BY p.firstName",
-        {qtest::ColType::STRING});
+    auto q = "UNWIND [" + sample_person_id_str() + ", " +
+             std::to_string(ldbc::SECOND_SAMPLE_PERSON_ID) + "] AS pid "
+             "MATCH (p:Person) WHERE p.id = pid "
+             "RETURN p.firstName ORDER BY p.firstName";
+    auto r = qr->run(q.c_str(), {qtest::ColType::STRING});
     REQUIRE(r.size() == 2);
-    CHECK(r[0].str_at(0) == "Mahinda");  // Person 933
-    CHECK(r[1].str_at(0) == "Samir");    // Person 2199023262543
+    // Sorted by firstName ASC: SAMPLE then SECOND on both fixtures (Hossein<Jan, Mahinda<Samir).
+    CHECK(r[0].str_at(0) == ldbc::SAMPLE_PERSON_FIRST_NAME);
+    CHECK(r[1].str_at(0) == ldbc::SECOND_SAMPLE_PERSON_FIRST_NAME);
 }
 
 TEST_CASE("UNWIND after WITH", "[ldbc][filter][unwind]") {
     SKIP_IF_NO_DB();
-    // Collect tags, then UNWIND them back
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933})-[:HAS_INTEREST]->(t:Tag) "
-        "WITH collect(t.name) AS tags "
-        "UNWIND tags AS tagName "
-        "RETURN tagName ORDER BY tagName",
-        {qtest::ColType::STRING});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:HAS_INTEREST]->(t:Tag) "
+             "WITH collect(t.name) AS tags "
+             "UNWIND tags AS tagName "
+             "RETURN tagName ORDER BY tagName";
+    auto r = qr->run(q.c_str(), {qtest::ColType::STRING});
     REQUIRE(r.size() > 0);
-    // Verify ordering
     for (size_t i = 1; i < r.size(); i++) {
         CHECK(r[i].str_at(0) >= r[i-1].str_at(0));
     }
@@ -183,42 +193,50 @@ TEST_CASE("UNWIND after WITH", "[ldbc][filter][unwind]") {
 
 TEST_CASE("UNWIND with aggregation", "[ldbc][filter][unwind]") {
     SKIP_IF_NO_DB();
-    // UNWIND + count
     auto r = qr->run(
         "UNWIND [10, 20, 30, 40, 50] AS x "
         "RETURN count(x) AS cnt, sum(x) AS total",
         {qtest::ColType::INT64, qtest::ColType::INT64});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 5);    // count
-    CHECK(r[0].int64_at(1) == 150);  // sum
+    CHECK(r[0].int64_at(0) == 5);
+    CHECK(r[0].int64_at(1) == 150);
 }
 
+// `:Country` sub-label is not tagged on the mini fixture — the load
+// script keeps every Place row as `:Place`. We probe `:Place` here on
+// both fixtures since the same names exist as countries in the Place
+// catalog regardless of scale.
 TEST_CASE("UNWIND string list", "[ldbc][filter][unwind]") {
     SKIP_IF_NO_DB();
-    // UNWIND with strings and MATCH
-    auto r = qr->run(
-        "UNWIND ['Laos', 'Scotland'] AS name "
-        "MATCH (c:Country) WHERE c.name = name "
-        "RETURN c.name ORDER BY c.name",
-        {qtest::ColType::STRING});
+    auto q = std::string("UNWIND ['") + ldbc::SAMPLE_COUNTRY_NAME_1 + "', '" +
+             ldbc::SAMPLE_COUNTRY_NAME_2 + "'] AS name "
+             "MATCH (c:Place) WHERE c.name = name "
+             "RETURN c.name ORDER BY c.name";
+    auto r = qr->run(q.c_str(), {qtest::ColType::STRING});
     REQUIRE(r.size() == 2);
-    CHECK(r[0].str_at(0) == "Laos");
-    CHECK(r[1].str_at(0) == "Scotland");
+    // The two pinned country names happen to be sorted ASC on both fixtures.
+    CHECK(r[0].str_at(0) == ldbc::SAMPLE_COUNTRY_NAME_1);
+    CHECK(r[1].str_at(0) == ldbc::SAMPLE_COUNTRY_NAME_2);
 }
 
+// Gated SF1-only: on the SF0.003 mini fixture this query SIGSEGVs
+// inside the engine (issue #76). A try/catch cannot intercept a
+// segfault — Catch2 sees the process die and stops scheduling further
+// cases — so we exclude the case from the mini build entirely until
+// #76 is fixed. SF1 dev runs still exercise it (was passing pre-migration).
+#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
 TEST_CASE("UNWIND empty list", "[ldbc][filter][unwind]") {
     SKIP_IF_NO_DB();
-    // UNWIND empty list → 0 rows (graceful: may throw or return empty)
     try {
         auto r = qr->run(
             "UNWIND [] AS x RETURN x",
             {qtest::ColType::INT64});
         CHECK(r.size() == 0);
     } catch (...) {
-        // Empty list UNWIND may not be supported yet — acceptable
         SUCCEED();
     }
 }
+#endif
 
 TEST_CASE("UNWIND null produces zero rows", "[ldbc][filter][unwind]") {
     SKIP_IF_NO_DB();
@@ -231,12 +249,13 @@ TEST_CASE("UNWIND null produces zero rows", "[ldbc][filter][unwind]") {
 
 TEST_CASE("UNWIND nullable list returns element values", "[ldbc][filter][unwind]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person) WHERE p.id IN [933, 2199023262543] "
-        "WITH CASE WHEN p.id = 933 THEN null ELSE [1, 2] END AS xs "
-        "UNWIND xs AS x "
-        "RETURN toString(x) AS sx ORDER BY sx",
-        {qtest::ColType::STRING});
+    auto q = "MATCH (p:Person) WHERE p.id IN [" + sample_person_id_str() + ", " +
+             std::to_string(ldbc::SECOND_SAMPLE_PERSON_ID) + "] "
+             "WITH CASE WHEN p.id = " + sample_person_id_str() +
+             " THEN null ELSE [1, 2] END AS xs "
+             "UNWIND xs AS x "
+             "RETURN toString(x) AS sx ORDER BY sx";
+    auto r = qr->run(q.c_str(), {qtest::ColType::STRING});
     REQUIRE(r.size() == 2);
     CHECK(r[0].str_at(0) == "1");
     CHECK(r[1].str_at(0) == "2");
@@ -248,36 +267,42 @@ TEST_CASE("UNWIND nullable list returns element values", "[ldbc][filter][unwind]
 
 TEST_CASE("toInteger", "[ldbc][filter][func]") {
     SKIP_IF_NO_DB();
-    // toInteger casts to BIGINT (truncates towards zero)
+    // Anchored on a single-row MATCH so the projection has one row to
+    // attach to; the actual values exercised are pure scalar literals.
     REQUIRE(qr->count(
-        "MATCH (p:Person {id: 933}) RETURN toInteger(3.7)") == 3);
+        ("MATCH (p:Person {id: " + sample_person_id_str() +
+         "}) RETURN toInteger(3.7)").c_str()) == 3);
     REQUIRE(qr->count(
-        "MATCH (p:Person {id: 933}) RETURN toInteger('42')") == 42);
-    // toInteger on property
+        ("MATCH (p:Person {id: " + sample_person_id_str() +
+         "}) RETURN toInteger('42')").c_str()) == 42);
     REQUIRE(qr->count(
-        "MATCH (p:Person {id: 933}) RETURN toInteger(p.id)") == 933);
+        ("MATCH (p:Person {id: " + sample_person_id_str() +
+         "}) RETURN toInteger(p.id)").c_str()) == ldbc::SAMPLE_PERSON_ID);
 }
 
 TEST_CASE("toFloat", "[ldbc][filter][func]") {
     SKIP_IF_NO_DB();
     REQUIRE(qr->count(
-        "MATCH (p:Person {id: 933}) RETURN toInteger(toFloat(42))") == 42);
+        ("MATCH (p:Person {id: " + sample_person_id_str() +
+         "}) RETURN toInteger(toFloat(42))").c_str()) == 42);
 }
 
 TEST_CASE("floor", "[ldbc][filter][func]") {
     SKIP_IF_NO_DB();
     REQUIRE(qr->count(
-        "MATCH (p:Person {id: 933}) RETURN toInteger(floor(3.7))") == 3);
+        ("MATCH (p:Person {id: " + sample_person_id_str() +
+         "}) RETURN toInteger(floor(3.7))").c_str()) == 3);
     REQUIRE(qr->count(
-        "MATCH (p:Person {id: 933}) RETURN toInteger(floor(3.2))") == 3);
+        ("MATCH (p:Person {id: " + sample_person_id_str() +
+         "}) RETURN toInteger(floor(3.2))").c_str()) == 3);
 }
 
 TEST_CASE("arithmetic + floor + toInteger combo", "[ldbc][filter][func]") {
     SKIP_IF_NO_DB();
-    // Simulates the IC7 minutesLatency calculation pattern
+    // Simulates the IC7 minutesLatency pattern.
     REQUIRE(qr->count(
-        "MATCH (p:Person {id: 933}) "
-        "RETURN toInteger(floor(toFloat(120000) / 1000.0 / 60.0))") == 2);
+        ("MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+         "RETURN toInteger(floor(toFloat(120000) / 1000.0 / 60.0))").c_str()) == 2);
 }
 
 // ============================================================
@@ -286,59 +311,49 @@ TEST_CASE("arithmetic + floor + toInteger combo", "[ldbc][filter][func]") {
 
 TEST_CASE("map literal basic", "[ldbc][filter][map]") {
     SKIP_IF_NO_DB();
-    // Create a map literal and access its fields
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "WITH {name: p.firstName, age: 42} AS info "
-        "RETURN info.name, toInteger(info.age) AS age",
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+             "WITH {name: p.firstName, age: 42} AS info "
+             "RETURN info.name, toInteger(info.age) AS age";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::STRING, qtest::ColType::INT64});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].str_at(0) == "Mahinda");
+    CHECK(r[0].str_at(0) == ldbc::SAMPLE_PERSON_FIRST_NAME);
     CHECK(r[0].int64_at(1) == 42);
 }
 
 TEST_CASE("map literal with multiple fields", "[ldbc][filter][map]") {
     SKIP_IF_NO_DB();
-    // Map with string and numeric fields
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "WITH {id: p.id, first: p.firstName, last: p.lastName} AS info "
-        "RETURN info.first, info.last",
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+             "WITH {id: p.id, first: p.firstName, last: p.lastName} AS info "
+             "RETURN info.first, info.last";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::STRING, qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].str_at(0) == "Mahinda");
-    CHECK(r[0].str_at(1) == "Perera");
+    CHECK(r[0].str_at(0) == ldbc::SAMPLE_PERSON_FIRST_NAME);
+    CHECK(r[0].str_at(1) == ldbc::SAMPLE_PERSON_LAST_NAME);
 }
-
-// Q2-42: collect(STRUCT) + head — skipped, requires ordered aggregation
-// + STRUCT serialization in collect's ListAggState (not yet implemented)
-// TEST_CASE("map in collect + head", "[ldbc][filter][map]") { ... }
 
 TEST_CASE("nested map property access", "[ldbc][filter][map]") {
     SKIP_IF_NO_DB();
-    // Access a property of a node stored in a map field
-    // This is the IC7 pattern: latestLike.msg.id
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933})-[:HAS_INTEREST]->(t:Tag) "
-        "WITH {tag: t, personName: p.firstName} AS info "
-        "RETURN info.personName "
-        "LIMIT 1",
-        {qtest::ColType::STRING});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:HAS_INTEREST]->(t:Tag) "
+             "WITH {tag: t, personName: p.firstName} AS info "
+             "RETURN info.personName "
+             "LIMIT 1";
+    auto r = qr->run(q.c_str(), {qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].str_at(0) == "Mahinda");
+    CHECK(r[0].str_at(0) == ldbc::SAMPLE_PERSON_FIRST_NAME);
 }
 
 TEST_CASE("head function on list", "[ldbc][filter][func][map]") {
     SKIP_IF_NO_DB();
-    // head() returns the first element of a list
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933})-[:HAS_INTEREST]->(t:Tag) "
-        "WITH collect(t.name) AS tags "
-        "RETURN head(tags)",
-        {qtest::ColType::STRING});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:HAS_INTEREST]->(t:Tag) "
+             "WITH collect(t.name) AS tags "
+             "RETURN head(tags)";
+    auto r = qr->run(q.c_str(), {qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
-    // Should return the first collected tag name
-    CHECK(r[0].str_at(0).size() > 0);  // non-empty string
+    CHECK(r[0].str_at(0).size() > 0);
 }
 
 // ============================================================
@@ -347,39 +362,35 @@ TEST_CASE("head function on list", "[ldbc][filter][func][map]") {
 
 TEST_CASE("head(collect()) inline in RETURN", "[ldbc][filter][func]") {
     SKIP_IF_NO_DB();
-    // head(collect(x)) inline — no separate WITH
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933})-[:HAS_INTEREST]->(t:Tag) "
-        "RETURN head(collect(t.name))",
-        {qtest::ColType::STRING});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:HAS_INTEREST]->(t:Tag) "
+             "RETURN head(collect(t.name))";
+    auto r = qr->run(q.c_str(), {qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
     CHECK(r[0].str_at(0).size() > 0);
 }
 
 TEST_CASE("ordered collect + head via two WITHs", "[ldbc][filter][func]") {
     SKIP_IF_NO_DB();
-    // ORDER BY → collect → head (two-step, known working)
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933})-[:HAS_INTEREST]->(t:Tag) "
-        "WITH t.name AS name ORDER BY name ASC "
-        "WITH collect(name) AS names "
-        "RETURN head(names)",
-        {qtest::ColType::STRING});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:HAS_INTEREST]->(t:Tag) "
+             "WITH t.name AS name ORDER BY name ASC "
+             "WITH collect(name) AS names "
+             "RETURN head(names)";
+    auto r = qr->run(q.c_str(), {qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
-    // First alphabetically (unicode en-dash in name)
-    CHECK(r[0].str_at(0).substr(0, 4) == "1962");
+    CHECK(r[0].str_at(0).substr(0, 4) == ldbc::SAMPLE_PERSON_FIRST_INTEREST_PREFIX);
 }
 
 TEST_CASE("head(collect()) with GROUP BY key", "[ldbc][filter][func]") {
     SKIP_IF_NO_DB();
-    // This is the IC7 pattern: group by + head(collect())
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933})-[:HAS_INTEREST]->(t:Tag) "
-        "WITH p, head(collect(t.name)) AS firstTag "
-        "RETURN firstTag",
-        {qtest::ColType::STRING});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:HAS_INTEREST]->(t:Tag) "
+             "WITH p, head(collect(t.name)) AS firstTag "
+             "RETURN firstTag";
+    auto r = qr->run(q.c_str(), {qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].str_at(0).size() > 0);  // non-empty tag name
+    CHECK(r[0].str_at(0).size() > 0);
 }
 
 // ============================================================
@@ -388,93 +399,87 @@ TEST_CASE("head(collect()) with GROUP BY key", "[ldbc][filter][func]") {
 
 TEST_CASE("shortestPath length", "[ldbc][filter][path]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p1:Person {id: 17592186055119}) "
-        "MATCH (p2:Person {id: 8796093025131}) "
-        "MATCH path = shortestPath((p1)-[:KNOWS*]-(p2)) "
-        "RETURN length(path) AS len",
-        {qtest::ColType::INT64});
+    auto q = "MATCH (p1:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH (p2:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_DEST_ID) + "}) "
+             "MATCH path = shortestPath((p1)-[:KNOWS*]-(p2)) "
+             "RETURN length(path) AS len";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 3);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PATH_LEN);
 }
 
 TEST_CASE("allShortestPaths count", "[ldbc][filter][path]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p1:Person {id: 17592186055119}) "
-        "MATCH (p2:Person {id: 10995116282665}) "
-        "MATCH path = allShortestPaths((p1)-[:KNOWS*]-(p2)) "
-        "RETURN length(path) AS len",
-        {qtest::ColType::INT64});
-    REQUIRE(r.size() == 7);
+    auto q = "MATCH (p1:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH (p2:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_DEST_ID) + "}) "
+             "MATCH path = allShortestPaths((p1)-[:KNOWS*]-(p2)) "
+             "RETURN length(path) AS len";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() == (size_t)ldbc::SAMPLE_PATH_NUM_ALL_SHORTEST);
     for (size_t i = 0; i < r.size(); i++) {
-        CHECK(r[i].int64_at(0) == 3);
+        CHECK(r[i].int64_at(0) == ldbc::SAMPLE_PATH_LEN);
     }
 }
 
 TEST_CASE("nodes(path) extracts node VIDs", "[ldbc][filter][path]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p1:Person {id: 17592186055119}) "
-        "MATCH (p2:Person {id: 8796093025131}) "
-        "MATCH path = shortestPath((p1)-[:KNOWS*]-(p2)) "
-        "WITH nodes(path) AS nodeIds "
-        "RETURN size(nodeIds) AS cnt",
-        {qtest::ColType::INT64});
+    auto q = "MATCH (p1:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH (p2:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_DEST_ID) + "}) "
+             "MATCH path = shortestPath((p1)-[:KNOWS*]-(p2)) "
+             "WITH nodes(path) AS nodeIds "
+             "RETURN size(nodeIds) AS cnt";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 4);  // 3 hops = 4 nodes
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PATH_LEN + 1);
 }
 
 TEST_CASE("relationships(path) extracts edge IDs", "[ldbc][filter][path]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p1:Person {id: 17592186055119}) "
-        "MATCH (p2:Person {id: 8796093025131}) "
-        "MATCH path = shortestPath((p1)-[:KNOWS*]-(p2)) "
-        "WITH relationships(path) AS relIds "
-        "RETURN size(relIds) AS cnt",
-        {qtest::ColType::INT64});
+    auto q = "MATCH (p1:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH (p2:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_DEST_ID) + "}) "
+             "MATCH path = shortestPath((p1)-[:KNOWS*]-(p2)) "
+             "WITH relationships(path) AS relIds "
+             "RETURN size(relIds) AS cnt";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 3);  // 3 edges for 3-hop path
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PATH_LEN);
 }
 
 TEST_CASE("relationships(path) returns empty list for zero-hop path",
           "[ldbc][filter][path]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "MATCH path = allShortestPaths((p)-[:KNOWS*0..0]-(p)) "
-        "RETURN size(relationships(path)) AS relCnt",
-        {qtest::ColType::INT64});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+             "MATCH path = allShortestPaths((p)-[:KNOWS*0..0]-(p)) "
+             "RETURN size(relationships(path)) AS relCnt";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
     REQUIRE(r.size() == 1);
     CHECK(r[0].int64_at(0) == 0);
 }
 
 TEST_CASE("allShortestPaths + collect + UNWIND + nodes", "[ldbc][filter][path]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p1:Person {id: 17592186055119}) "
-        "MATCH (p2:Person {id: 10995116282665}) "
-        "MATCH path = allShortestPaths((p1)-[:KNOWS*]-(p2)) "
-        "WITH collect(path) AS paths "
-        "UNWIND paths AS p "
-        "RETURN size(nodes(p)) AS nodeCnt, size(relationships(p)) AS relCnt",
+    auto q = "MATCH (p1:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH (p2:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_DEST_ID) + "}) "
+             "MATCH path = allShortestPaths((p1)-[:KNOWS*]-(p2)) "
+             "WITH collect(path) AS paths "
+             "UNWIND paths AS p "
+             "RETURN size(nodes(p)) AS nodeCnt, size(relationships(p)) AS relCnt";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::INT64});
-    REQUIRE(r.size() == 7);
+    REQUIRE(r.size() == (size_t)ldbc::SAMPLE_PATH_NUM_ALL_SHORTEST);
     for (size_t i = 0; i < r.size(); i++) {
-        CHECK(r[i].int64_at(0) == 4);  // 4 nodes per path
-        CHECK(r[i].int64_at(1) == 3);  // 3 edges per path
+        CHECK(r[i].int64_at(0) == ldbc::SAMPLE_PATH_LEN + 1);
+        CHECK(r[i].int64_at(1) == ldbc::SAMPLE_PATH_LEN);
     }
 }
 
 TEST_CASE("length on string (not path)", "[ldbc][filter][path]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "RETURN length(p.firstName) AS len",
-        {qtest::ColType::INT64});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+             "RETURN length(p.firstName) AS len";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) > 0);  // "Mahinda" = 7
+    CHECK(r[0].int64_at(0) > 0);
 }
 
 // ============================================================
@@ -483,19 +488,17 @@ TEST_CASE("length on string (not path)", "[ldbc][filter][path]") {
 
 TEST_CASE("reduce sum doubles", "[ldbc][filter][reduce]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "RETURN reduce(w = 0.0, v IN [1.0, 2.0, 3.0] | w + v) AS total",
-        {qtest::ColType::AUTO});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+             "RETURN reduce(w = 0.0, v IN [1.0, 2.0, 3.0] | w + v) AS total";
+    auto r = qr->run(q.c_str(), {qtest::ColType::AUTO});
     REQUIRE(r.size() == 1);
 }
 
 TEST_CASE("reduce sum integers", "[ldbc][filter][reduce]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "RETURN reduce(w = 0, v IN [10, 20, 30] | w + v) AS total",
-        {qtest::ColType::AUTO});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+             "RETURN reduce(w = 0, v IN [10, 20, 30] | w + v) AS total";
+    auto r = qr->run(q.c_str(), {qtest::ColType::AUTO});
     REQUIRE(r.size() == 1);
 }
 
@@ -518,78 +521,78 @@ TEST_CASE("reduce unsupported form throws", "[ldbc][filter][reduce]") {
 TEST_CASE("reduce empty list", "[ldbc][filter][reduce]") {
     SKIP_IF_NO_DB();
     try {
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "WITH collect(p.firstName) AS names "
-        "WHERE false "
-        "RETURN reduce(w = 0.0, v IN [1.0] | w + v) AS total",
-        {qtest::ColType::AUTO});
+        auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+                 "WITH collect(p.firstName) AS names "
+                 "WHERE false "
+                 "RETURN reduce(w = 0.0, v IN [1.0] | w + v) AS total";
+        qr->run(q.c_str(), {qtest::ColType::AUTO});
     } catch (...) { /* may fail gracefully */ }
     SUCCEED();
 }
 
 TEST_CASE("reduce with path weights", "[ldbc][filter][reduce]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "WITH [1.0, 1.0, 0.5, 0.5] AS weights "
-        "RETURN reduce(w = 0.0, v IN weights | w + v) AS total",
-        {qtest::ColType::AUTO});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+             "WITH [1.0, 1.0, 0.5, 0.5] AS weights "
+             "RETURN reduce(w = 0.0, v IN weights | w + v) AS total";
+    auto r = qr->run(q.c_str(), {qtest::ColType::AUTO});
     REQUIRE(r.size() == 1);
 }
 
 TEST_CASE("reduce with collect result", "[ldbc][filter][reduce]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933})-[:KNOWS]-(f:Person) "
-        "WITH collect(f.id) AS ids "
-        "RETURN reduce(s = 0, x IN ids | s + x) AS total",
-        {qtest::ColType::AUTO});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:KNOWS]-(f:Person) "
+             "WITH collect(f.id) AS ids "
+             "RETURN reduce(s = 0, x IN ids | s + x) AS total";
+    auto r = qr->run(q.c_str(), {qtest::ColType::AUTO});
     REQUIRE(r.size() == 1);
 }
 
 TEST_CASE("reduce in WITH pipeline", "[ldbc][filter][reduce]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "WITH [1.0, 2.0, 3.0, 4.0] AS vals "
-        "WITH reduce(w = 0.0, v IN vals | w + v) AS total "
-        "RETURN total",
-        {qtest::ColType::AUTO});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+             "WITH [1.0, 2.0, 3.0, 4.0] AS vals "
+             "WITH reduce(w = 0.0, v IN vals | w + v) AS total "
+             "RETURN total";
+    auto r = qr->run(q.c_str(), {qtest::ColType::AUTO});
     REQUIRE(r.size() == 1);
 }
 
 TEST_CASE("reduce with single element", "[ldbc][filter][reduce]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "RETURN reduce(w = 0.0, v IN [42.0] | w + v) AS total",
-        {qtest::ColType::AUTO});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+             "RETURN reduce(w = 0.0, v IN [42.0] | w + v) AS total";
+    auto r = qr->run(q.c_str(), {qtest::ColType::AUTO});
     REQUIRE(r.size() == 1);
 }
 
 TEST_CASE("reduce used in arithmetic", "[ldbc][filter][reduce]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "WITH [1.0, 1.0, 0.5] AS w1, [0.5, 0.5] AS w2 "
-        "RETURN reduce(a = 0.0, v IN w1 | a + v) + reduce(b = 0.0, v IN w2 | b + v) AS combined",
-        {qtest::ColType::AUTO});
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+             "WITH [1.0, 1.0, 0.5] AS w1, [0.5, 0.5] AS w2 "
+             "RETURN reduce(a = 0.0, v IN w1 | a + v) + reduce(b = 0.0, v IN w2 | b + v) AS combined";
+    auto r = qr->run(q.c_str(), {qtest::ColType::AUTO});
     REQUIRE(r.size() == 1);
 }
 
 // ============================================================
 // Pattern comprehension tests (M4)
 // ============================================================
-
+// Both cases SIGSEGV on the SF0.003 mini fixture (issue #77). Pre-
+// migration both were WARN-on-throw on SF1 (flaky but non-fatal);
+// on the mini fixture they crash the harness instead of throwing,
+// so we gate them out of the mini build. SF1 dev runs still
+// exercise them.
+#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
 TEST_CASE("pattern comprehension with WHERE", "[ldbc][filter][patterncomp]") {
     SKIP_IF_NO_DB();
     try {
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "RETURN [(p)<-[:HAS_CREATOR]-(:Comment) WHERE p.id = 933 | 1.0] AS matches",
-        {qtest::ColType::AUTO});
-    REQUIRE(r.size() == 1);
+        auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+                 "RETURN [(p)<-[:HAS_CREATOR]-(:Comment) WHERE p.id = " +
+                 sample_person_id_str() + " | 1.0] AS matches";
+        auto r = qr->run(q.c_str(), {qtest::ColType::AUTO});
+        REQUIRE(r.size() == 1);
     } catch (const std::exception &e) {
         WARN("Q2-64: " << e.what());
     }
@@ -598,15 +601,15 @@ TEST_CASE("pattern comprehension with WHERE", "[ldbc][filter][patterncomp]") {
 TEST_CASE("pattern comprehension simple", "[ldbc][filter][patterncomp]") {
     SKIP_IF_NO_DB();
     try {
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "RETURN [(p)-[:KNOWS]-(f:Person) WHERE f.id > 0 | 1.0] AS friends",
-        {qtest::ColType::AUTO});
-    REQUIRE(r.size() == 1);
+        auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+                 "RETURN [(p)-[:KNOWS]-(f:Person) WHERE f.id > 0 | 1.0] AS friends";
+        auto r = qr->run(q.c_str(), {qtest::ColType::AUTO});
+        REQUIRE(r.size() == 1);
     } catch (const std::exception &e) {
         WARN("Q2-65: " << e.what());
     }
 }
+#endif
 
 // ============================================================
 // XOR expression tests
@@ -614,47 +617,49 @@ TEST_CASE("pattern comprehension simple", "[ldbc][filter][patterncomp]") {
 
 TEST_CASE("XOR basic", "[ldbc][filter][xor]") {
     SKIP_IF_NO_DB();
-    // n.id=933: (933>100)=true XOR (933<500)=false → true XOR false = true
-    auto r = qr->run(
-        "MATCH (n:Person {id: 933}) "
-        "RETURN (n.id > 100 XOR n.id < 500) AS x",
-        {qtest::ColType::BOOL});
+    // (id > 100) XOR (id < 500): for any positive sample_id this is
+    // (true XOR <id<500>). For SF1 933 it's (true XOR false) = true;
+    // for SF0.003 14 it's (false XOR true) = true. Both yield true.
+    auto q = "MATCH (n:Person {id: " + sample_person_id_str() + "}) "
+             "RETURN (n.id > 100 XOR n.id < 500) AS x";
+    auto r = qr->run(q.c_str(), {qtest::ColType::BOOL});
     REQUIRE(r.size() == 1);
+    // For SF0.003 (id=14): false XOR true = true.
+    // For SF1 (id=933):    true  XOR false = true.
     CHECK(r[0].bool_at(0) == true);
 }
 
 TEST_CASE("XOR true", "[ldbc][filter][xor]") {
     SKIP_IF_NO_DB();
-    // true XOR false = true
-    auto r = qr->run(
-        "MATCH (n:Person {id: 933}) "
-        "RETURN (n.id > 100 XOR n.id > 10000) AS x",
-        {qtest::ColType::BOOL});
+    // (id > 100) XOR (id > 10000) — true XOR false on SF1, false XOR false on mini.
+#ifdef TURBOLYNX_LDBC_FIXTURE_MINI
+    // SF0.003 SAMPLE_PERSON id=14 < 100, so both branches are false → XOR = false.
+    auto q = "MATCH (n:Person {id: " + sample_person_id_str() + "}) "
+             "RETURN (n.id > 0 XOR n.id > 10000) AS x";
+#else
+    auto q = "MATCH (n:Person {id: " + sample_person_id_str() + "}) "
+             "RETURN (n.id > 100 XOR n.id > 10000) AS x";
+#endif
+    auto r = qr->run(q.c_str(), {qtest::ColType::BOOL});
     REQUIRE(r.size() == 1);
     CHECK(r[0].bool_at(0) == true);
 }
 
 TEST_CASE("XOR in WHERE", "[ldbc][filter][xor]") {
     SKIP_IF_NO_DB();
-    // true XOR false = true, so WHERE passes and row is returned
-    auto r = qr->run(
-        "MATCH (n:Person {id: 933}) "
-        "WHERE (n.id > 100 XOR n.id > 10000) "
-        "RETURN n.id",
-        {qtest::ColType::INT64});
+#ifdef TURBOLYNX_LDBC_FIXTURE_MINI
+    auto q = "MATCH (n:Person {id: " + sample_person_id_str() + "}) "
+             "WHERE (n.id > 0 XOR n.id > 10000) "
+             "RETURN n.id";
+#else
+    auto q = "MATCH (n:Person {id: " + sample_person_id_str() + "}) "
+             "WHERE (n.id > 100 XOR n.id > 10000) "
+             "RETURN n.id";
+#endif
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 933);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
 }
-
-// ============================================================
-// List indexing tests
-// ============================================================
-
-// TODO: list indexing tests — list_extract return type needs ORCA integration work
-// The shell renders correctly but C API returns NULL due to ANY return type.
-// TEST_CASE("list index 0", "[ldbc][filter][listindex]") { ... }
-// TEST_CASE("list index 2", "[ldbc][filter][listindex]") { ... }
-// TEST_CASE("list negative index", "[ldbc][filter][listindex]") { ... }
 
 // ============================================================
 // String predicate tests
@@ -662,53 +667,53 @@ TEST_CASE("XOR in WHERE", "[ldbc][filter][xor]") {
 
 TEST_CASE("STARTS WITH true", "[ldbc][filter][stringpred]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (n:Person {id: 933}) "
-        "RETURN n.firstName STARTS WITH 'Ma' AS x",
-        {qtest::ColType::BOOL});
+    auto q = std::string("MATCH (n:Person {id: ") + sample_person_id_str() + "}) "
+             "RETURN n.firstName STARTS WITH '" +
+             ldbc::SAMPLE_PERSON_NAME_STARTS_MATCH + "' AS x";
+    auto r = qr->run(q.c_str(), {qtest::ColType::BOOL});
     REQUIRE(r.size() == 1);
     CHECK(r[0].bool_at(0) == true);
 }
 
 TEST_CASE("STARTS WITH false", "[ldbc][filter][stringpred]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (n:Person {id: 933}) "
-        "RETURN n.firstName STARTS WITH 'Jo' AS x",
-        {qtest::ColType::BOOL});
+    auto q = std::string("MATCH (n:Person {id: ") + sample_person_id_str() + "}) "
+             "RETURN n.firstName STARTS WITH '" +
+             ldbc::SAMPLE_PERSON_NAME_STARTS_NOMATCH + "' AS x";
+    auto r = qr->run(q.c_str(), {qtest::ColType::BOOL});
     REQUIRE(r.size() == 1);
     CHECK(r[0].bool_at(0) == false);
 }
 
 TEST_CASE("ENDS WITH", "[ldbc][filter][stringpred]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (n:Person {id: 933}) "
-        "RETURN n.firstName ENDS WITH 'di' AS x",
-        {qtest::ColType::BOOL});
+    auto q = std::string("MATCH (n:Person {id: ") + sample_person_id_str() + "}) "
+             "RETURN n.firstName ENDS WITH '" +
+             ldbc::SAMPLE_PERSON_NAME_ENDS_MATCH + "' AS x";
+    auto r = qr->run(q.c_str(), {qtest::ColType::BOOL});
     REQUIRE(r.size() == 1);
-    // Person 933 firstName is "Mahinda" — ends with "di" is false
-    CHECK(r[0].bool_at(0) == false);
+    CHECK(r[0].bool_at(0) == true);
 }
 
 TEST_CASE("CONTAINS true", "[ldbc][filter][stringpred]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (n:Person {id: 933}) "
-        "RETURN n.firstName CONTAINS 'ah' AS x",
-        {qtest::ColType::BOOL});
+    auto q = std::string("MATCH (n:Person {id: ") + sample_person_id_str() + "}) "
+             "RETURN n.firstName CONTAINS '" +
+             ldbc::SAMPLE_PERSON_NAME_CONTAINS_MATCH + "' AS x";
+    auto r = qr->run(q.c_str(), {qtest::ColType::BOOL});
     REQUIRE(r.size() == 1);
     CHECK(r[0].bool_at(0) == true);
 }
 
 TEST_CASE("pattern expression preserves direction", "[ldbc][filter][patternexpr]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (p:Person {id: 933})<-[:HAS_CREATOR]-(m:Message) "
-        "RETURN (m)-[:HAS_CREATOR]->(p) AS out_ok, "
-        "(m)<-[:HAS_CREATOR]-(p) AS in_wrong, "
-        "(m)-[:HAS_CREATOR]-(p) AS both_ok "
-        "LIMIT 1",
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})<-[:HAS_CREATOR]-(m:Message) "
+             "RETURN (m)-[:HAS_CREATOR]->(p) AS out_ok, "
+             "(m)<-[:HAS_CREATOR]-(p) AS in_wrong, "
+             "(m)-[:HAS_CREATOR]-(p) AS both_ok "
+             "LIMIT 1";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::BOOL, qtest::ColType::BOOL, qtest::ColType::BOOL});
     REQUIRE(r.size() == 1);
     CHECK(r[0].bool_at(0) == true);
@@ -718,30 +723,29 @@ TEST_CASE("pattern expression preserves direction", "[ldbc][filter][patternexpr]
 
 TEST_CASE("pattern expression rejects unresolved endpoint", "[ldbc][filter][patternexpr]") {
     SKIP_IF_NO_DB();
-    REQUIRE_THROWS(qr->run(
-        "MATCH (p:Person {id: 933}) "
-        "RETURN (p)-[:KNOWS]->() AS x",
-        {qtest::ColType::BOOL}));
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
+             "RETURN (p)-[:KNOWS]->() AS x";
+    REQUIRE_THROWS(qr->run(q.c_str(), {qtest::ColType::BOOL}));
 }
 
 TEST_CASE("CONTAINS in WHERE", "[ldbc][filter][stringpred]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (n:Person {id: 933}) "
-        "WHERE n.firstName CONTAINS 'ah' "
-        "RETURN n.id",
-        {qtest::ColType::INT64});
+    auto q = std::string("MATCH (n:Person {id: ") + sample_person_id_str() + "}) "
+             "WHERE n.firstName CONTAINS '" +
+             ldbc::SAMPLE_PERSON_NAME_CONTAINS_MATCH + "' "
+             "RETURN n.id";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 933);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
 }
 
 TEST_CASE("STARTS WITH in WHERE", "[ldbc][filter][stringpred]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (n:Person {id: 933}) "
-        "WHERE n.firstName STARTS WITH 'Ma' "
-        "RETURN n.id",
-        {qtest::ColType::INT64});
+    auto q = std::string("MATCH (n:Person {id: ") + sample_person_id_str() + "}) "
+             "WHERE n.firstName STARTS WITH '" +
+             ldbc::SAMPLE_PERSON_NAME_STARTS_MATCH + "' "
+             "RETURN n.id";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 933);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
 }


### PR DESCRIPTION
## Summary

- Parameterize `test_ldbc_filter.cpp` (62 cases) off the hardcoded SF1 Person/Comment/Forum/Tag/path constants — switch to header-pinned `SAMPLE_*` and `TRAV_*` constants in `helpers/ldbc_expected_counts.hpp`. Same source builds against both SF1 (dev) and SF0.003 (CI).
- SF0.003 expected values are Neo4j-verified against the committed mini fixture.
- New CI step runs `[ldbc][filter]`. The previous `~[filter]` exclusion on the `[ldbc][func]` step is dropped.

## Per-fixture deltas (notable)

| Constant | SF0.003 | SF1 |
| --- | --- | --- |
| `SAMPLE_PERSON_FIRST_NAME` / `_LAST_NAME` | "Hossein" / "Forouhar" | "Mahinda" / "Perera" |
| `SAMPLE_PERSON_CITY_ID` / `_NAME` | 1166 / "Tehran" | 1353 / "Kelaniya" |
| `SAMPLE_FORUM_ID` / post count | 137438953609 / 20 | 77644 / 1208 |
| `SAMPLE_TAG_NAME` | "Hannibal" | "Genghis_Khan" |
| `SAMPLE_PATH_SRC_ID` → `_DEST_ID` | 14 → 16 | 17592186055119 → 10995116282665 |

`SAMPLE_PATH_NUM_ALL_SHORTEST` happens to be 7 on both fixtures.

## Bugs surfaced (filed)

Three cases SIGSEGV on the mini fixture and are gated `#ifndef TURBOLYNX_LDBC_FIXTURE_MINI`:

- [#76](https://github.com/turbolynx-dslab/TurboLynx/issues/76) — `UNWIND [] AS x RETURN x` SIGSEGVs on mini (non-empty UNWIND, `UNWIND null`, etc. all work)
- [#77](https://github.com/turbolynx-dslab/TurboLynx/issues/77) — pattern comprehension `[(p)<-[...]-(...) | ...]` SIGSEGVs on mini

A fourth case (`Person ... IS_LOCATED_IN City`) is also SF1-only because the mini load script does not tag the `:City` sub-label on `:Place` rows. The `:Place` form is tested on both fixtures.

## Test plan

- [x] `cmake --build build-portable --target query_test` (Release, `-DTURBOLYNX_LDBC_FIXTURE_MINI=ON`)
- [x] `bash scripts/load-ldbc-mini.sh build-portable /tmp/ldbc-mini-ws`
- [x] `./build-portable/test/query/query_test "[ldbc][filter]" --ldbc-path /tmp/ldbc-mini-ws` → **58/58 passed (179 assertions)**
- [x] `[ldbc][count]` no regression (33/33)
- [x] `[ldbc][traversal]` no regression (142 assertions in 19 cases)
- [x] `[ldbc][func]` (now without `~[filter]` exclusion) → 15 passed + 2 mayfail-skipped (#73)
- [ ] CI Build & Test (Ubuntu + macOS)