### PR TITLE
Fix DATE_EPOCHMS truncation; enable [ldbc][is] in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,6 +16,13 @@ jobs:
   build-test:
     name: Build & Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # The default GitHub-Actions job timeout is 360 minutes — too long when
+    # something hangs. Healthy runs finish in ~7 min on a warm cache, so cap
+    # at 45 min to fail fast on hangs (e.g. ORCA picking an eager-evaluation
+    # plan for unbounded VarLen on the SF0.003 fixture under GCC) without
+    # tripping legitimate cold-cache builds. Re-tune if cold-cache builds
+    # start landing near the cap.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -130,6 +130,16 @@ jobs:
         # and were Neo4j-verified on the SF0.003 fixture.
         run: ./build-portable/test/query/query_test "[ldbc][traversal]" --ldbc-path /tmp/ldbc-mini-ws
 
+      - name: Run LDBC [is] tests on mini fixture
+        # `[ldbc][is]` exercises Interactive Short queries (IS1–IS6 on
+        # the mini fixture; IS7 is gated SF1-only behind issue #83 —
+        # OPTIONAL MATCH on `:KNOWS` duplicates rows). The fix in #82
+        # (DATE_EPOCHMS storage + Value::GetValueInternal grouping)
+        # is what lets these queries assert on millisecond-precision
+        # creationDate / messageCreationDate values; without it
+        # IS storage truncates to day-only.
+        run: ./build-portable/test/query/query_test "[ldbc][is]" --ldbc-path /tmp/ldbc-mini-ws
+
       - name: Run LDBC [robustness] tests on mini fixture
         # `[ldbc][robustness]~[stress]` exercises invalid/malformed
         # query handling against fixture-pinned anchors. `~[stress]`

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -777,6 +777,18 @@ T Value::GetValueInternal() const {
 		return Cast::Operation<dtime_t, T>(value_.time);
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_SEC:
+		// All TIMESTAMP variants are stored via `Value::TIMESTAMP*(timestamp_t)`
+		// constructors which write to `value_.timestamp` (see lines 476–509).
+		// Reading them back through `value_.ubigint` triggered a UINT64→T
+		// dispatch — for `T = timestamp_t` that hit the unimplemented
+		// Cast<uint64_t, timestamp_t> fallback ("Unimplemented type for cast
+		// (UINT64 -> TIMESTAMP)"). Pre-fix this misgrouping had no visible
+		// symptom because no LogicalType in the codebase actually surfaced
+		// as TIMESTAMP_MS at read time — DATE_EPOCHMS columns were silently
+		// stored as DATE, so this branch was effectively dead. Issue #82.
 		return Cast::Operation<timestamp_t, T>(value_.timestamp);
 	case LogicalTypeId::UTINYINT:
 		return Cast::Operation<uint8_t, T>(value_.utinyint);
@@ -784,9 +796,6 @@ T Value::GetValueInternal() const {
 		return Cast::Operation<uint16_t, T>(value_.usmallint);
 	case LogicalTypeId::UINTEGER:
 		return Cast::Operation<uint32_t, T>(value_.uinteger);
-	case LogicalTypeId::TIMESTAMP_MS:
-	case LogicalTypeId::TIMESTAMP_NS:
-	case LogicalTypeId::TIMESTAMP_SEC:
 	case LogicalTypeId::UBIGINT:
 	case LogicalTypeId::ID:
 		return Cast::Operation<uint64_t, T>(value_.ubigint);

--- a/src/include/common/graph_simdcsv_parser.hpp
+++ b/src/include/common/graph_simdcsv_parser.hpp
@@ -6,6 +6,7 @@
 #include "common/types/data_chunk.hpp"
 #include "common/enums/graph_component_type.hpp"
 #include "common/types/date.hpp"
+#include "common/types/timestamp.hpp"
 #include "common/output_util.hpp"
 #include "csv.hpp"
 #include <unistd.h> // for getopt
@@ -381,8 +382,12 @@ inline void SetValueFromCSV(LogicalType type, DataChunk &output, size_t i, idx_t
     case LogicalTypeId::TIMESTAMP_MS:
       int64_t epoch_ms;
       std::from_chars((const char*)p.data() + start_offset, (const char*)p.data() + end_offset, epoch_ms);
-      epoch_ms = epoch_ms / 1000;
-      ((date_t *)data_ptr)[current_index] = Date::EpochToDate(epoch_ms);
+      // Pre-fix this divided by 1000 and stored a date_t — silently truncated
+      // sub-day precision and, after the mapping was corrected, also wrote a
+      // 32-bit value into a 64-bit slot. Now go through the existing
+      // Timestamp::FromEpochMs helper (ms → μs) and store into timestamp_t,
+      // so DATE_EPOCHMS columns round-trip with full precision (issue #82).
+      ((timestamp_t *)data_ptr)[current_index] = Timestamp::FromEpochMs(epoch_ms);
       break;
 		default:
 			throw NotImplementedException("SetValueFromCSV - Unsupported type");
@@ -898,7 +903,14 @@ private:
     {"DOUBLE", LogicalType(LogicalTypeId::DOUBLE)},
     {"DATE", LogicalType(LogicalTypeId::DATE)},
     {"DECIMAL", LogicalType(LogicalTypeId::DECIMAL)},
-    {"DATE_EPOCHMS", LogicalType(LogicalTypeId::DATE)},
+    // DATE_EPOCHMS values carry sub-day precision (e.g. LDBC creationDate
+    // 1262531431499 = 2010-01-03T15:10:31.499Z). Mapping to LogicalTypeId::DATE
+    // truncated to day-only at storage time, silently dropping ordering /
+    // equality precision needed by Interactive Short queries (IS2 ORDER BY
+    // messageCreationDate, IS3 friendship ordering, etc.). The key-column
+    // path on line ~813 already uses TIMESTAMP_MS for the same CSV type;
+    // do the same for general property columns so storage is lossless.
+    {"DATE_EPOCHMS", LogicalType(LogicalTypeId::TIMESTAMP_MS)},
 	};
 };
 

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -4016,6 +4016,12 @@ int64_t turbolynx_get_int64(turbolynx_resultset_wrapper* result_set_wrp, idx_t c
 	//
 	// DATE is also stored as int32 days-since-epoch; when the caller treats
 	// it as int64 we convert to milliseconds.
+	//
+	// TIMESTAMP_MS is internally microseconds (timestamp_t.value); we divide
+	// by 1000 to expose the same epoch-ms units as the DATE branch above so
+	// that callers comparing against epoch_ms literals (e.g. LDBC IS / IC
+	// expected values) get a consistent unit regardless of the underlying
+	// storage representation. Issue #82.
 	if (result_set_wrp != NULL) {
 		size_t local_cursor;
 		auto result = turbolynx_move_to_cursored_result(result_set_wrp, col_idx, local_cursor);
@@ -4026,6 +4032,10 @@ int64_t turbolynx_get_int64(turbolynx_resultset_wrapper* result_set_wrp, idx_t c
 			case duckdb::LogicalTypeId::DATE: {
 				duckdb::date_t d = turbolynx_get_value<duckdb::date_t, duckdb::LogicalTypeId::DATE>(result_set_wrp, col_idx);
 				return (int64_t)d.days * 86400000LL;
+			}
+			case duckdb::LogicalTypeId::TIMESTAMP_MS: {
+				duckdb::timestamp_t ts = turbolynx_get_value<duckdb::timestamp_t, duckdb::LogicalTypeId::TIMESTAMP_MS>(result_set_wrp, col_idx);
+				return ts.value / 1000;
 			}
 			case duckdb::LogicalTypeId::INTEGER:
 				return (int64_t)turbolynx_get_value<int32_t, duckdb::LogicalTypeId::INTEGER>(result_set_wrp, col_idx);

--- a/test/bulkload/test_smoke_cli.cpp
+++ b/test/bulkload/test_smoke_cli.cpp
@@ -251,3 +251,56 @@ TEST_CASE("CLI import skips dangling source edge rows without poisoning previous
     REQUIRE(qr.count(
         "MATCH (:Person {id: 1})-[:KNOWS]->(:Person {id: 3}) RETURN count(*) AS cnt") == 0);
 }
+
+// Regression for issue #82: DATE_EPOCHMS property columns must store the
+// raw millisecond-since-epoch value losslessly and read back through the
+// `int64_at` C-API path in the same units. Pre-fix, the CSV parser
+// rounded ms→sec and stored into a 4-byte date_t (silently dropping
+// sub-day precision); a follow-on mapping change exposed a separate
+// Value::GetValueInternal mis-grouping that read TIMESTAMP_MS via the
+// uint64 union slot and threw "Unimplemented type for cast
+// (UINT64 -> TIMESTAMP)". Keep this fixture-independent round trip so
+// either regression fails the suite immediately, without depending on
+// the LDBC mini fixture being loaded.
+TEST_CASE("DATE_EPOCHMS column round-trips with millisecond precision",
+          "[bulkload][smoke][cli][timestamp]") {
+    turbolynxtest::ScopedTempDir temp_dir;
+    fs::path workspace = fs::path(temp_dir.path()) / "ws_ts";
+    fs::path csv = fs::path(temp_dir.path()) / "person_ts.csv";
+    {
+        std::ofstream out(csv);
+        REQUIRE(out.good());
+        out << "id:ID(Person)|name:STRING|created:DATE_EPOCHMS\n";
+        // 1262531431499 = 2010-01-03T15:10:31.499Z (sub-day precision —
+        //                 the regressing value pre-fix would round to
+        //                 1262476800000 = 2010-01-03T00:00:00).
+        // 1577664000000 = 2019-12-30T00:00:00.000Z (day-aligned).
+        // 0             = 1970-01-01T00:00:00.000Z (epoch boundary).
+        out << "1|Alice|1262531431499\n";
+        out << "2|Bob|1577664000000\n";
+        out << "3|Carol|0\n";
+    }
+
+    std::ostringstream cmd;
+    cmd << ShellQuote(TEST_BULKLOAD_BIN) << " import"
+        << " --workspace " << ShellQuote(workspace.string())
+        << " --nodes Person " << ShellQuote(csv.string())
+        << " --skip-histogram";
+    INFO(cmd.str());
+    REQUIRE(RunCommand(cmd.str()) == 0);
+
+    qtest::QueryRunner qr(workspace.string());
+    auto rows = qr.run(
+        "MATCH (p:Person) RETURN p.id AS pid, p.created AS ms ORDER BY pid",
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(rows.size() == 3);
+
+    CHECK(rows[0].int64_at(0) == 1);
+    CHECK(rows[0].int64_at(1) == 1262531431499LL);
+
+    CHECK(rows[1].int64_at(0) == 2);
+    CHECK(rows[1].int64_at(1) == 1577664000000LL);
+
+    CHECK(rows[2].int64_at(0) == 3);
+    CHECK(rows[2].int64_at(1) == 0);
+}

--- a/test/query/helpers/ldbc_expected_counts.hpp
+++ b/test/query/helpers/ldbc_expected_counts.hpp
@@ -192,6 +192,92 @@ inline constexpr int64_t SAMPLE_PATH_NUM_ALL_SHORTEST = 7;
 // WORK_AT — pick any equivalent Person here.
 inline constexpr int64_t SAMPLE_PERSON_NO_WORK_ID = 2199023255557LL;
 
+// ---- IS (Interactive Short) expected values (Neo4j-verified on SF0.003) ----
+//
+// IS1: Person basic info. Mini reuses SAMPLE_PERSON_ID; SF1 used a
+// separate Changpeng/Wei anchor pre-migration so we expose IS1_* directly
+// even though all of these are duplicates of SAMPLE_PERSON_* on mini.
+inline constexpr int64_t     IS1_PERSON_ID         = SAMPLE_PERSON_ID;
+inline constexpr const char* IS1_FIRST_NAME        = SAMPLE_PERSON_FIRST_NAME;
+inline constexpr const char* IS1_LAST_NAME         = SAMPLE_PERSON_LAST_NAME;
+inline constexpr int64_t     IS1_BIRTHDAY_MS       = SAMPLE_PERSON_BIRTHDAY_MS;
+inline constexpr const char* IS1_LOCATION_IP       = SAMPLE_PERSON_LOCATION_IP;
+inline constexpr const char* IS1_BROWSER_USED      = SAMPLE_PERSON_BROWSER;
+inline constexpr int64_t     IS1_CITY_ID           = SAMPLE_PERSON_CITY_ID;
+inline constexpr const char* IS1_GENDER            = SAMPLE_PERSON_GENDER;
+inline constexpr int64_t     IS1_CREATION_DATE_MS  = 1262531431499LL;
+
+// IS2: SAMPLE_PERSON's 10 most recent Comment-with-original-Post info,
+// ordered by messageCreationDate DESC, messageId ASC.
+struct IsRecentComment {
+    int64_t     message_id;
+    const char* content;
+    int64_t     message_creation_ms;
+    int64_t     post_id;
+    int64_t     person_id;
+    const char* first_name;
+    const char* last_name;
+};
+inline constexpr IsRecentComment IS2_RECENT_COMMENTS[] = {
+    {1168231108486LL, "thanks",                                                                                                       1356562996399LL, 1168231108477LL,  8796093022234LL, "Rahul",            "Sharma"},
+    {1168231108516LL, "About Estonia, ed to Finnish. One distinctive feature that has caused a great",                                 1356547280755LL, 1168231108506LL, 10995116277808LL, "Adje van den Berg", "Vries"},
+    {1168231108514LL, "great",                                                                                                        1356542235020LL, 1168231108506LL, 10995116277808LL, "Adje van den Berg", "Vries"},
+    {1168231107550LL, "About Aq Qoyunlu,  parts of present-day Eastern Turkey, AAbout Drive-In Satur",                                 1355579276206LL, 1168231107539LL, 30786325577740LL, "Jose",             "Alonso"},
+    {1168231106604LL, "ok",                                                                                                           1353902374659LL,  962072676387LL, 10995116277782LL, "Ken",              "Yamada"},
+    {1168231106601LL, "About Woodrow Wilson, d has been a contentioAbout Robert F. Kennedy, officially named a",                       1353830401258LL,  962072676387LL, 10995116277782LL, "Ken",              "Yamada"},
+    {1168231106594LL, "About Nicholas II of Russia, on of political opponents, and his pursuit ofAbout Second Spanish Republic, f the Second Spanish Republic", 1353730304489LL, 481036339222LL, 10995116277782LL, "Ken", "Yamada"},
+    {1168231106633LL, "yes",                                                                                                          1352846306943LL,  755914246211LL, 10995116277782LL, "Ken",              "Yamada"},
+    {1168231106625LL, "About Sarah McLachlan, nown as a highly vAbout Simón Bolívar, , he played a key About Por",                     1352846199009LL,  481036339251LL, 10995116277782LL, "Ken",              "Yamada"},
+    {1168231106634LL, "yes",                                                                                                          1352824016064LL,  755914246211LL, 10995116277782LL, "Ken",              "Yamada"},
+};
+
+// IS3: SAMPLE_PERSON's friends list, ordered by friendshipCreationDate DESC,
+// personId ASC.
+struct IsFriend {
+    int64_t     person_id;
+    const char* first_name;
+    const char* last_name;
+    int64_t     friendship_ms;
+};
+inline constexpr IsFriend IS3_FRIENDS[] = {
+    {26388279066668LL, "Alexei", "Kahnovich", 1353883521004LL},
+    {10995116277782LL, "Ken",    "Yamada",    1349551480381LL},
+    {24189255811081LL, "Alim",   "Guliyev",   1341736032264LL},
+};
+
+// IS4: a Post with a non-empty imageFile, authored by SAMPLE_PERSON.
+inline constexpr int64_t     IS4_POST_ID            = 68719476848LL;
+inline constexpr int64_t     IS4_CREATION_MS        = 1269114863092LL;
+inline constexpr const char* IS4_IMAGE_FILE         = "photo68719476848.jpg";
+
+// IS5: SAMPLE_COMMENT creator's last name (id+firstName already pinned above).
+inline constexpr const char* SAMPLE_COMMENT_CREATOR_LASTNAME = "Achiou";
+
+// IS6: forum + moderator that contains SAMPLE_COMMENT (via REPLY_OF*0..->Post).
+inline constexpr int64_t     IS6_FORUM_ID    = 343597383879LL;
+inline constexpr const char* IS6_FORUM_TITLE = "Wall of Evangelos Alkaios";
+inline constexpr int64_t     IS6_MOD_ID      = 10995116277761LL;
+inline constexpr const char* IS6_MOD_FIRST   = "Evangelos";
+inline constexpr const char* IS6_MOD_LAST    = "Alkaios";
+
+// IS7: a Message with exactly two replies, where the replies' author is a
+// KNOWS-friend of the original message author. Picked to mirror the SF1 IS7
+// shape (author != reply author, knows-author = true on both rows).
+inline constexpr int64_t IS7_MESSAGE_ID = 618475290624LL;
+struct IsReply {
+    int64_t     comment_id;
+    const char* content;
+    int64_t     creation_ms;
+    int64_t     reply_author_id;
+    const char* reply_author_first;
+    const char* reply_author_last;
+    bool        reply_author_knows_orig;
+};
+inline constexpr IsReply IS7_REPLIES[] = {
+    {962072674305LL, "yes",    1341766121630LL, 24189255811081LL, "Alim", "Guliyev", true},
+    {962072674306LL, "thanks", 1341754323239LL, 24189255811081LL, "Alim", "Guliyev", true},
+};
+
 #else
 // SF1 (full) — original values, Neo4j 5.24.0 verified.
 inline constexpr int64_t PERSON_COUNT       = 9892;
@@ -332,6 +418,90 @@ inline constexpr int64_t SAMPLE_PATH_NUM_ALL_SHORTEST = 7;
 // Sample Person without WORK_AT — pre-migration the legacy code used
 // Person 290 here.
 inline constexpr int64_t SAMPLE_PERSON_NO_WORK_ID = 290;
+
+// ---- IS (Interactive Short) expected values (SF1, Neo4j 5.24.0 verified) ----
+// Pre-migration these were hardcoded inside test_ldbc_is_correctness.cpp.
+//
+// IS1 used a different sample person (Changpeng Wei id=35184372099695)
+// than the SAMPLE_PERSON the rest of the file shares (Mahinda Perera id=933).
+// Keep the legacy SF1 anchor as-is via IS1_* constants; the mini path
+// happens to reuse SAMPLE_PERSON_ID since 14 is fine for both.
+inline constexpr int64_t     IS1_PERSON_ID         = 35184372099695LL;
+inline constexpr const char* IS1_FIRST_NAME        = "Changpeng";
+inline constexpr const char* IS1_LAST_NAME         = "Wei";
+inline constexpr int64_t     IS1_BIRTHDAY_MS       = 337132800000LL;
+inline constexpr const char* IS1_LOCATION_IP       = "1.1.39.242";
+inline constexpr const char* IS1_BROWSER_USED      = "Internet Explorer";
+inline constexpr int64_t     IS1_CITY_ID           = 367;
+inline constexpr const char* IS1_GENDER            = "female";
+inline constexpr int64_t     IS1_CREATION_DATE_MS  = 1347431652132LL;
+
+struct IsRecentComment {
+    int64_t     message_id;
+    const char* content;
+    int64_t     message_creation_ms;
+    int64_t     post_id;
+    int64_t     person_id;
+    const char* first_name;
+    const char* last_name;
+};
+// IS2 expected (SAMPLE_PERSON 933): 10 rows, original SF1 hardcoded values.
+// Only first 7 fields per row carry, content uses substring-startswith
+// for some rows; here we encode the canonical first-message-row check
+// the test still does. Keeping the structure identical to mini.
+inline constexpr IsRecentComment IS2_RECENT_COMMENTS[] = {
+    {2199027727462LL, "good",                       1347156463979LL, 2061588773973LL, 32985348833579LL, "Otto",   "Becker"},
+    {2061588773980LL, "no way!",                    1347020779693LL, 2061588773973LL, 32985348833579LL, "Otto",   "Becker"},
+    {2061584946139LL, "yes",                        1343987237082LL, 2061584946128LL,            4139, "Baruch", "Dego"},
+    {2061585616327LL, "About Arnold Schwarzenegger",1343919397609LL, 2061585616321LL,  6597069777240LL, "Fritz",  "Muller"},
+    {2061585618894LL, "thanks",                     1343106691147LL, 2061585618887LL,  6597069777240LL, "Fritz",  "Muller"},
+    {2061585619578LL, "About Josip Broz Tito",      1342380120292LL, 2061585619561LL,  6597069777240LL, "Fritz",  "Muller"},
+    {1786707214487LL, "maybe",                      1335712528590LL, 1786707214481LL, 10995116284808LL, "Andrei", "Condariuc"},
+    {1786707214957LL, "About Lady Gaga",            1335694024103LL, 1786707214955LL, 10995116284808LL, "Andrei", "Condariuc"},
+    {1786707214469LL, "About Enrique Iglesias",     1335678484226LL, 1786707214468LL, 10995116284808LL, "Andrei", "Condariuc"},
+    {1786707216224LL, "no way!",                    1335668918002LL, 1786707216218LL, 10995116284808LL, "Andrei", "Condariuc"},
+};
+
+struct IsFriend {
+    int64_t     person_id;
+    const char* first_name;
+    const char* last_name;
+    int64_t     friendship_ms;
+};
+inline constexpr IsFriend IS3_FRIENDS[] = {
+    {32985348833579LL, "Otto",   "Becker",    1346980290195LL},
+    {32985348838375LL, "Otto",   "Richter",   1342512289463LL},
+    {10995116284808LL, "Andrei", "Condariuc", 1293950621955LL},
+    { 6597069777240LL, "Fritz",  "Muller",    1284975763187LL},
+    {            4139, "Baruch", "Dego",      1268465841718LL},
+};
+
+inline constexpr int64_t     IS4_POST_ID    = 2199029886840LL;
+inline constexpr int64_t     IS4_CREATION_MS = 1347463431887LL;
+inline constexpr const char* IS4_IMAGE_FILE = "photo2199029886840.jpg";
+
+inline constexpr const char* SAMPLE_COMMENT_CREATOR_LASTNAME = "Perera";
+
+inline constexpr int64_t     IS6_FORUM_ID    = 412317916558LL;
+inline constexpr const char* IS6_FORUM_TITLE = "Wall of Fritz Muller";
+inline constexpr int64_t     IS6_MOD_ID      = 6597069777240LL;
+inline constexpr const char* IS6_MOD_FIRST   = "Fritz";
+inline constexpr const char* IS6_MOD_LAST    = "Muller";
+
+inline constexpr int64_t IS7_MESSAGE_ID = 824635044682LL;
+struct IsReply {
+    int64_t     comment_id;
+    const char* content;
+    int64_t     creation_ms;
+    int64_t     reply_author_id;
+    const char* reply_author_first;
+    const char* reply_author_last;
+    bool        reply_author_knows_orig;
+};
+inline constexpr IsReply IS7_REPLIES[] = {
+    {824635044685LL, "great", 1295218398759LL,            2738, "Eden",    "Atias",  true},
+    {824635044686LL, "cool",  1295203653676LL,             933, "Mahinda", "Perera", true},
+};
 
 #endif
 

--- a/test/query/test_ldbc_is_correctness.cpp
+++ b/test/query/test_ldbc_is_correctness.cpp
@@ -1,9 +1,14 @@
 // Stage 4 — LDBC Interactive Short (IS) queries (IS1–IS7)
-// All expected values verified against Neo4j 5.24.0 with LDBC SF1.
-// Queries match Neo4j exactly (Message label, OPTIONAL MATCH, CASE, etc.)
+//
+// Two fixture sizes are supported via `helpers/ldbc_expected_counts.hpp`,
+// which dispatches between SF1 (default) and SF0.003 (mini, set with
+// `cmake -DTURBOLYNX_LDBC_FIXTURE_MINI=ON`). All SF0.003 expected
+// values are Neo4j-verified against the committed mini fixture.
 
 #include "catch.hpp"
 #include "helpers/query_runner.hpp"
+#include "helpers/ldbc_expected_counts.hpp"
+#include <string>
 #include <vector>
 
 extern std::string g_ldbc_path;
@@ -18,274 +23,215 @@ extern qtest::QueryRunner* get_ldbc_runner();
     auto* qr = get_ldbc_runner(); \
     if (!qr) { FAIL("Cannot open DB: " << g_ldbc_path); return; }
 
-// IS1 — Person basic info with city (both :City and :Place should work)
-TEST_CASE("IS1a Person 35184372099695 basic info (City)", "[ldbc][is]") {
+static std::string sample_person_id_str() {
+    return std::to_string(ldbc::SAMPLE_PERSON_ID);
+}
+
+// IS1 — Person basic info with city.
+//
+// `:City` is a sub-label SF1's load script tags but `load-ldbc-mini.sh`
+// does not (Place.csv `type` column is not split into separate label
+// files). IS1a uses :City and is therefore SF1-only; IS1b uses the
+// parent :Place label and exercises the same query path on both
+// fixtures.
+#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
+TEST_CASE("IS1a sample person basic info (City)", "[ldbc][is]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (n:Person {id: 35184372099695})-[r:IS_LOCATED_IN]->(p:City) "
-        "RETURN n.firstName AS firstName, n.lastName AS lastName, "
-        "       n.birthday AS birthday, n.locationIP AS locationIP, "
-        "       n.browserUsed AS browserUsed, p.id AS cityId, "
-        "       n.gender AS gender, n.creationDate AS creationDate",
+    auto q = "MATCH (n:Person {id: " + std::to_string(ldbc::IS1_PERSON_ID) +
+             "})-[r:IS_LOCATED_IN]->(p:City) "
+             "RETURN n.firstName AS firstName, n.lastName AS lastName, "
+             "       n.birthday AS birthday, n.locationIP AS locationIP, "
+             "       n.browserUsed AS browserUsed, p.id AS cityId, "
+             "       n.gender AS gender, n.creationDate AS creationDate";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::STRING, qtest::ColType::STRING,
          qtest::ColType::INT64,  qtest::ColType::STRING,
          qtest::ColType::STRING, qtest::ColType::INT64,
          qtest::ColType::STRING, qtest::ColType::INT64});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].str_at(0) == "Changpeng");
-    CHECK(r[0].str_at(1) == "Wei");
-    CHECK(r[0].int64_at(2) == 337132800000LL);
-    CHECK(r[0].str_at(3) == "1.1.39.242");
-    CHECK(r[0].str_at(4) == "Internet Explorer");
-    CHECK(r[0].int64_at(5) == 367);
-    CHECK(r[0].str_at(6) == "female");
-    CHECK(r[0].int64_at(7) == 1347431652132LL);
+    CHECK(r[0].str_at(0) == ldbc::IS1_FIRST_NAME);
+    CHECK(r[0].str_at(1) == ldbc::IS1_LAST_NAME);
+    CHECK(r[0].int64_at(2) == ldbc::IS1_BIRTHDAY_MS);
+    CHECK(r[0].str_at(3) == ldbc::IS1_LOCATION_IP);
+    CHECK(r[0].str_at(4) == ldbc::IS1_BROWSER_USED);
+    CHECK(r[0].int64_at(5) == ldbc::IS1_CITY_ID);
+    CHECK(r[0].str_at(6) == ldbc::IS1_GENDER);
+    CHECK(r[0].int64_at(7) == ldbc::IS1_CREATION_DATE_MS);
 }
+#endif
 
-TEST_CASE("IS1b Person 35184372099695 basic info (Place)", "[ldbc][is]") {
+TEST_CASE("IS1b sample person basic info (Place)", "[ldbc][is]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (n:Person {id: 35184372099695})-[r:IS_LOCATED_IN]->(p:Place) "
-        "RETURN n.firstName AS firstName, n.lastName AS lastName, "
-        "       n.birthday AS birthday, n.locationIP AS locationIP, "
-        "       n.browserUsed AS browserUsed, p.id AS cityId, "
-        "       n.gender AS gender, n.creationDate AS creationDate",
+    auto q = "MATCH (n:Person {id: " + std::to_string(ldbc::IS1_PERSON_ID) +
+             "})-[r:IS_LOCATED_IN]->(p:Place) "
+             "RETURN n.firstName AS firstName, n.lastName AS lastName, "
+             "       n.birthday AS birthday, n.locationIP AS locationIP, "
+             "       n.browserUsed AS browserUsed, p.id AS cityId, "
+             "       n.gender AS gender, n.creationDate AS creationDate";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::STRING, qtest::ColType::STRING,
          qtest::ColType::INT64,  qtest::ColType::STRING,
          qtest::ColType::STRING, qtest::ColType::INT64,
          qtest::ColType::STRING, qtest::ColType::INT64});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].str_at(0) == "Changpeng");
