### PR TITLE
test: disable two unbounded VarLen [robustness] cases (#86)

### DIFF
--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -948,6 +948,15 @@ TEST_CASE("circular 3-hop pattern", "[ldbc][robustness]") {
         "RETURN a.id, b.id, c.id LIMIT 3");
 }
 
+// FIXME(#86): both cases below hang on Linux because LIMIT is not propagated
+// through HashAgg(DISTINCT). The aggregate pulls its child to EOF, which
+// never happens for unbounded VarLen on a connected mini-fixture. They
+// "passed" on macOS only because unordered_set::reserve(UINT64_MAX) throws
+// bad_array_new_length under libc++, which EXPECT_GRACEFUL_FAILURE swallows
+// — i.e. the queries never actually executed there either.
+// Re-enable (and ideally migrate to a real [traversal] case with a
+// Neo4j-verified expected count) once #86 lands.
+#if 0
 TEST_CASE("VarLen unbounded upper", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
     EXPECT_GRACEFUL_FAILURE(
@@ -961,6 +970,7 @@ TEST_CASE("VarLen star only", "[ldbc][robustness]") {
         "MATCH (n:Person {id: " LDBC_SAMPLE_PID_STR "})-[:KNOWS*]-(m:Person) "
         "RETURN DISTINCT m.id LIMIT 3");
 }
+#endif
 
 TEST_CASE("five-hop chain", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();


### PR DESCRIPTION
## Summary

- Wraps `VarLen unbounded upper` and `VarLen star only` in `#if 0` with a FIXME pointing to #86. Both hang on Linux and only "passed" on macOS because `unordered_set::reserve(UINT64_MAX)` throws under libc++, which `EXPECT_GRACEFUL_FAILURE` silently swallows — the queries never actually executed there either.
- Underlying engine fix tracked in #86 (LIMIT not propagated through `HashAgg(DISTINCT)`). The broader `EXPECT_GRACEFUL_FAILURE` silent-pass pattern is being audited separately in #87.

## Test plan
- [x] Local build (macOS) succeeds
- [x] `./build-portable/test/query/query_test "[ldbc][robustness]~[stress]" --ldbc-path /tmp/ldbc-mini-ws` — 213/213 passed (was 215 before; the two disabled cases drop out)
- [ ] CI [robustness] step on Linux now completes (was previously hanging at 6h timeout)