### PR TITLE
test: TPC-H audit step 2 — Q12 + Q17 + Q21 row-by-row (resubmit of #96)

### DIFF
--- a/test/query/helpers/tpch_expected_counts.hpp
+++ b/test/query/helpers/tpch_expected_counts.hpp
@@ -71,6 +71,35 @@ inline constexpr Q22Row Q22_ROWS[] = {
     {"29", 12, "93510.05"},
     {"32", 10, "66977.84"},
 };
+
+// Q17 — single-row scalar: avg yearly extended price for `Brand#15` /
+// `LG CASE` parts, 0.2-of-avg threshold. The expression `sum(...)/7.0`
+// promotes the result to DOUBLE, which the runner formats as `"%f"`
+// (six fractional digits). DuckDB rounds the same value to 4229.144286.
+inline constexpr const char* Q17_AVG_YEARLY_STR = "4229.144286";
+
+// Q21 — single-row supplier ranking: SAUDI ARABIA suppliers with the
+// most "wait" orders (l_receiptdate > l_commitdate) where they were
+// the only late party for the order.
+struct Q21Row {
+    const char* s_name;
+    int64_t     numwait;
+};
+inline constexpr Q21Row Q21_ROWS[] = {
+    {"Supplier#000000074", 9},
+};
+
+// Q12 — late-shipped order priority breakdown for ship modes
+// `REG AIR` and `FOB` in calendar 1997.
+struct Q12Row {
+    const char* l_shipmode;
+    int64_t     high_line_count;
+    int64_t     low_line_count;
+};
+inline constexpr Q12Row Q12_ROWS[] = {
+    {"FOB",     49,  93},
+    {"REG AIR", 72, 106},
+};
 #else
 // SF1 (full benchmark) — DuckDB-reference verified.
 inline constexpr int64_t Q1  = 4;

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -99,13 +99,55 @@ TEST_CASE("TPC-H Q" #qnum " (broken on SF0.01, issue " issue ")", \
 TPCH_TEST(2,  tpch::Q2)
 TPCH_TEST(4,  tpch::Q4)
 TPCH_TEST(8,  tpch::Q8)
-TPCH_TEST(12, tpch::Q12)
 TPCH_TEST(13, tpch::Q13)
 TPCH_TEST(16, tpch::Q16)
-TPCH_TEST(17, tpch::Q17)
 TPCH_TEST(18, tpch::Q18)
 TPCH_TEST(20, tpch::Q20)
-TPCH_TEST(21, tpch::Q21)
+
+// Q12 — 2-row priority breakdown by ship mode.
+TEST_CASE("TPC-H Q12 (rows)", "[tpch][q12]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q12.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::STRING, qtest::ColType::INT64, qtest::ColType::INT64});
+    constexpr size_t N = sizeof(tpch::Q12_ROWS) / sizeof(tpch::Q12_ROWS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = tpch::Q12_ROWS[i];
+        CHECK(r[i].str_at(0)   == exp.l_shipmode);
+        CHECK(r[i].int64_at(1) == exp.high_line_count);
+        CHECK(r[i].int64_at(2) == exp.low_line_count);
+    }
+}
+
+// Q17 — scalar 1-row value check (DuckDB-verified).
+TEST_CASE("TPC-H Q17 (rows)", "[tpch][q17]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q17.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(), {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == tpch::Q17_AVG_YEARLY_STR);
+}
+
+// Q21 — supplier ranking, 1-row result on mini.
+TEST_CASE("TPC-H Q21 (rows)", "[tpch][q21]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q21.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::STRING, qtest::ColType::INT64});
+    constexpr size_t N = sizeof(tpch::Q21_ROWS) / sizeof(tpch::Q21_ROWS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = tpch::Q21_ROWS[i];
+        CHECK(r[i].str_at(0)   == exp.s_name);
+        CHECK(r[i].int64_at(1) == exp.numwait);
+    }
+}
 
 // Q22 — strengthened to row-by-row value comparison against DuckDB
 // reference (see tpch_expected_counts.hpp Q22_ROWS for the oracle).


### PR DESCRIPTION
> Resubmit of [#96](https://github.com/turbolynx-dslab/TurboLynx/pull/96), which auto-closed when the merged \`tpch-audit\` base branch was deleted. Same commit, base now \`main\`.

## Summary

Continues from #95 (step 1: Q22 + DECIMAL infra). Three more queries strengthened with row-by-row value checks.

| Case | Result | Cols verified |
|---|---|---|
| **Q17** | 1 row scalar | avg_yearly (DOUBLE → \"4229.144286\") |
| **Q21** | 1 row supplier ranking | s_name (varchar), numwait (bigint) |
| **Q12** | 2 rows shipmode breakdown | l_shipmode (varchar), high_line_count (bigint), low_line_count (bigint) |

DuckDB v1.5.2 was the oracle. Each query uses Cypher-specific parameters different from DuckDB's standard TPC-H defaults, so custom SQL with matching parameters was used.

\`[tpch]~[broken-mini]~[stress]\` on mini: **11 cases / 51 assertions** (was 42 in step 1 — +9 from these three). LDBC unchanged.

## Test plan
- [x] Local build succeeds.
- [x] All [tpch] mini tests pass.
- [ ] CI green.