-    CHECK(r[0].str_at(1) == "Wei");
-    CHECK(r[0].int64_at(2) == 337132800000LL);
-    CHECK(r[0].str_at(3) == "1.1.39.242");
-    CHECK(r[0].str_at(4) == "Internet Explorer");
-    CHECK(r[0].int64_at(5) == 367);
-    CHECK(r[0].str_at(6) == "female");
-    CHECK(r[0].int64_at(7) == 1347431652132LL);
+    CHECK(r[0].str_at(0) == ldbc::IS1_FIRST_NAME);
+    CHECK(r[0].str_at(1) == ldbc::IS1_LAST_NAME);
+    CHECK(r[0].int64_at(2) == ldbc::IS1_BIRTHDAY_MS);
+    CHECK(r[0].str_at(3) == ldbc::IS1_LOCATION_IP);
+    CHECK(r[0].str_at(4) == ldbc::IS1_BROWSER_USED);
+    CHECK(r[0].int64_at(5) == ldbc::IS1_CITY_ID);
+    CHECK(r[0].str_at(6) == ldbc::IS1_GENDER);
+    CHECK(r[0].int64_at(7) == ldbc::IS1_CREATION_DATE_MS);
 }
 
-// IS2 — Recent 10 comments by Person 933 with originating post info
-TEST_CASE("IS2 Person 933 recent 10 comments with post info", "[ldbc][is]") {
+// IS2 — Recent 10 comments by SAMPLE_PERSON with originating post info
+TEST_CASE("IS2 sample person recent 10 comments with post info", "[ldbc][is]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (:Person {id: 933})<-[:HAS_CREATOR]-(message:Comment) "
-        "WITH message, message.id AS messageId, "
-        "     message.creationDate AS messageCreationDate "
-        "ORDER BY messageCreationDate DESC, messageId ASC "
-        "LIMIT 10 "
-        "MATCH (message)-[:REPLY_OF*0..]->(post:Post), "
-        "      (post)-[:HAS_CREATOR]->(person) "
-        "RETURN messageId, message.content AS messageContent, "
-        "       messageCreationDate, post.id AS postId, "
-        "       person.id AS personId, person.firstName AS personFirstName, "
-        "       person.lastName AS personLastName "
-        "ORDER BY messageCreationDate DESC, messageId ASC",
+    auto q = "MATCH (:Person {id: " + sample_person_id_str() +
+             "})<-[:HAS_CREATOR]-(message:Comment) "
+             "WITH message, message.id AS messageId, "
+             "     message.creationDate AS messageCreationDate "
+             "ORDER BY messageCreationDate DESC, messageId ASC "
+             "LIMIT 10 "
+             "MATCH (message)-[:REPLY_OF*0..]->(post:Post), "
+             "      (post)-[:HAS_CREATOR]->(person) "
+             "RETURN messageId, message.content AS messageContent, "
+             "       messageCreationDate, post.id AS postId, "
+             "       person.id AS personId, person.firstName AS personFirstName, "
+             "       person.lastName AS personLastName "
+             "ORDER BY messageCreationDate DESC, messageId ASC";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::INT64,
          qtest::ColType::INT64, qtest::ColType::INT64, qtest::ColType::STRING,
          qtest::ColType::STRING});
