### PR TITLE
test: enable LDBC IC2/IC3/IC4/IC5/IC9 on mini fixture (PR-E2c, stacked on #93)

### DIFF
--- a/test/query/helpers/ldbc_expected_counts.hpp
+++ b/test/query/helpers/ldbc_expected_counts.hpp
@@ -433,6 +433,120 @@ inline constexpr IcRecentReply IC8_RESULTS[] = {
     {24189255811081LL, "Alim",      "Guliyev",         1349431344692LL, 1099511628654LL, "About Pope John XXIII,"},
 };
 
+// IC3 — friends-of-friends posting in BOTH country X and country Y.
+// Mini fixture is too sparse for the SF1 anchor (Laos / Scotland yields 0
+// rows on Ali's neighbourhood). Azerbaijan / Rwanda is the one country
+// pair where a single FoF (Arbaaz Ali) crosses both. Date range is widened
+// to [2010-01-01, 2013-01-01) so the test isn't fragile against the few
+// messages Arbaaz has in those countries.
+inline constexpr int64_t     IC3_ANCHOR_PERSON_ID  = IC1_ANCHOR_PERSON_ID;
+inline constexpr const char* IC3_COUNTRY_X         = "Azerbaijan";
+inline constexpr const char* IC3_COUNTRY_Y         = "Rwanda";
+inline constexpr int64_t     IC3_DATE_START_MS     = 1262304000000LL;  // 2010-01-01
+inline constexpr int64_t     IC3_DATE_END_MS       = 1356998400000LL;  // 2013-01-01
+struct IcCountryFriend {
+    int64_t     friend_id;
+    const char* first_name;
+    const char* last_name;
+    int64_t     x_count;
+    int64_t     y_count;
+};
+inline constexpr IcCountryFriend IC3_RESULTS[] = {
+    {2199023255573LL, "Arbaaz", "Ali", 2, 2},
+};
+
+// IC4 — popular Tags on (anchor)'s friends' Posts created strictly in the
+// valid window, with zero "older" Posts. Anchor = Ali. Window =
+// [2012-01-01, 2013-01-01) chosen so Ali's 1-hop friend Posts produce a
+// non-trivial top-10 (the SF1 Apr-2012 window yields 0 rows on mini).
+inline constexpr int64_t IC4_ANCHOR_PERSON_ID = IC1_ANCHOR_PERSON_ID;
+inline constexpr int64_t IC4_VALID_START_MS   = 1325376000000LL;  // 2012-01-01
+inline constexpr int64_t IC4_VALID_END_MS     = 1356998400000LL;  // 2013-01-01
+inline constexpr IcTagCount IC4_RESULTS[] = {
+    {"Hannibal",            10},
+    {"Nat_King_Cole",        5},
+    {"Judy_Davis",           3},
+    {"Saint_George",         3},
+    {"Jacques_Chirac",       2},
+    {"Jim_Carrey",           2},
+    {"Cardinal_Richelieu",   1},
+    {"Daniel_Nestor",        1},
+    {"Fidel_Castro",         1},
+    {"George_Lucas",         1},
+};
+
+// IC5 — Forums whose HAS_MEMBER (anchor's FoF) joined after threshold,
+// with Post counts contributed by those FoF in that Forum. Anchor = Ali,
+// threshold = 2012-07-24 (= SF1 anchor date — works on mini too: top
+// 6 rows are real forum activity, rows 7-19 are zero-post Walls/Albums).
+// Mini HAS_MEMBER edge property is `creationDate` (DATE_EPOCHMS); SF1
+// uses `joinDate`. Test code branches on the property name.
+inline constexpr int64_t IC5_ANCHOR_PERSON_ID = IC1_ANCHOR_PERSON_ID;
+inline constexpr int64_t IC5_JOIN_THRESHOLD_MS = 1343088000000LL;
+struct IcForumPostCount {
+    const char* forum_title;
+    int64_t     post_count;
+    int64_t     forum_id;
+};
+inline constexpr IcForumPostCount IC5_RESULTS[] = {
+    {"Group for Hannibal in Changyi",                  14, 1030792151326LL},
+    {"Group for Nat_King_Cole in Cooch_Behar",          8, 1099511628156LL},
+    {"Group for Saint_George in Changyi",               4,  893353197855LL},
+    {"Group for Jacques_Chirac in Cooch_Behar",         3, 1099511628157LL},
+    {"Group for Cardinal_Richelieu in Changyi",         2,  962072674592LL},
+    {"Group for Wolfgang_Amadeus_Mozart in Cooch_Behar", 2, 1168231104894LL},
+    {"Wall of Hossein Forouhar",                        0,             0},
+    {"Wall of Jan Zakrzewski",                          0,            37},
+    {"Wall of Miguel Gonzalez",                         0,            38},
+    {"Wall of Ali Achiou",                              0,  68719476809LL},
+    {"Album 5 of Ali Achiou",                           0,  68719476815LL},
+    {"Album 23 of Ali Achiou",                          0,  68719476833LL},
+    {"Album 8 of Ali Achiou",                           0, 137438953554LL},
+    {"Album 13 of Ali Achiou",                          0, 137438953559LL},
+    {"Album 16 of Ali Achiou",                          0, 137438953562LL},
+    {"Album 19 of Ali Achiou",                          0, 137438953565LL},
+    {"Album 24 of Ali Achiou",                          0, 137438953570LL},
+    {"Album 20 of Ali Achiou",                          0, 206158430302LL},
+    {"Album 28 of Ali Achiou",                          0, 206158430310LL},
+    {"Album 29 of Ali Achiou",                          0, 206158430311LL},
+};
+
+// IC9 — recent messages of (anchor)'s friends-of-friends with
+// creationDate < threshold. Anchor = Ali, threshold = 2013-01-01.
+// Returns 20 rows ordered by creationDate DESC, message id ASC.
+inline constexpr int64_t IC9_ANCHOR_PERSON_ID  = IC1_ANCHOR_PERSON_ID;
+inline constexpr int64_t IC9_DATE_THRESHOLD_MS = 1356998400000LL;
+struct IcFofMessage {
+    int64_t     person_id;
+    const char* first_name;
+    const char* last_name;
+    int64_t     message_id;
+    const char* content;       // startswith semantics
+    int64_t     message_creation_ms;
+};
+inline constexpr IcFofMessage IC9_RESULTS[] = {
+    {19791209299968LL, "John",      "Khan",        1168231108487LL, "About Nat King Cole,",       1356994051470LL},
+    {21990232555527LL, "Jun",       "Li",          1168231108577LL, "About Wolfgang Amadeus Mozart,", 1356990424630LL},
+    {10995116277761LL, "Evangelos", "Alkaios",     1168231107530LL, "ok",                          1356983798219LL},
+    {              32, "Miguel",    "Gonzalez",    1168231107522LL, "maybe",                       1356980204838LL},
+    {26388279066641LL, "Almira",    "Patras",      1168231107529LL, "About Josip Broz Tito,",      1356978747364LL},
+    {10995116277782LL, "Ken",       "Yamada",      1168231107527LL, "I see",                       1356975189220LL},
+    {              32, "Miguel",    "Gonzalez",    1168231107526LL, "I see",                       1356971087128LL},
+    {              32, "Miguel",    "Gonzalez",    1168231108493LL, "fine",                        1356969762149LL},
+    { 2199023255573LL, "Arbaaz",    "Ali",         1168231107525LL, "About Pope Pius IX,",         1356967673506LL},
+    {19791209299968LL, "John",      "Khan",        1168231107524LL, "thx",                         1356966254544LL},
+    {28587302322191LL, "Ge",        "Wei",         1168231107523LL, "thx",                         1356965735991LL},
+    {35184372088850LL, "Neil",      "Murray",      1168231107521LL, "About Pope Pius IX,",         1356965137335LL},
+    {35184372088850LL, "Neil",      "Murray",      1168231107520LL, "About Hannibal,",             1356950518910LL},
+    {              32, "Miguel",    "Gonzalez",    1168231108455LL, "About One Headlight,",        1356948775806LL},
+    {26388279066658LL, "Roberto",   "Diaz",        1168231108423LL, "maybe",                       1356947952509LL},
+    { 2199023255573LL, "Arbaaz",    "Ali",         1168231108573LL, "ok",                          1356945869242LL},
+    {30786325577731LL, "Aleksandr", "Efimkin",     1168231107557LL, "About Saint George,",         1356939457136LL},
+    {24189255811109LL, "Wei",       "Wei",         1168231108570LL, "cool",                        1356939072367LL},
+    {35184372088850LL, "Neil",      "Murray",      1168231107444LL, "thx",                         1356929220284LL},
+    {26388279066658LL, "Roberto",   "Diaz",        1168231108434LL, "thx",                         1356915516217LL},
+};
+
 // IC2 — recent messages of (anchor)'s friends, with creationDate <= threshold.
 // Threshold = 2013-01-01T00:00:00Z. Returns 20 rows ordered by date DESC,
 // id ASC. Anchor reuses IC1_ANCHOR_PERSON_ID (Ali, 17 friends → enough
@@ -726,6 +840,67 @@ inline constexpr IcShortestPathRow IC1_BASIC_RESULTS[] = {
     { 8796093031224LL, "Nguyen", 2},
     {26388279068635LL, "Nguyen", 2},
     {28587302322743LL, "Nguyen", 2},
+};
+
+// IC3 — SF1 legacy uses anchor 17592186055119, Laos/Scotland, 41-day window.
+inline constexpr int64_t     IC3_ANCHOR_PERSON_ID = 17592186055119LL;
+inline constexpr const char* IC3_COUNTRY_X        = "Laos";
+inline constexpr const char* IC3_COUNTRY_Y        = "Scotland";
+inline constexpr int64_t     IC3_DATE_START_MS    = 1306886400000LL;
+inline constexpr int64_t     IC3_DATE_END_MS      = 1310515200000LL;
+struct IcCountryFriend {
+    int64_t     friend_id;
+    const char* first_name;
+    const char* last_name;
+    int64_t     x_count;
+    int64_t     y_count;
+};
+inline constexpr IcCountryFriend IC3_RESULTS[] = {
+    {8796093029689LL, "Eun-Hye", "Yoon", 1, 1},
+};
+
+// IC4 — SF1 legacy: anchor 21990232559429, window 2012-05-01 to 2012-06-07.
+inline constexpr int64_t IC4_ANCHOR_PERSON_ID = 21990232559429LL;
+inline constexpr int64_t IC4_VALID_START_MS   = 1335830400000LL;
+inline constexpr int64_t IC4_VALID_END_MS     = 1339027200000LL;
+inline constexpr IcTagCount IC4_RESULTS[] = {
+    {"Hassan_II_of_Morocco",            2},
+    {"Appeal_to_Reason",                1},
+    {"Principality_of_Littoral_Croatia", 1},
+    {"Rivers_of_Babylon",               1},
+    {"Van_Morrison",                    1},
+};
+
+// IC5 — SF1 legacy: anchor 28587302325306, threshold 2012-07-24, returns 20 rows.
+// Test code only spot-checks first 5 rows + ordering (postCount values),
+// so we just stub the array; spot-check assertions remain inline.
+inline constexpr int64_t IC5_ANCHOR_PERSON_ID = 28587302325306LL;
+inline constexpr int64_t IC5_JOIN_THRESHOLD_MS = 1343088000000LL;
+struct IcForumPostCount {
+    const char* forum_title;
+    int64_t     post_count;
+    int64_t     forum_id;
+};
+inline constexpr IcForumPostCount IC5_RESULTS[] = {
+    {"Group for She_Blinded_Me_with_Science in Antofagasta", 10, 1236950612644LL},
+    // SF1 rows 1-19 are spot-checked inline (legacy values), so we
+    // pad here only to mark the array non-empty for compile.
+};
+
+// IC9 — SF1 legacy: anchor 13194139542834, threshold 2011-12-17.
+// Test only spot-checks rows 0/1 inline.
+inline constexpr int64_t IC9_ANCHOR_PERSON_ID  = 13194139542834LL;
+inline constexpr int64_t IC9_DATE_THRESHOLD_MS = 1324080000000LL;
+struct IcFofMessage {
+    int64_t     person_id;
+    const char* first_name;
+    const char* last_name;
+    int64_t     message_id;
+    const char* content;
+    int64_t     message_creation_ms;
+};
+inline constexpr IcFofMessage IC9_RESULTS[] = {
+    {0, "", "", 0, "", 0},  // SF1 falls back to inline spot-checks.
 };
 
 // IC2 — SF1 path keeps its inline spot-checks (legacy hardcoded values).

--- a/test/query/test_ldbc_ic_correctness.cpp
+++ b/test/query/test_ldbc_ic_correctness.cpp
@@ -104,12 +104,12 @@ TEST_CASE("IC1-full shortestPath with collect and OPTIONAL MATCH", "[ldbc][ic]")
 // IC2 — recent messages of friends.
 // Tests: 2-hop traversal, WHERE <=, coalesce, ORDER BY DESC+ASC, Message union label.
 //
-// Gated SF1-only: `WHERE message.creationDate <= <ms-literal>` blocks on
-// the missing BIGINT → TIMESTAMP_MS cast (issue #89). Mini-fixture path
-// will be enabled once #89 ships. The Neo4j-verified mini expected rows
-// are already pinned in `helpers/ldbc_expected_counts.hpp`
-// (IC2_RECENT_MESSAGES + IC2_DATE_THRESHOLD_MS) so the migration is just
-// a matter of un-gating the second TEST_CASE below.
+// SF1 and mini diverge in anchor/threshold + per-row content, so each
+// fixture has its own TEST_CASE (legacy SF1 hardcoded body retained for
+// dev runs; mini case uses Neo4j-verified IC2_RECENT_MESSAGES from the
+// helpers). The `WHERE creationDate <= <ms-literal>` comparison was
+// previously gated on issue #89 (BIGINT → TIMESTAMP_MS cast); now
+// unblocked by PR #93.
 #ifndef TURBOLYNX_LDBC_FIXTURE_MINI
 TEST_CASE("IC2 recent messages of friends", "[ldbc][ic]") {
     SKIP_IF_NO_DB();
@@ -175,7 +175,38 @@ TEST_CASE("IC2 recent messages of friends", "[ldbc][ic]") {
         CHECK(r[i].int64_at(5) <= r[i-1].int64_at(5));
     }
 }
-#endif  // !TURBOLYNX_LDBC_FIXTURE_MINI (IC2 mini gated on #89)
+#else
+TEST_CASE("IC2 recent messages of friends (mini)", "[ldbc][ic]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (n:Person {id: " + std::to_string(ldbc::IC1_ANCHOR_PERSON_ID) +
+             "})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(message:Message) "
+             "WHERE message.creationDate <= " + std::to_string(ldbc::IC2_DATE_THRESHOLD_MS) + " "
+             "RETURN "
+             "  friend.id AS personId, "
+             "  friend.firstName AS personFirstName, "
+             "  friend.lastName AS personLastName, "
+             "  message.id AS postOrCommentId, "
+             "  coalesce(message.content, message.imageFile) AS postOrCommentContent, "
+             "  message.creationDate AS postOrCommentCreationDate "
+             "ORDER BY postOrCommentCreationDate DESC, postOrCommentId ASC "
+             "LIMIT 20";
+    auto r = qr->run(q.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::STRING,
+         qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::INT64});
+    constexpr size_t N = sizeof(ldbc::IC2_RECENT_MESSAGES) / sizeof(ldbc::IC2_RECENT_MESSAGES[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = ldbc::IC2_RECENT_MESSAGES[i];
+        CHECK(r[i].int64_at(0) == exp.person_id);
+        CHECK(r[i].str_at(1) == exp.first_name);
+        CHECK(r[i].str_at(2) == exp.last_name);
+        CHECK(r[i].int64_at(3) == exp.message_id);
+        CHECK(r[i].str_at(4).find(exp.content) == 0);
+        CHECK(r[i].int64_at(5) == exp.message_creation_ms);
+    }
+}
+#endif
 
 // IC3 — original LDBC IC3 query (friends-of-friends messaging in two countries)
 // Tests: Country/City sub-labels, IN operator, chained comparison (a > x >= b),
@@ -183,19 +214,24 @@ TEST_CASE("IC2 recent messages of friends", "[ldbc][ic]") {
 //        sum(alias) from WITH, WHERE after WITH aggregation, arithmetic on aliases,
 //        KNOWS*1..2 undirected, multi-stage WITH, multiple MATCH clauses.
 //
-// Gated SF1-only: same BIGINT → TIMESTAMP_MS cast hole as IC2 (#89), here
-// the chained `1310515200000 > message.creationDate >= 1306886400000`
-// range filter triggers it.
-#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
+// SF1 uses :Country / :City sub-labels. Mini load script does not tag
+// these so the mini variant uses :Place uniformly. Per-fixture anchor +
+// country pair + date range are pinned in the helpers (IC3_*).
 TEST_CASE("IC3 friends in countries", "[ldbc][ic][ic3]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (countryX:Country {name: 'Laos'}), "
-        "      (countryY:Country {name: 'Scotland'}), "
-        "      (person:Person {id: 17592186055119}) "
+#ifdef TURBOLYNX_LDBC_FIXTURE_MINI
+    const char* country_label = "Place";
+    const char* city_label    = "Place";
+#else
+    const char* country_label = "Country";
+    const char* city_label    = "City";
+#endif
+    auto q = std::string("MATCH (countryX:") + country_label + " {name: '" + ldbc::IC3_COUNTRY_X + "'}), "
+        "      (countryY:" + country_label + " {name: '" + ldbc::IC3_COUNTRY_Y + "'}), "
+        "      (person:Person {id: " + std::to_string(ldbc::IC3_ANCHOR_PERSON_ID) + "}) "
         "WITH person, countryX, countryY "
         "LIMIT 1 "
-        "MATCH (city:City)-[:IS_PART_OF]->(country:Country) "
+        "MATCH (city:" + city_label + ")-[:IS_PART_OF]->(country:" + country_label + ") "
         "WHERE country IN [countryX, countryY] "
         "WITH person, countryX, countryY, collect(city) AS cities "
         "MATCH (person)-[:KNOWS*1..2]-(friend)-[:IS_LOCATED_IN]->(city) "
@@ -203,7 +239,8 @@ TEST_CASE("IC3 friends in countries", "[ldbc][ic][ic3]") {
         "WITH DISTINCT friend, countryX, countryY "
         "MATCH (friend)<-[:HAS_CREATOR]-(message), "
         "      (message)-[:IS_LOCATED_IN]->(country) "
-        "WHERE 1310515200000 > message.creationDate >= 1306886400000 AND "
+        "WHERE " + std::to_string(ldbc::IC3_DATE_END_MS) +
+        " > message.creationDate >= " + std::to_string(ldbc::IC3_DATE_START_MS) + " AND "
         "      country IN [countryX, countryY] "
         "WITH friend, "
         "     CASE WHEN country=countryX THEN 1 ELSE 0 END AS messageX, "
@@ -217,70 +254,58 @@ TEST_CASE("IC3 friends in countries", "[ldbc][ic][ic3]") {
         "       yCount, "
         "       xCount + yCount AS xyCount "
         "ORDER BY xyCount DESC, friendId ASC "
-        "LIMIT 20",
+        "LIMIT 20";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::STRING,
          qtest::ColType::INT64, qtest::ColType::INT64, qtest::ColType::INT64});
-    // Neo4j-verified: only 1 friend has messages in BOTH countries during the time window
-    REQUIRE(r.size() == 1);
-    CHECK(r[0].int64_at(0) == 8796093029689LL);
-    CHECK(r[0].str_at(1) == "Eun-Hye");
-    CHECK(r[0].str_at(2) == "Yoon");
-    CHECK(r[0].int64_at(3) == 1);
-    CHECK(r[0].int64_at(4) == 1);
-    CHECK(r[0].int64_at(5) == 2);
+    constexpr size_t N = sizeof(ldbc::IC3_RESULTS) / sizeof(ldbc::IC3_RESULTS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = ldbc::IC3_RESULTS[i];
+        CHECK(r[i].int64_at(0) == exp.friend_id);
+        CHECK(r[i].str_at(1) == exp.first_name);
+        CHECK(r[i].str_at(2) == exp.last_name);
+        CHECK(r[i].int64_at(3) == exp.x_count);
+        CHECK(r[i].int64_at(4) == exp.y_count);
+        CHECK(r[i].int64_at(5) == exp.x_count + exp.y_count);
+    }
 }
-#endif  // !TURBOLYNX_LDBC_FIXTURE_MINI (IC3 mini gated on #89)
 
 // IC4 — popular topics in a time range (excluding older posts).
 // Tests: DISTINCT on (tag, post) pair, multi-stage WITH, CASE WHEN with AND,
 //        sum aggregation, WHERE after aggregation with >0 AND =0, ORDER BY DESC+ASC.
-//
-// Gated SF1-only: same BIGINT → TIMESTAMP_MS cast hole as IC2/IC3 (#89).
-#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
 TEST_CASE("IC4 popular topics in time range", "[ldbc][ic][ic4]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (person:Person {id: 21990232559429})-[:KNOWS]-(friend:Person), "
+    auto q = "MATCH (person:Person {id: " + std::to_string(ldbc::IC4_ANCHOR_PERSON_ID) +
+        "})-[:KNOWS]-(friend:Person), "
         "      (friend)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag) "
         "WITH DISTINCT tag, post "
         "WITH tag, "
         "    CASE "
-        "        WHEN post.creationDate >= 1335830400000 AND post.creationDate < 1339027200000 THEN 1 "
+        "        WHEN post.creationDate >= " + std::to_string(ldbc::IC4_VALID_START_MS) +
+        " AND post.creationDate < " + std::to_string(ldbc::IC4_VALID_END_MS) + " THEN 1 "
         "        ELSE 0 "
         "    END AS valid, "
         "    CASE "
-        "        WHEN post.creationDate < 1335830400000 THEN 1 "
+        "        WHEN post.creationDate < " + std::to_string(ldbc::IC4_VALID_START_MS) + " THEN 1 "
         "        ELSE 0 "
         "    END AS inValid "
         "WITH tag, sum(valid) AS postCount, sum(inValid) AS inValidPostCount "
         "WHERE postCount>0 AND inValidPostCount=0 "
         "RETURN tag.name AS tagName, postCount "
         "ORDER BY postCount DESC, tagName ASC "
-        "LIMIT 10",
-        {qtest::ColType::STRING, qtest::ColType::INT64});
-    REQUIRE(r.size() == 5);
-
-    // row 0: Hassan_II_of_Morocco, 2
-    CHECK(r[0].str_at(0) == "Hassan_II_of_Morocco");
-    CHECK(r[0].int64_at(1) == 2);
-
-    // row 1: Appeal_to_Reason, 1
-    CHECK(r[1].str_at(0) == "Appeal_to_Reason");
-    CHECK(r[1].int64_at(1) == 1);
-
-    // row 2: Principality_of_Littoral_Croatia, 1
-    CHECK(r[2].str_at(0) == "Principality_of_Littoral_Croatia");
-    CHECK(r[2].int64_at(1) == 1);
-
-    // row 3: Rivers_of_Babylon, 1
-    CHECK(r[3].str_at(0) == "Rivers_of_Babylon");
-    CHECK(r[3].int64_at(1) == 1);
-
-    // row 4: Van_Morrison, 1
-    CHECK(r[4].str_at(0) == "Van_Morrison");
-    CHECK(r[4].int64_at(1) == 1);
-
-    // Verify ordering: postCount DESC, then tagName ASC
+        "LIMIT 10";
+    auto r = qr->run(q.c_str(), {qtest::ColType::STRING, qtest::ColType::INT64});
+    constexpr size_t N = sizeof(ldbc::IC4_RESULTS) / sizeof(ldbc::IC4_RESULTS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = ldbc::IC4_RESULTS[i];
+        CHECK(r[i].str_at(0) == exp.tag_name);
+        CHECK(r[i].int64_at(1) == exp.post_count);
+    }
+    // Ordering: postCount DESC, tagName ASC.
     for (size_t i = 1; i < r.size(); i++) {
         if (r[i].int64_at(1) == r[i-1].int64_at(1)) {
             CHECK(r[i].str_at(0) >= r[i-1].str_at(0));
@@ -289,44 +314,62 @@ TEST_CASE("IC4 popular topics in time range", "[ldbc][ic][ic4]") {
         }
     }
 }
-#endif  // !TURBOLYNX_LDBC_FIXTURE_MINI (IC4 mini gated on #89)
 
 // IC5 — new groups (forums joined by friends-of-friends after a date, with post counts).
 // Original LDBC IC5 query using collect() + IN list operators.
 // Tests: KNOWS*1..2 undirected, collect() aggregation, IN list predicate,
 //        OPTIONAL MATCH with edge reordering, GROUP BY + ORDER BY.
 //
-// Gated SF1-only: `WHERE membership.joinDate > 1343088000000` hits the
-// same BIGINT → TIMESTAMP_MS cast hole as IC2/3/4 (#89).
-#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
+// HAS_MEMBER edge property differs across schema versions: SF1 (legacy)
+// uses `joinDate`, mini fixture (newer LDBC SNB CSV) uses `creationDate`.
+// Test branches on the property name; otherwise queries are identical.
 TEST_CASE("IC5 new groups", "[ldbc][ic][ic5]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (person:Person {id: 28587302325306})-[:KNOWS*1..2]-(friend:Person) "
+#ifdef TURBOLYNX_LDBC_FIXTURE_MINI
+    const char* member_date_prop = "creationDate";
+#else
+    const char* member_date_prop = "joinDate";
+#endif
+    auto q = std::string("MATCH (person:Person {id: ") +
+        std::to_string(ldbc::IC5_ANCHOR_PERSON_ID) +
+        "})-[:KNOWS*1..2]-(friend:Person) "
         "WHERE NOT person = friend "
         "WITH DISTINCT friend "
         "MATCH (friend)<-[membership:HAS_MEMBER]-(forum:Forum) "
-        "WHERE membership.joinDate > 1343088000000 "
+        "WHERE membership." + member_date_prop + " > " + std::to_string(ldbc::IC5_JOIN_THRESHOLD_MS) + " "
         "WITH forum, collect(friend) AS friends "
         "OPTIONAL MATCH (friend)<-[:HAS_CREATOR]-(post:Post)<-[:CONTAINER_OF]-(forum) "
         "WHERE friend IN friends "
         "WITH forum, count(post) AS postCount "
         "RETURN forum.title AS forumName, postCount, forum.id AS forumId "
         "ORDER BY postCount DESC, forumId ASC "
-        "LIMIT 20",
+        "LIMIT 20";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::STRING, qtest::ColType::INT64, qtest::ColType::INT64});
-    REQUIRE(r.size() == 20);
 
-    // Verify top results (Neo4j-verified)
+#ifdef TURBOLYNX_LDBC_FIXTURE_MINI
+    constexpr size_t N = sizeof(ldbc::IC5_RESULTS) / sizeof(ldbc::IC5_RESULTS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = ldbc::IC5_RESULTS[i];
+        CHECK(r[i].str_at(0) == exp.forum_title);
+        CHECK(r[i].int64_at(1) == exp.post_count);
+        CHECK(r[i].int64_at(2) == exp.forum_id);
+    }
+#else
+    REQUIRE(r.size() == 20);
+    // Legacy SF1 spot-checks.
     CHECK(r[0].str_at(0) == "Group for She_Blinded_Me_with_Science in Antofagasta");
     CHECK(r[0].int64_at(1) == 10);
     CHECK(r[0].int64_at(2) == 1236950612644);
-    CHECK(r[1].int64_at(1) == 8);   // 50_Cent in Bacolod
-    CHECK(r[2].int64_at(1) == 6);   // Alice_Cooper in Lashkar_Gah
-    CHECK(r[3].int64_at(1) == 4);   // Hosni_Mubarak in Berlin
-    CHECK(r[4].int64_at(1) == 4);   // Gil_Kane in Topi
+    CHECK(r[1].int64_at(1) == 8);
+    CHECK(r[2].int64_at(1) == 6);
+    CHECK(r[3].int64_at(1) == 4);
+    CHECK(r[4].int64_at(1) == 4);
+#endif
 
-    // Verify ordering: postCount DESC, then forumId ASC
+    // Ordering: postCount DESC, then forumId ASC (both fixtures).
     for (size_t i = 1; i < r.size(); i++) {
         if (r[i].int64_at(1) == r[i-1].int64_at(1)) {
             CHECK(r[i].int64_at(2) >= r[i-1].int64_at(2));
@@ -335,7 +378,6 @@ TEST_CASE("IC5 new groups", "[ldbc][ic][ic5]") {
         }
     }
 }
-#endif  // !TURBOLYNX_LDBC_FIXTURE_MINI (IC5 mini gated on #89)
 
 // IC6 — tag co-occurrence (original LDBC IC6 query).
 // Tags appearing on posts by friends-of-friends that also have a known tag.
@@ -536,27 +578,18 @@ TEST_CASE("IC8 recent replies", "[ldbc][ic][ic8]") {
     }
 }
 
