### PR TITLE
test: TPC-H audit step 3 — Q2 + Q4 + Q20 + defer Q8 (stacked on #96)

### DIFF
--- a/test/query/helpers/tpch_expected_counts.hpp
+++ b/test/query/helpers/tpch_expected_counts.hpp
@@ -100,6 +100,68 @@ inline constexpr Q12Row Q12_ROWS[] = {
     {"FOB",     49,  93},
     {"REG AIR", 72, 106},
 };
+
+// Q2 — top suppliers offering minimum-cost AMERICA parts of size 43
+// ending in "COPPER". 5-row top-K. s_comment (varchar) uses startswith
+// semantics for the long comment field; s_address checked exactly
+// (TPC-H load preserves trailing whitespace where present in .tbl).
+struct Q2Row {
+    const char* s_acctbal;     // decimal(15,2) → "%.2f"
+    const char* s_name;
+    const char* n_name;
+    int64_t     p_partkey;
+    const char* p_mfgr;
+    const char* s_address;
+    const char* s_phone;
+    const char* s_comment_prefix;  // startswith
+};
+inline constexpr Q2Row Q2_ROWS[] = {
+    {"9107.22", "Supplier#000000013", "CANADA",        1374, "Manufacturer#1",
+     "kgTZjbt4CAa4c3SlirlBLqIL41YbCj",        "13-727-620-7813",
+     "against the quickly ironic packages."},
+    {"9107.22", "Supplier#000000013", "CANADA",        1495, "Manufacturer#5",
+     "kgTZjbt4CAa4c3SlirlBLqIL41YbCj",        "13-727-620-7813",
+     "against the quickly ironic packages."},
+    {"7162.15", "Supplier#000000055", "UNITED STATES", 1437, "Manufacturer#4",
+     "dAN28JcaMkXMkIUYU7H",                   "34-876-912-6007",
+     "al requests after the blithely"},
+    {"4746.66", "Supplier#000000087", "UNITED STATES", 1114, "Manufacturer#4",
+     "5ovT6anHSsD1TyApXOBEU",                 "34-860-229-1674",
+     " beans are silently idle requests."},
+    {"3580.35", "Supplier#000000046", "UNITED STATES",  487, "Manufacturer#5",
+     "N,6964Lnc2fNgMZV1VJV9ye9PtkE7z1nYOHRB", "34-748-308-3215",
+     "d somas use around the furious"},
+};
+
+// Q4 — order priority counts for orders made in Q1 1994 with at least
+// one late-shipped lineitem.
+struct Q4Row {
+    const char* o_orderpriority;
+    int64_t     order_count;
+};
+inline constexpr Q4Row Q4_ROWS[] = {
+    {"1-URGENT",        115},
+    {"2-HIGH",          109},
+    {"3-MEDIUM",        105},
+    {"4-NOT SPECIFIED", 112},
+    {"5-LOW",            94},
+};
+
+// Q8 — strengthening deferred (issue #97: mkt_share returns int64(0)
+// instead of the DuckDB-verified double 0.041475 / 0.0). The CASE
+// expression promotes integer literal 0 over DOUBLE volume, truncating
+// every contribution to 0. Re-enable Q8_ROWS comparison once #97 ships.
+
+// Q20 — BRAZIL suppliers shipping "smoke%" parts in 1997 in
+// quantities exceeding 0.5× the lineitem total. 2 rows.
+struct Q20Row {
+    const char* s_name;
+    const char* s_address;
+};
+inline constexpr Q20Row Q20_ROWS[] = {
+    {"Supplier#000000021", "TZoQwNFFO i,baXpbpin02,hvuhE,GRVIKm "},
+    {"Supplier#000000092", "EWS4tXaiXFFFS7Y,T G"},
+};
 #else
 // SF1 (full benchmark) — DuckDB-reference verified.
 inline constexpr int64_t Q1  = 4;

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -96,13 +96,69 @@ TEST_CASE("TPC-H Q" #qnum " (broken on SF0.01, issue " issue ")", \
 
 #ifdef TURBOLYNX_TPCH_FIXTURE_MINI
 // SF0.01 mini fixture: 11 passing queries + 11 broken-mini.
-TPCH_TEST(2,  tpch::Q2)
-TPCH_TEST(4,  tpch::Q4)
-TPCH_TEST(8,  tpch::Q8)
+TPCH_TEST(8,  tpch::Q8)   // count-only — strengthening blocked on issue #97
 TPCH_TEST(13, tpch::Q13)
 TPCH_TEST(16, tpch::Q16)
 TPCH_TEST(18, tpch::Q18)
-TPCH_TEST(20, tpch::Q20)
+
+// Q2 — 5-row top-K supplier listing with 8 columns each.
+TEST_CASE("TPC-H Q2 (rows)", "[tpch][q2]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q2.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::AUTO,   qtest::ColType::STRING, qtest::ColType::STRING,
+         qtest::ColType::INT64,  qtest::ColType::STRING, qtest::ColType::STRING,
+         qtest::ColType::STRING, qtest::ColType::STRING});
+    constexpr size_t N = sizeof(tpch::Q2_ROWS) / sizeof(tpch::Q2_ROWS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = tpch::Q2_ROWS[i];
+        CHECK(r[i].str_at(0)   == exp.s_acctbal);
+        CHECK(r[i].str_at(1)   == exp.s_name);
+        CHECK(r[i].str_at(2)   == exp.n_name);
+        CHECK(r[i].int64_at(3) == exp.p_partkey);
+        CHECK(r[i].str_at(4)   == exp.p_mfgr);
+        CHECK(r[i].str_at(5)   == exp.s_address);
+        CHECK(r[i].str_at(6)   == exp.s_phone);
+        CHECK(r[i].str_at(7).find(exp.s_comment_prefix) == 0);
+    }
+}
+
+// Q4 — 5-row order priority breakdown.
+TEST_CASE("TPC-H Q4 (rows)", "[tpch][q4]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q4.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::STRING, qtest::ColType::INT64});
+    constexpr size_t N = sizeof(tpch::Q4_ROWS) / sizeof(tpch::Q4_ROWS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = tpch::Q4_ROWS[i];
+        CHECK(r[i].str_at(0)   == exp.o_orderpriority);
+        CHECK(r[i].int64_at(1) == exp.order_count);
+    }
+}
+
+// Q20 — 2-row BRAZIL supplier list.
+TEST_CASE("TPC-H Q20 (rows)", "[tpch][q20]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q20.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::STRING, qtest::ColType::STRING});
+    constexpr size_t N = sizeof(tpch::Q20_ROWS) / sizeof(tpch::Q20_ROWS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = tpch::Q20_ROWS[i];
+        CHECK(r[i].str_at(0) == exp.s_name);
+        CHECK(r[i].str_at(1) == exp.s_address);
+    }
+}
 
 // Q12 — 2-row priority breakdown by ship mode.
 TEST_CASE("TPC-H Q12 (rows)", "[tpch][q12]") {


### PR DESCRIPTION
> **Stacked on [#96](https://github.com/turbolynx-dslab/TurboLynx/pull/96).** Base is \`tpch-audit-step2\`. Once #96 merges, change base to \`main\`.

## Summary

Continues from #96 (step 2). Three more queries strengthened with row-by-row value checks; Q8 surfaces an engine bug and stays count-only with a tracked follow-up.

| Case | Result | Cols verified |
|---|---|---|
| **Q2**  | 5 rows top-K | 8 cols: s_acctbal (DECIMAL→\"%.2f\"), s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment (startswith) |
| **Q4**  | 5 rows priority breakdown | o_orderpriority, order_count |
| **Q20** | 2 rows supplier list | s_name, s_address (TPC-H .tbl preserves trailing whitespace; pinned exactly) |
| **Q8**  | deferred → [#97](https://github.com/turbolynx-dslab/TurboLynx/issues/97) | mkt_share returns int64(0); CASE LCT promotes integer literal 0 over DOUBLE volume |

\`[tpch]~[broken-mini]~[stress]\` on mini: **11 cases / 105 assertions** (was 51 in step 2 — +54). LDBC unchanged.

## New issue
- [#97](https://github.com/turbolynx-dslab/TurboLynx/issues/97) — Q8 mkt_share returns 0 instead of computed division ratio. Engine-side CASE expression type-promotion bug.

## Test plan
- [x] Local build (mini config) succeeds.
- [x] All [tpch] mini tests pass with stronger checks (Q8 stays count-only).
- [x] LDBC suites unchanged.
- [ ] CI green.

## Remaining queries

| Query | Result rows on mini | Status |
|---|---|---|
| Q13 | 32 | TBD step 4 (medium) |
| Q16 | 315 | TBD step 4 (largest passing on mini) |
| Q18 | 0 | TBD — needs parameter rewrite (`>300` → `>50`) |
| Q8  | — | Blocked on #97 |

Plus 11 cases gated as `[broken-mini]` for #69 SIGSEGV (separate engine work, not test infra).