### PR TITLE
test: fix dead /turbograph-v3 path in test_tpch_stress.cpp

### DIFF
--- a/test/query/test_tpch_stress.cpp
+++ b/test/query/test_tpch_stress.cpp
@@ -22,7 +22,16 @@ extern qtest::QueryRunner* get_tpch_runner();
     auto* qr = get_tpch_runner(); \
     if (!qr) { FAIL("Cannot open DB: " << g_tpch_path); return; }
 
-static const std::string QUERY_DIR = "/turbograph-v3/benchmark/tpch/sf1/";
+// Resolve the .cql path the same way `test_tpch_correctness.cpp` does — at
+// compile time via the TURBOLYNX_REPO_ROOT define injected by the test
+// CMakeLists. The previous hardcoded `/turbograph-v3/...` path predated
+// the renaming and has not resolved on any machine since; the stress
+// tag is excluded from CI (`~[stress]`) so the breakage was unobservable.
+#ifndef TURBOLYNX_REPO_ROOT
+#error "TURBOLYNX_REPO_ROOT must be defined by the build system"
+#endif
+static const std::string QUERY_DIR =
+    std::string(TURBOLYNX_REPO_ROOT) + "/benchmark/tpch/sf1/";
 
 static std::string readFile(const std::string &path) {
     std::ifstream f(path);


### PR DESCRIPTION
## Summary

Stress tests resolved query files via a hardcoded \`/turbograph-v3/benchmark/tpch/sf1/\` path inherited from the s62 → turbograph-v3 → turbolynx rename history. No machine has that directory; \`readFile()\` returned empty and the immediately-following \`REQUIRE(!query.empty())\` failed. The breakage was invisible because CI excludes the \`[stress]\` tag (\`[tpch]~[broken-mini]~[stress]\`).

Use the same \`TURBOLYNX_REPO_ROOT\` CMake define as \`test_tpch_correctness.cpp\` so the path resolves correctly on any machine. 1 file, +10/-1.

## Test plan
- [x] \`Q21 16-thread loop\` runs 30 iters, 31 assertions pass.
- [x] \`Q12 64-thread loop\` runs 30 iters, 31 assertions pass.
- [x] Full \`[tpch]~[broken-mini]~[stress]\` regression — 105 assertions / 11 cases (unchanged).
- [x] LDBC suites unchanged.

## Notes for review

- This **does not add stress tests to CI** — the workflow's \`~[stress]\` filter is unchanged. Reason: these are long-running parallel-scaling probes (per-test 30 iterations, plus the bench sweeps thread counts) better suited to an opt-in nightly job than to PR-blocking CI.
- Doc-only change to the comment block makes it explicit that this fix only restores runnability, not CI inclusion.