### PR TITLE
test: TPC-H audit step 1 — DECIMAL test infra + Q22 row-by-row strengthening

### DIFF
--- a/test/query/helpers/query_runner.hpp
+++ b/test/query/helpers/query_runner.hpp
@@ -145,6 +145,32 @@ public:
                         char buf[64];
                         snprintf(buf, sizeof(buf), "%f", turbolynx_get_double(rw, (idx_t)c));
                         v = std::string(buf);
+                    } else if (dtype == TURBOLYNX_TYPE_DECIMAL) {
+                        // DECIMAL is stored as `unscaled hugeint + scale`; the
+                        // numeric value equals `value / 10^scale`. Format as
+                        // a fixed-point string with exactly `scale` fractional
+                        // digits so test code can do exact equality against a
+                        // pinned literal (e.g. "82845.34"). Negative values
+                        // and a 0-scale (== integer DECIMAL) are both handled.
+                        auto dec = turbolynx_get_decimal(rw, (idx_t)c);
+                        int64_t lo = (int64_t)dec.value.lower;
+                        int64_t scale_div = 1;
+                        for (uint8_t i = 0; i < dec.scale; ++i) scale_div *= 10;
+                        char buf[64];
+                        if (dec.scale == 0) {
+                            snprintf(buf, sizeof(buf), "%lld", (long long)lo);
+                        } else {
+                            int64_t int_part  = lo / scale_div;
+                            int64_t frac_part = lo % scale_div;
+                            if (frac_part < 0) frac_part = -frac_part;
+                            // Negative values: int_part already carries the sign;
+                            // for -1 < value < 0 the int part is 0 so prepend "-".
+                            const char* sign = (lo < 0 && int_part == 0) ? "-" : "";
+                            snprintf(buf, sizeof(buf), "%s%lld.%0*lld",
+                                     sign, (long long)int_part,
+                                     (int)dec.scale, (long long)frac_part);
+                        }
+                        v = std::string(buf);
                     } else {
                         // Default: try int64
                         v = turbolynx_get_int64(rw, (idx_t)c);

--- a/test/query/helpers/tpch_expected_counts.hpp
+++ b/test/query/helpers/tpch_expected_counts.hpp
@@ -44,6 +44,33 @@ inline constexpr int64_t SUPPLIER_COUNT = 100;
 inline constexpr int64_t PART_COUNT     = 2000;
 inline constexpr int64_t NATION_COUNT   = 25;
 inline constexpr int64_t REGION_COUNT   = 5;
+
+// ---- Per-query expected result rows (DuckDB-verified on SF0.01) ----
+//
+// Generated via DuckDB v1.5.2 against the same scale-factor data:
+//   duckdb -c "INSTALL tpch; LOAD tpch; CALL dbgen(sf=0.01); <SQL>"
+// dbgen at SF=0.01 is deterministic and produces byte-for-byte identical
+// rows to test/data/tpch-mini/*.tbl (verified by spot-checking lineitem
+// rows 1, 30000, 60000), so DuckDB's output is a valid oracle.
+//
+// DECIMAL columns are encoded as fixed-point strings ("82845.34"); the
+// QueryRunner formats DECIMAL results via "%.<scale>f" so the comparison
+// is exact.
+
+struct Q22Row {
+    const char* cntrycode;     // varchar (substring of phone)
+    int64_t     numcust;       // bigint (count(*))
+    const char* totacctbal;    // decimal(38,2) — formatted "%.2f"
+};
+inline constexpr Q22Row Q22_ROWS[] = {
+    {"11", 11, "82845.34"},
+    {"12",  9, "64585.54"},
+    {"14",  7, "51640.71"},
+    {"16",  4, "24532.04"},
+    {"27",  9, "70735.49"},
+    {"29", 12, "93510.05"},
+    {"32", 10, "66977.84"},
+};
 #else
 // SF1 (full benchmark) — DuckDB-reference verified.
 inline constexpr int64_t Q1  = 4;

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -106,7 +106,27 @@ TPCH_TEST(17, tpch::Q17)
 TPCH_TEST(18, tpch::Q18)
 TPCH_TEST(20, tpch::Q20)
 TPCH_TEST(21, tpch::Q21)
-TPCH_TEST(22, tpch::Q22)
+
+// Q22 — strengthened to row-by-row value comparison against DuckDB
+// reference (see tpch_expected_counts.hpp Q22_ROWS for the oracle).
+// First TPC-H query to move beyond pure row-count checking; sets the
+// pattern for the other ten passing-on-mini queries to follow.
+TEST_CASE("TPC-H Q22 (rows)", "[tpch][q22]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q22.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::STRING, qtest::ColType::INT64, qtest::ColType::AUTO});
+    constexpr size_t N = sizeof(tpch::Q22_ROWS) / sizeof(tpch::Q22_ROWS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = tpch::Q22_ROWS[i];
+        CHECK(r[i].str_at(0)   == exp.cntrycode);
+        CHECK(r[i].int64_at(1) == exp.numcust);
+        CHECK(r[i].str_at(2)   == exp.totacctbal);
+    }
+}
 TPCH_TEST_BROKEN_MINI(1,  "#69")
 TPCH_TEST_BROKEN_MINI(3,  "#69")
 TPCH_TEST_BROKEN_MINI(5,  "#69")


### PR DESCRIPTION
## Summary

First step of the TPC-H test audit — establishes the row-by-row check pattern with Q22 and adds DECIMAL handling to the test runner. Sets up DuckDB as the cross-validation oracle.

Background: TPC-H tests were row-count-only (\`CHECK(r.size() == expected)\` is the entire assertion). A regression that returned the right number of rows with all wrong values would pass — defeats the purpose of running a reference workload.

## DuckDB oracle setup (verified, no install steps in this PR)

DuckDB v1.5.2 with the bundled \`tpch\` extension produces byte-for-byte identical SF=0.01 data to \`test/data/tpch-mini/*.tbl\` (verified by spot-checking lineitem rows 1, 30000, 60000), so its output is a valid cross-check. Generation:

\`\`\`bash
duckdb -c \"INSTALL tpch; LOAD tpch; CALL dbgen(sf=0.01); <SQL>\"
\`\`\`

For queries whose Cypher uses different parameters from DuckDB's standard TPC-H queries (e.g. Q22's country-code list), a custom SQL with matching parameters is run instead of \`PRAGMA tpch(N)\`.

## Changes

1. **[\`helpers/query_runner.hpp\`](test/query/helpers/query_runner.hpp)** — add a \`TURBOLYNX_TYPE_DECIMAL\` branch. Previously DECIMAL columns fell through to \`turbolynx_get_int64\` and surfaced as \`int64(0)\`, making any DECIMAL aggregate (e.g. \`SUM(C_ACCTBAL)\`) silently unverifiable. Now DECIMAL is formatted via \`turbolynx_get_decimal\` as \`\"%.<scale>f\"\` for exact equality against pinned literals.
2. **[\`helpers/tpch_expected_counts.hpp\`](test/query/helpers/tpch_expected_counts.hpp)** — add \`Q22_ROWS[]\` (7 rows of \`{cntrycode, numcust, totacctbal}\`) verified against DuckDB.
3. **[\`test_tpch_correctness.cpp\`](test/query/test_tpch_correctness.cpp)** — replace \`TPCH_TEST(22, ...)\` with a row-by-row TEST_CASE.

## Audit findings (out of scope for this PR — file separately)

- **10 of 11 mini-passing TPC-H queries still use count-only**: Q2, Q4, Q8, Q12, Q13, Q16, Q17, Q18, Q20, Q21. Each gets the same row-by-row treatment in subsequent PRs.
- **Q18 mini is no-assertion**: \`expected_rows = 0\` means the \`if (exp > 0)\` branch never fires — pure smoke test. The \`sum(l_quantity) > 300\` predicate filters all rows at SF=0.01; needs a parameter rewrite (e.g. \`> 50\`) so the test exercises the aggregate.
- **\`test_tpch_stress.cpp\` has hardcoded legacy path** \`/turbograph-v3/benchmark/tpch/sf1/\` that no longer exists. CI excludes \`[stress]\` so the breakage is unobservable.

## Test plan
- [x] Local build (mini config) succeeds.
- [x] \`[tpch]~[broken-mini]~[stress]\` → 11 cases / 42 assertions pass (was 11 / 22 — +20 from Q22).
- [x] LDBC unchanged: 1422 / 1426 / 4 skipped.
- [ ] Linux CI: same step passes with stronger checks.

## Follow-up PRs
- TPC-H audit step 2: Q21, Q17, Q12 (small result sets — easiest)
- TPC-H audit step 3: Q2, Q4, Q8, Q13, Q16, Q20 (medium)
- Q18 parameter rewrite to make it return non-zero rows
- \`test_tpch_stress.cpp\` path fix (or formal removal)