-    REQUIRE(r.size() == 10);
-    // row 0
-    CHECK(r[0].int64_at(0) == 2199027727462LL);
-    CHECK(r[0].str_at(1) == "good");
-    CHECK(r[0].int64_at(2) == 1347156463979LL);
-    CHECK(r[0].int64_at(3) == 2061588773973LL);
-    CHECK(r[0].int64_at(4) == 32985348833579LL);
-    CHECK(r[0].str_at(5) == "Otto");
-    CHECK(r[0].str_at(6) == "Becker");
-    // row 1
-    CHECK(r[1].int64_at(0) == 2061588773980LL);
-    CHECK(r[1].str_at(1) == "no way!");
-    CHECK(r[1].int64_at(2) == 1347020779693LL);
-    CHECK(r[1].int64_at(3) == 2061588773973LL);
-    CHECK(r[1].int64_at(4) == 32985348833579LL);
-    CHECK(r[1].str_at(5) == "Otto");
-    CHECK(r[1].str_at(6) == "Becker");
-    // row 2
-    CHECK(r[2].int64_at(0) == 2061584946139LL);
-    CHECK(r[2].str_at(1) == "yes");
-    CHECK(r[2].int64_at(2) == 1343987237082LL);
-    CHECK(r[2].int64_at(3) == 2061584946128LL);
-    CHECK(r[2].int64_at(4) == 4139);
-    CHECK(r[2].str_at(5) == "Baruch");
-    CHECK(r[2].str_at(6) == "Dego");
-    // row 3
-    CHECK(r[3].int64_at(0) == 2061585616327LL);
-    CHECK(r[3].str_at(1).find("About Arnold Schwarzenegger") == 0);
-    CHECK(r[3].int64_at(2) == 1343919397609LL);
-    CHECK(r[3].int64_at(3) == 2061585616321LL);
-    CHECK(r[3].int64_at(4) == 6597069777240LL);
-    CHECK(r[3].str_at(5) == "Fritz");
-    CHECK(r[3].str_at(6) == "Muller");
-    // row 4
-    CHECK(r[4].int64_at(0) == 2061585618894LL);
-    CHECK(r[4].str_at(1) == "thanks");
-    CHECK(r[4].int64_at(2) == 1343106691147LL);
-    CHECK(r[4].int64_at(3) == 2061585618887LL);
-    CHECK(r[4].int64_at(4) == 6597069777240LL);
-    CHECK(r[4].str_at(5) == "Fritz");
-    CHECK(r[4].str_at(6) == "Muller");
-    // row 5
-    CHECK(r[5].int64_at(0) == 2061585619578LL);
-    CHECK(r[5].str_at(1).find("About Josip Broz Tito") == 0);
-    CHECK(r[5].int64_at(2) == 1342380120292LL);
-    CHECK(r[5].int64_at(3) == 2061585619561LL);
-    CHECK(r[5].int64_at(4) == 6597069777240LL);
-    CHECK(r[5].str_at(5) == "Fritz");
-    CHECK(r[5].str_at(6) == "Muller");
-    // row 6
-    CHECK(r[6].int64_at(0) == 1786707214487LL);
-    CHECK(r[6].str_at(1) == "maybe");
-    CHECK(r[6].int64_at(2) == 1335712528590LL);
-    CHECK(r[6].int64_at(3) == 1786707214481LL);
-    CHECK(r[6].int64_at(4) == 10995116284808LL);
-    CHECK(r[6].str_at(5) == "Andrei");
-    CHECK(r[6].str_at(6) == "Condariuc");
-    // row 7
-    CHECK(r[7].int64_at(0) == 1786707214957LL);
-    CHECK(r[7].str_at(1).find("About Lady Gaga") == 0);
-    CHECK(r[7].int64_at(2) == 1335694024103LL);
-    CHECK(r[7].int64_at(3) == 1786707214955LL);
-    CHECK(r[7].int64_at(4) == 10995116284808LL);
-    CHECK(r[7].str_at(5) == "Andrei");
-    CHECK(r[7].str_at(6) == "Condariuc");
-    // row 8
-    CHECK(r[8].int64_at(0) == 1786707214469LL);
-    CHECK(r[8].str_at(1).find("About Enrique Iglesias") == 0);
-    CHECK(r[8].int64_at(2) == 1335678484226LL);
-    CHECK(r[8].int64_at(3) == 1786707214468LL);
-    CHECK(r[8].int64_at(4) == 10995116284808LL);
-    CHECK(r[8].str_at(5) == "Andrei");
-    CHECK(r[8].str_at(6) == "Condariuc");
-    // row 9
-    CHECK(r[9].int64_at(0) == 1786707216224LL);
-    CHECK(r[9].str_at(1) == "no way!");
-    CHECK(r[9].int64_at(2) == 1335668918002LL);
-    CHECK(r[9].int64_at(3) == 1786707216218LL);
-    CHECK(r[9].int64_at(4) == 10995116284808LL);
-    CHECK(r[9].str_at(5) == "Andrei");
-    CHECK(r[9].str_at(6) == "Condariuc");
+    constexpr size_t N = sizeof(ldbc::IS2_RECENT_COMMENTS) / sizeof(ldbc::IS2_RECENT_COMMENTS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = ldbc::IS2_RECENT_COMMENTS[i];
+        CHECK(r[i].int64_at(0) == exp.message_id);
+        // Some content strings are very long ("About …" prefixes); use
+        // startswith semantics to keep the assertion robust to the
+        // 256-char chunk truncation the legacy test relied on.
+        CHECK(r[i].str_at(1).find(exp.content) == 0);
+        CHECK(r[i].int64_at(2) == exp.message_creation_ms);
+        CHECK(r[i].int64_at(3) == exp.post_id);
+        CHECK(r[i].int64_at(4) == exp.person_id);
+        CHECK(r[i].str_at(5) == exp.first_name);
+        CHECK(r[i].str_at(6) == exp.last_name);
+    }
 }
 