-// IC9–IC14 below stay SF1-only inside this block — they are blocked
-// either on issue #89 (BIGINT → TIMESTAMP_MS cast for `creationDate`
-// filters), missing :City / :Country / :Company sub-labels on the
-// mini load script, or pending per-case oracle work. Each TEST_CASE
-// that becomes mini-ready gets pulled out individually.
-#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
-
-// IC9 — recent messages by friends/friends-of-friends
+// IC9 — recent messages by friends/friends-of-friends.
 // Tests: KNOWS*1..2 undirected, collect(DISTINCT)+UNWIND rewrite to DISTINCT,
-//        multi-MATCH, coalesce, ORDER BY DESC+ASC, LIMIT
-// Note: collect(distinct friend)+UNWIND is rewritten to WITH DISTINCT friend.
-// Known issue: MPV (Message = Comment + Post) causes extra output columns.
+//        multi-MATCH, coalesce, ORDER BY DESC+ASC, LIMIT.
 TEST_CASE("IC9 recent messages by friends", "[ldbc][ic][ic9]") {
     SKIP_IF_NO_DB();
-    auto r = qr->run(
-        "MATCH (root:Person {id: 13194139542834})-[:KNOWS*1..2]-(friend:Person) "
+    auto q = "MATCH (root:Person {id: " + std::to_string(ldbc::IC9_ANCHOR_PERSON_ID) +
+        "})-[:KNOWS*1..2]-(friend:Person) "
         "WHERE NOT friend = root "
         "WITH collect(distinct friend) as friends "
         "UNWIND friends as friend "
         "MATCH (friend)<-[:HAS_CREATOR]-(message:Message) "
-        "WHERE message.creationDate < 1324080000000 "
+        "WHERE message.creationDate < " + std::to_string(ldbc::IC9_DATE_THRESHOLD_MS) + " "
         "RETURN "
         "  friend.id AS personId, "
         "  friend.firstName AS personFirstName, "
@@ -565,12 +598,27 @@ TEST_CASE("IC9 recent messages by friends", "[ldbc][ic][ic9]") {
         "  coalesce(message.content, message.imageFile) AS commentOrPostContent, "
         "  message.creationDate AS commentOrPostCreationDate "
         "ORDER BY commentOrPostCreationDate DESC, message.id ASC "
-        "LIMIT 20",
+        "LIMIT 20";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::STRING,
          qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::INT64});
     REQUIRE(r.size() == 20);
 
-    // Neo4j-verified expected values (first two rows match)
+#ifdef TURBOLYNX_LDBC_FIXTURE_MINI
+    constexpr size_t N = sizeof(ldbc::IC9_RESULTS) / sizeof(ldbc::IC9_RESULTS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = ldbc::IC9_RESULTS[i];
+        CHECK(r[i].int64_at(0) == exp.person_id);
+        CHECK(r[i].str_at(1) == exp.first_name);
+        CHECK(r[i].str_at(2) == exp.last_name);
+        CHECK(r[i].int64_at(3) == exp.message_id);
+        CHECK(r[i].str_at(4).find(exp.content) == 0);
+        CHECK(r[i].int64_at(5) == exp.message_creation_ms);
+    }
+#else
+    // Legacy SF1 spot-checks (first two rows).
     CHECK(r[0].int64_at(0) == 2199023260919LL);
     CHECK(r[0].str_at(1) == "Xiaolu");
     CHECK(r[0].str_at(2) == "Wang");
@@ -583,12 +631,18 @@ TEST_CASE("IC9 recent messages by friends", "[ldbc][ic][ic9]") {
     CHECK(r[1].int64_at(3) == 1511830666887LL);
     CHECK(r[1].str_at(4) == "good");
     CHECK(r[1].int64_at(5) == 1324079829064LL);
+#endif
 
-    // Verify ordering: creationDate DESC
+    // Verify ordering: creationDate DESC (both fixtures).
     for (size_t i = 1; i < r.size(); i++) {
         CHECK(r[i].int64_at(5) <= r[i-1].int64_at(5));
     }
 }
+
+// IC10–IC11 below stay SF1-only — they need :City / :Country / :Company
+// sub-labels (mini load script does not tag these) and additional date
+// function support. Each becomes mini-ready in a follow-up PR.
+#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
 
 // IC10 — friend recommendation
 // Tests: KNOWS*2..2, NOT pattern expression (anti-edge check),


### PR DESCRIPTION
> **Stacked on [#93](https://github.com/turbolynx-dslab/TurboLynx/pull/93).** Base is \`fix-bigint-timestamp-cast\`. Once #93 merges, change base to \`main\` (or it auto-rebases on merge depending on settings).

## Summary

Now that #93 fixes the BIGINT → TIMESTAMP_MS cast hole, the LDBC IC tests with \`WHERE creationDate <op> <integer-ms-literal>\` filters work on the SF0.003 mini fixture. This PR enables the five remaining IC cases.

## Migrated to mini

| Case | Anchor / params (mini) | Result on mini |
|---|---|---|
| **IC2** (recent messages of friends) | Ali, threshold 2013-01-01 | 20 rows (helpers data already pinned in PR-E2a) |
| **IC3** (friends in two countries) | Ali, Azerbaijan / Rwanda, [2010-01-01, 2013-01-01) | 1 row (Arbaaz Ali) — mini fixture is too sparse for SF1's Laos/Scotland; \`:Country\`/\`:City\` swapped to \`:Place\` |
| **IC4** (popular topics) | Ali, valid window [2012-01-01, 2013-01-01) | 10 rows (Hannibal=10 top) |
| **IC5** (new groups) | Ali, threshold 2012-07-24 | 20 rows; HAS_MEMBER property branched to \`creationDate\` (mini schema) vs \`joinDate\` (SF1 schema) |
| **IC9** (recent messages by FoF) | Ali, threshold 2013-01-01 | 20 rows |

\`[ldbc][ic]\` on mini: **16 cases / ~600 assertions** (was 11 in PR-E2b).

## Stayed SF1-only (deferred to PR-E2d if ever)

- **IC10** (friend recommendation): uses \`:City\` (not tagged on mini) + \`datetime({epochMillis: birthday}).month/.day\` extraction — needs label switch + Cypher datetime function on DATE column.
- **IC11** (job referral): uses \`:Country\` / \`:Company\` sub-labels (mini load script does not tag these) + \`workAt.workFrom\` edge-property year filter.

These are smaller surface but each needs schema/feature work in addition to oracle data; not blocking.

## Test plan
- [x] Local build (mini config) succeeds.
- [x] \`[ldbc][ic]\` mini: 16 cases pass.
- [x] Full ldbc regression: 1422 / 1426 (4 pre-existing skipped, no new failures).

## Notes for review
- IC3 and IC5 are the only cases that truly diverge in query shape between fixtures (label name / edge-property name); both isolate the divergence to a single \`#ifdef\` line and keep the rest of the query identical.
- IC2 / IC4 / IC9 use the same query template across fixtures, just with per-fixture parameters from \`helpers/ldbc_expected_counts.hpp\`.
- IC5 mini result includes 14 zero-post Walls/Albums in the bottom rows — this is real data (Walls/Albums are auto-created Forums per Person per album, with no Posts), preserved as-is so the test exercises the OPTIONAL MATCH + zero-count path.