### PR TITLE
Fix TIMESTAMP_MS storage to ms (was µs); add BIGINT → TIMESTAMP_MS cast (#89)

### DIFF
--- a/src/common/vector_operations/vector_cast.cpp
+++ b/src/common/vector_operations/vector_cast.cpp
@@ -137,6 +137,25 @@ static void VectorStringCast(Vector &source, Vector &result, idx_t count) {
 	UnaryExecutor::GenericExecute<SRC, string_t, VectorStringCastOperator<OP>>(source, result, count, (void *)&result);
 }
 
+// Cast an integer (interpreted as epoch-ms) into a TIMESTAMP_MS column.
+// TIMESTAMP_MS storage is `timestamp_t.value` = ms-since-epoch (see the
+// CSV loader / C API getter / CastTimestamp{Ms,Us}{To,From} family — they
+// all assume ms storage). So the cast is a single overflow-checked widen
+// of the source into int64 followed by a `timestamp_t` wrap. Resolves
+// issue #89 (`Conversion Error: Unimplemented type for cast (BIGINT ->
+// TIMESTAMP_MS)` blocking LDBC IC2/3/4/5/9 mini-fixture migration).
+struct NumericToTimestampMsCast {
+	template <class SRC, class DST>
+	static inline bool Operation(SRC input, DST &result, bool strict = false) {
+		int64_t ms;
+		if (!duckdb::NumericTryCast::Operation<SRC, int64_t>(input, ms)) {
+			return false;
+		}
+		result = timestamp_t(ms);
+		return true;
+	}
+};
+
 template <class SRC>
 static bool NumericCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
 	// now switch on the result type
@@ -169,6 +188,8 @@ static bool NumericCastSwitch(Vector &source, Vector &result, idx_t count, strin
 		return VectorTryCastLoop<SRC, double, duckdb::NumericTryCast>(source, result, count, error_message);
 	case LogicalTypeId::DECIMAL:
 		return ToDecimalCast<SRC>(source, result, count, error_message);
+	case LogicalTypeId::TIMESTAMP_MS:
+		return VectorTryCastLoop<SRC, timestamp_t, NumericToTimestampMsCast>(source, result, count, error_message);
 	case LogicalTypeId::JSON:
 	case LogicalTypeId::VARCHAR: {
 		VectorStringCast<SRC, duckdb::StringCast>(source, result, count);

--- a/src/include/common/graph_simdcsv_parser.hpp
+++ b/src/include/common/graph_simdcsv_parser.hpp
@@ -380,14 +380,18 @@ inline void SetValueFromCSV(LogicalType type, DataChunk &output, size_t i, idx_t
     case LogicalTypeId::DATE:
       ((date_t *)data_ptr)[current_index] = Date::FromCString((const char*)p.data() + start_offset, end_offset - start_offset); break;
     case LogicalTypeId::TIMESTAMP_MS:
+      // TIMESTAMP_MS storage is millisecond-since-epoch in `timestamp_t.value`
+      // — every other cast / format path in the codebase (CastTimestampMsToUs,
+      // CastTimestampUsToMs, TryCastToTimestampMS, Value::ToString) already
+      // treats this column as ms storage. The earlier #82 fix mistakenly went
+      // through `Timestamp::FromEpochMs` (which scales ms × 1000 = µs) and
+      // then compensated in the C API getter with `/1000`. The two cancelled
+      // out for round-trip but left storage in µs and broke any in-engine
+      // comparison against an integer-ms literal (issue #89). Restore the
+      // ms-storage convention by writing the parsed int64 directly.
       int64_t epoch_ms;
       std::from_chars((const char*)p.data() + start_offset, (const char*)p.data() + end_offset, epoch_ms);
-      // Pre-fix this divided by 1000 and stored a date_t — silently truncated
-      // sub-day precision and, after the mapping was corrected, also wrote a
-      // 32-bit value into a 64-bit slot. Now go through the existing
-      // Timestamp::FromEpochMs helper (ms → μs) and store into timestamp_t,
-      // so DATE_EPOCHMS columns round-trip with full precision (issue #82).
-      ((timestamp_t *)data_ptr)[current_index] = Timestamp::FromEpochMs(epoch_ms);
+      ((timestamp_t *)data_ptr)[current_index] = timestamp_t(epoch_ms);
       break;
 		default:
 			throw NotImplementedException("SetValueFromCSV - Unsupported type");

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -4017,11 +4017,10 @@ int64_t turbolynx_get_int64(turbolynx_resultset_wrapper* result_set_wrp, idx_t c
 	// DATE is also stored as int32 days-since-epoch; when the caller treats
 	// it as int64 we convert to milliseconds.
 	//
-	// TIMESTAMP_MS is internally microseconds (timestamp_t.value); we divide
-	// by 1000 to expose the same epoch-ms units as the DATE branch above so
-	// that callers comparing against epoch_ms literals (e.g. LDBC IS / IC
-	// expected values) get a consistent unit regardless of the underlying
-	// storage representation. Issue #82.
+	// TIMESTAMP_MS storage is now ms-since-epoch in `timestamp_t.value` (issue
+	// #89; the earlier #82 path stored µs here and divided here to compensate,
+	// which cancelled out for round-trip but broke in-engine `WHERE col <op>
+	// <integer-ms-literal>` comparisons). Return the raw value directly.
 	if (result_set_wrp != NULL) {
 		size_t local_cursor;
 		auto result = turbolynx_move_to_cursored_result(result_set_wrp, col_idx, local_cursor);
@@ -4035,7 +4034,7 @@ int64_t turbolynx_get_int64(turbolynx_resultset_wrapper* result_set_wrp, idx_t c
 			}
 			case duckdb::LogicalTypeId::TIMESTAMP_MS: {
 				duckdb::timestamp_t ts = turbolynx_get_value<duckdb::timestamp_t, duckdb::LogicalTypeId::TIMESTAMP_MS>(result_set_wrp, col_idx);
-				return ts.value / 1000;
+				return ts.value;
 			}
 			case duckdb::LogicalTypeId::INTEGER:
 				return (int64_t)turbolynx_get_value<int32_t, duckdb::LogicalTypeId::INTEGER>(result_set_wrp, col_idx);


### PR DESCRIPTION
## Summary

Resolves [#89](https://github.com/turbolynx-dslab/TurboLynx/issues/89). Three small changes that together restore the documented `TIMESTAMP_MS` storage convention (`timestamp_t.value` = ms-since-epoch) and add the implicit numeric → `TIMESTAMP_MS` cast that the documented convention makes trivial.

## Background

The earlier #82 fix routed CSV `DATE_EPOCHMS` columns through `Timestamp::FromEpochMs` (which scales ms × 1000 = µs) and stored the result in `TIMESTAMP_MS` columns, then divided back by 1000 in the C API getter.

Round-trip through these two boundaries looked correct from the test runner, but **every other in-engine code path that handles `TIMESTAMP_MS` already assumes ms storage** — `CastTimestampMsToUs`, `CastTimestampUsToMs`, `TryCastToTimestampMS`, `Value::ToString` — and was producing wrong values whenever the column flowed through them. The most visible symptom was that any `WHERE creationDate <op> <integer-ms-literal>` comparison hit the unimplemented `BIGINT → TIMESTAMP_MS` cast (#89), blocking LDBC IC2/3/4/5/9 mini-fixture migration.

## Changes

1. [`graph_simdcsv_parser.hpp`](src/include/common/graph_simdcsv_parser.hpp:382) — drop `Timestamp::FromEpochMs(epoch_ms)`, write `timestamp_t(epoch_ms)` directly. Storage is now ms as the type name (and every other `TIMESTAMP_MS` code path) implies.
2. [`turbolynx-c.cpp`](src/main/capi/turbolynx-c.cpp:4036) — drop the compensating `ts.value / 1000` in the `TIMESTAMP_MS` branch of `turbolynx_get_int64`; return `ts.value` directly (already ms).
3. [`vector_cast.cpp`](src/common/vector_operations/vector_cast.cpp) — add a `NumericToTimestampMsCast` operator and wire it into `NumericCastSwitch` so integer literals (TINYINT through HUGEINT, FLOAT, DOUBLE) cast to `TIMESTAMP_MS` by reinterpreting the value as ms-since-epoch. Source-side overflow checks via `NumericTryCast::Operation<SRC, int64_t>` first.

3 files changed, +36 / −12.

## Implicit cast principle

> **NUMERIC → TIMESTAMP_MS treats the integer as the column's storage value (= ms-since-epoch).**

User suggested this rule (\"데이터 타입에 맞춰서 변환\") and it is consistent with how every other `TIMESTAMP_MS` cast in the engine already behaves. Other temporal target types (`TIMESTAMP`, `TIMESTAMP_TZ`, `TIMESTAMP_NS`, `TIMESTAMP_SEC`, `DATE`) are intentionally left unimplemented in this PR — their storage units are ambiguous to a typical user (\"is `1356998400000` µs or ms?\") so explicit `epoch_ms() / to_timestamp() / datetime({...})` should be required.

## Test plan
- [x] Reload `/tmp/ldbc-mini-ws` with `bash scripts/load-ldbc-mini.sh build-portable /tmp/ldbc-mini-ws` (stale µs-storage data from the pre-fix loader needs regenerating once).
- [x] `[ldbc][is] [ic] [traversal] [count] [robustness]~[stress] [filter] [func]` → 346 cases / 1043 assertions pass / 4 skipped (unchanged from pre-fix counts — round-tripping IS tests still match because the storage-unit change is balanced by removing the C API divider).
- [x] `ctest -R turbolynx_(common|catalog|storage|execution)` → 4/4 pass.
- [x] Throwaway probe `TEST_CASE` confirmed `WHERE creationDate <= 1356998400000` now works on IC2's mini query on Ali (probe removed before commit; left for the follow-up).
- [ ] CI: full Ubuntu + macOS pipeline.

## Follow-up

A separate PR should re-enable the IC2/3/4/5/9 mini test cases (currently `#ifndef TURBOLYNX_LDBC_FIXTURE_MINI` gates pointing at this issue). Mini-fixture expected rows for IC2 are already pinned in [`ldbc_expected_counts.hpp`](test/query/helpers/ldbc_expected_counts.hpp) (`IC2_RECENT_MESSAGES`, `IC2_DATE_THRESHOLD_MS`); the others need oracle work.

## Caveat

Anyone with a pre-existing `/tmp/ldbc-mini-ws` (or any other workspace bulk-loaded before this PR) needs to reload — the µs-storage data from the old loader will mismatch the new ms-storage assumptions. CI is unaffected because it runs `load-ldbc-mini.sh` fresh each pipeline. Local devs: re-run the load script.