-// IS3 — Friend list for Person 933
-TEST_CASE("IS3 Person 933 friend list", "[ldbc][is]") {
+// IS3 — Friend list for SAMPLE_PERSON
+TEST_CASE("IS3 sample person friend list", "[ldbc][is]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (n:Person {id: 933})-[r:KNOWS]-(friend) "
-        "RETURN friend.id AS personId, friend.firstName AS firstName, "
-        "       friend.lastName AS lastName, "
-        "       r.creationDate AS friendshipCreationDate "
-        "ORDER BY friendshipCreationDate DESC, personId ASC",
+    auto q = "MATCH (n:Person {id: " + sample_person_id_str() +
+             "})-[r:KNOWS]-(friend) "
+             "RETURN friend.id AS personId, friend.firstName AS firstName, "
+             "       friend.lastName AS lastName, "
+             "       r.creationDate AS friendshipCreationDate "
+             "ORDER BY friendshipCreationDate DESC, personId ASC";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::STRING,
          qtest::ColType::STRING, qtest::ColType::INT64});
-    REQUIRE(r.size() == 5);
-    // row 0
-    CHECK(r[0].int64_at(0) == 32985348833579LL);
-    CHECK(r[0].str_at(1) == "Otto");
-    CHECK(r[0].str_at(2) == "Becker");
-    CHECK(r[0].int64_at(3) == 1346980290195LL);
-    // row 1
-    CHECK(r[1].int64_at(0) == 32985348838375LL);
-    CHECK(r[1].str_at(1) == "Otto");
-    CHECK(r[1].str_at(2) == "Richter");
-    CHECK(r[1].int64_at(3) == 1342512289463LL);
-    // row 2
-    CHECK(r[2].int64_at(0) == 10995116284808LL);
-    CHECK(r[2].str_at(1) == "Andrei");
-    CHECK(r[2].str_at(2) == "Condariuc");
-    CHECK(r[2].int64_at(3) == 1293950621955LL);
-    // row 3
-    CHECK(r[3].int64_at(0) == 6597069777240LL);
-    CHECK(r[3].str_at(1) == "Fritz");
-    CHECK(r[3].str_at(2) == "Muller");
-    CHECK(r[3].int64_at(3) == 1284975763187LL);
-    // row 4
-    CHECK(r[4].int64_at(0) == 4139);
-    CHECK(r[4].str_at(1) == "Baruch");
-    CHECK(r[4].str_at(2) == "Dego");
-    CHECK(r[4].int64_at(3) == 1268465841718LL);
+    constexpr size_t N = sizeof(ldbc::IS3_FRIENDS) / sizeof(ldbc::IS3_FRIENDS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = ldbc::IS3_FRIENDS[i];
+        CHECK(r[i].int64_at(0) == exp.person_id);
+        CHECK(r[i].str_at(1) == exp.first_name);
+        CHECK(r[i].str_at(2) == exp.last_name);
+        CHECK(r[i].int64_at(3) == exp.friendship_ms);
+    }
 }
 
 // IS4 — Message content (uses Message super-label, not Post/Comment)
-TEST_CASE("IS4 Message 2199029886840 content", "[ldbc][is]") {
+TEST_CASE("IS4 sample post content", "[ldbc][is]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (m:Message {id: 2199029886840}) "
-        "RETURN m.creationDate AS messageCreationDate, "
-        "       m.imageFile AS messageContent",
+    auto q = "MATCH (m:Message {id: " + std::to_string(ldbc::IS4_POST_ID) + "}) "
+             "RETURN m.creationDate AS messageCreationDate, "
+             "       m.imageFile AS messageContent";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 1347463431887LL);
-    CHECK(r[0].str_at(1) == "photo2199029886840.jpg");
+    CHECK(r[0].int64_at(0) == ldbc::IS4_CREATION_MS);
+    CHECK(r[0].str_at(1) == ldbc::IS4_IMAGE_FILE);
 }
 
 // IS5 — Message creator (uses Message super-label)
-TEST_CASE("IS5 Message 824635044686 creator", "[ldbc][is]") {
+TEST_CASE("IS5 sample comment creator", "[ldbc][is]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (m:Message {id: 824635044686})-[r:HAS_CREATOR]->(p:Person) "
-        "RETURN p.id AS personId, p.firstName AS firstName, "
-        "       p.lastName AS lastName",
+    auto q = "MATCH (m:Message {id: " + std::to_string(ldbc::SAMPLE_COMMENT_ID) +
+             "})-[r:HAS_CREATOR]->(p:Person) "
+             "RETURN p.id AS personId, p.firstName AS firstName, "
+             "       p.lastName AS lastName";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 933);
-    CHECK(r[0].str_at(1) == "Mahinda");
-    CHECK(r[0].str_at(2) == "Perera");
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_COMMENT_CREATOR_ID);
+    CHECK(r[0].str_at(1) == ldbc::SAMPLE_COMMENT_CREATOR_FIRSTNAME);
+    CHECK(r[0].str_at(2) == ldbc::SAMPLE_COMMENT_CREATOR_LASTNAME);
 }
 
 // IS6 — Forum containing the message (uses Message super-label, REPLY_OF chain)
-TEST_CASE("IS6 Forum of Message 824635044686", "[ldbc][is]") {
+TEST_CASE("IS6 forum of sample comment", "[ldbc][is]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (m:Message {id: 824635044686})-[:REPLY_OF*0..]->(p:Post)"
-        "      <-[:CONTAINER_OF]-(f:Forum)"
-        "      -[:HAS_MODERATOR]->(mod:Person) "
-        "RETURN f.id AS forumId, f.title AS forumTitle, "
-        "       mod.id AS moderatorId, mod.firstName AS moderatorFirstName, "
-        "       mod.lastName AS moderatorLastName",
+    auto q = "MATCH (m:Message {id: " + std::to_string(ldbc::SAMPLE_COMMENT_ID) +
+             "})-[:REPLY_OF*0..]->(p:Post)"
+             "      <-[:CONTAINER_OF]-(f:Forum)"
+             "      -[:HAS_MODERATOR]->(mod:Person) "
+             "RETURN f.id AS forumId, f.title AS forumTitle, "
+             "       mod.id AS moderatorId, mod.firstName AS moderatorFirstName, "
+             "       mod.lastName AS moderatorLastName";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::STRING,
          qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::STRING});
     REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 412317916558LL);
-    CHECK(r[0].str_at(1) == "Wall of Fritz Muller");
-    CHECK(r[0].int64_at(2) == 6597069777240LL);
-    CHECK(r[0].str_at(3) == "Fritz");
-    CHECK(r[0].str_at(4) == "Muller");
+    CHECK(r[0].int64_at(0) == ldbc::IS6_FORUM_ID);
+    CHECK(r[0].str_at(1) == ldbc::IS6_FORUM_TITLE);
+    CHECK(r[0].int64_at(2) == ldbc::IS6_MOD_ID);
+    CHECK(r[0].str_at(3) == ldbc::IS6_MOD_FIRST);
+    CHECK(r[0].str_at(4) == ldbc::IS6_MOD_LAST);
 }
 
 // IS7 — Replies to message with OPTIONAL MATCH + CASE (uses Message super-label)
-TEST_CASE("IS7 Replies to Message 824635044682", "[ldbc][is]") {
+//
+// Gated SF1-only: the `(m)-[:HAS_CREATOR]->(a)-[r:KNOWS]-(p)` OPTIONAL
+// MATCH clause traverses the undirected `:KNOWS` edge in both directions
+// without deduping on the mini fixture, so each reply row is duplicated
+// (issue #83). SF1 dev runs still exercise the case.
+#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
+TEST_CASE("IS7 replies to sample message", "[ldbc][is]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (m:Message {id: 824635044682})<-[:REPLY_OF]-(c:Comment)"
-        "      -[:HAS_CREATOR]->(p:Person) "
-        "OPTIONAL MATCH (m)-[:HAS_CREATOR]->(a:Person)-[r:KNOWS]-(p) "
-        "RETURN c.id AS commentId, c.content AS commentContent, "
-        "       c.creationDate AS commentCreationDate, "
-        "       p.id AS replyAuthorId, "
-        "       p.firstName AS replyAuthorFirstName, "
-        "       p.lastName AS replyAuthorLastName, "
-        "       CASE r._id WHEN null THEN false ELSE true END "
-        "           AS replyAuthorKnowsOriginalMessageAuthor "
-        "ORDER BY commentCreationDate DESC, replyAuthorId ASC",
+    auto q = "MATCH (m:Message {id: " + std::to_string(ldbc::IS7_MESSAGE_ID) +
+             "})<-[:REPLY_OF]-(c:Comment)"
+             "      -[:HAS_CREATOR]->(p:Person) "
+             "OPTIONAL MATCH (m)-[:HAS_CREATOR]->(a:Person)-[r:KNOWS]-(p) "
+             "RETURN c.id AS commentId, c.content AS commentContent, "
+             "       c.creationDate AS commentCreationDate, "
+             "       p.id AS replyAuthorId, "
+             "       p.firstName AS replyAuthorFirstName, "
+             "       p.lastName AS replyAuthorLastName, "
+             "       CASE r._id WHEN null THEN false ELSE true END "
+             "           AS replyAuthorKnowsOriginalMessageAuthor "
+             "ORDER BY commentCreationDate DESC, replyAuthorId ASC";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::INT64,
          qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::STRING,
          qtest::ColType::BOOL});
-    REQUIRE(r.size() == 2);
-    // row 0: 824635044685, "great", 1295218398759, 2738, "Eden", "Atias", true
-    CHECK(r[0].int64_at(0) == 824635044685LL);
-    CHECK(r[0].str_at(1) == "great");
-    CHECK(r[0].int64_at(2) == 1295218398759LL);
-    CHECK(r[0].int64_at(3) == 2738);
-    CHECK(r[0].str_at(4) == "Eden");
-    CHECK(r[0].str_at(5) == "Atias");
-    CHECK(r[0].bool_at(6) == true);
-    // row 1: 824635044686, "cool", 1295203653676, 933, "Mahinda", "Perera", true
-    CHECK(r[1].int64_at(0) == 824635044686LL);
-    CHECK(r[1].str_at(1) == "cool");
-    CHECK(r[1].int64_at(2) == 1295203653676LL);
-    CHECK(r[1].int64_at(3) == 933);
-    CHECK(r[1].str_at(4) == "Mahinda");
-    CHECK(r[1].str_at(5) == "Perera");
-    CHECK(r[1].bool_at(6) == true);
+    constexpr size_t N = sizeof(ldbc::IS7_REPLIES) / sizeof(ldbc::IS7_REPLIES[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = ldbc::IS7_REPLIES[i];
+        CHECK(r[i].int64_at(0) == exp.comment_id);
+        CHECK(r[i].str_at(1) == exp.content);
+        CHECK(r[i].int64_at(2) == exp.creation_ms);
+        CHECK(r[i].int64_at(3) == exp.reply_author_id);
+        CHECK(r[i].str_at(4) == exp.reply_author_first);
+        CHECK(r[i].str_at(5) == exp.reply_author_last);
+        CHECK(r[i].bool_at(6) == exp.reply_author_knows_orig);
+    }
 }
+#endif  // !TURBOLYNX_LDBC_FIXTURE_MINI (IS7 gated, see issue #83)


### PR DESCRIPTION
## Summary

Lands the full DATE_EPOCHMS fix (issue #82) and migrates `[ldbc][is]` tests to the SF0.003 mini fixture in one PR — the IS migration is what surfaced the bug, and the IS suite is the highest-value regression coverage for it.

## Bug fix (closes #82)

Three sites are touched, each addresses a different stage of the same underlying inconsistency:

1. **Mapping table** (`graph_simdcsv_parser.hpp` line 901): `DATE_EPOCHMS` → `TIMESTAMP_MS` instead of `DATE`. Matches what the key-column path (line ~813) already did via `internal_key_types`.
2. **Parser case** (`graph_simdcsv_parser.hpp` line 381): drop the `/1000 → date_t` shortcut, call `Timestamp::FromEpochMs` and store into the `timestamp_t` slot. Storage now round-trips ms losslessly.
3. **Value getter** (`value.cpp` line 787): move TIMESTAMP / TIMESTAMP_TZ / TIMESTAMP_MS / TIMESTAMP_NS / TIMESTAMP_SEC into one arm reading `value_.timestamp`, matching where every `Value::TIMESTAMP*(timestamp_t)` constructor actually writes. UBIGINT / ID stay on `value_.ubigint`. Pre-fix the misgrouping was dead code (no LogicalType actually surfaced as TIMESTAMP_MS) — the mapping fix made it live and triggered the `Unimplemented type for cast (UINT64 -> TIMESTAMP)` throw.
4. **C-API getter** (`turbolynx-c.cpp`): add a TIMESTAMP_MS case to `turbolynx_get_int64`'s widening switch so callers see epoch-ms units, the same way the existing DATE branch does (`days * 86400000` vs `ts.value / 1000`).

## Test coverage

Two new test surfaces lock in the fix:

- **Bulkload smoke round-trip** (`test/bulkload/test_smoke_cli.cpp`, new `[bulkload][smoke][cli][timestamp]` case). Self-contained: writes a tiny `:DATE_EPOCHMS` CSV, imports via the CLI, asserts `int64_at` round-trips three boundary values (sub-day precision, day-aligned, epoch zero). Fixture-independent — guards both the storage and read paths without depending on the LDBC mini fixture.
- **LDBC IS migration** (`test_ldbc_is_correctness.cpp`, 8 cases → 6 active on mini): off SF1 hardcoded IDs and onto `IS*` constants in `helpers/ldbc_expected_counts.hpp`. SF0.003 expected values Neo4j-verified.

## SF1-only gates added

- **IS1a** (`(p:City)`) — the mini load script does not tag the `:City` sub-label on `:Place` rows. IS1b uses the parent `:Place` label and exercises the same query path on both fixtures.
- **IS7** (`OPTIONAL MATCH … (a)-[r:KNOWS]-(p)` with CASE) — undirected `:KNOWS` traversal duplicates rows on the mini fixture (issue [#83](https://github.com/turbolynx-dslab/TurboLynx/issues/83)).

## Test plan

- [x] `cmake --build build-portable --target query_test --target turbolynx_bin --target bulkload_test` (Release, `-DTURBOLYNX_LDBC_FIXTURE_MINI=ON`)
- [x] `bulkload_test "DATE_EPOCHMS column round-trips with millisecond precision"` → 1/1 (9 assertions)
- [x] `query_test "[ldbc][is]" --ldbc-path /tmp/ldbc-mini-ws` → **6/6 (106 assertions)**
- [x] No regression on `[ldbc][count]` (30/30), `[ldbc][traversal]` (19/19), `[ldbc][filter]` (58/58), `[ldbc][func]` (15+2 mayfail-skipped/17), `[ldbc][robustness]~[stress]` (215/215)
- [ ] CI Build & Test (Ubuntu + macOS)

Closes [#82](https://github.com/turbolynx-dslab/TurboLynx/issues/82). Tracks [#83](https://github.com/turbolynx-dslab/TurboLynx/issues/83) for the OPTIONAL MATCH dedup follow-up.