### PR TITLE
test: TPC-H audit step 4 — strengthen Q13 (32-bucket histogram)

### DIFF
--- a/test/query/helpers/tpch_expected_counts.hpp
+++ b/test/query/helpers/tpch_expected_counts.hpp
@@ -101,6 +101,23 @@ inline constexpr Q12Row Q12_ROWS[] = {
     {"REG AIR", 72, 106},
 };
 
+// Q13 — customer order-count distribution, filtering out orders whose
+// O_COMMENT matches `.*express.*deposits.*`. 32-bucket histogram
+// ordered by custdist DESC, c_count DESC. The c_count=0 / custdist=500
+// row is the LEFT OUTER MATCH wing (customers with no orders).
+struct Q13Row {
+    int64_t c_count;
+    int64_t custdist;
+};
+inline constexpr Q13Row Q13_ROWS[] = {
+    { 0, 500}, {11,  74}, { 8,  68}, {10,  66}, {12,  58}, { 9,  58},
+    {14,  57}, {20,  55}, {13,  49}, {18,  47}, {16,  46}, {15,  45},
+    {21,  44}, { 7,  41}, {17,  40}, {24,  34}, {22,  34}, { 6,  33},
+    {19,  29}, {23,  24}, {25,  20}, {26,  16}, { 5,  16}, {27,  15},
+    {28,   7}, { 4,   6}, {32,   4}, {30,   4}, {29,   4}, {31,   2},
+    { 3,   2}, { 2,   2},
+};
+
 // Q2 — top suppliers offering minimum-cost AMERICA parts of size 43
 // ending in "COPPER". 5-row top-K. s_comment (varchar) uses startswith
 // semantics for the long comment field; s_address checked exactly

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -97,9 +97,35 @@ TEST_CASE("TPC-H Q" #qnum " (broken on SF0.01, issue " issue ")", \
 #ifdef TURBOLYNX_TPCH_FIXTURE_MINI
 // SF0.01 mini fixture: 11 passing queries + 11 broken-mini.
 TPCH_TEST(8,  tpch::Q8)   // count-only — strengthening blocked on issue #97
-TPCH_TEST(13, tpch::Q13)
 TPCH_TEST(16, tpch::Q16)
 TPCH_TEST(18, tpch::Q18)
+
+// Q13 — 32-bucket customer order-count histogram. The OPTIONAL MATCH
+// makes the c_count=0 / custdist=500 row (= customers with no orders)
+// the largest bucket. Ordered by custdist DESC, c_count DESC.
+TEST_CASE("TPC-H Q13 (rows)", "[tpch][q13]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q13.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    constexpr size_t N = sizeof(tpch::Q13_ROWS) / sizeof(tpch::Q13_ROWS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = tpch::Q13_ROWS[i];
+        CHECK(r[i].int64_at(0) == exp.c_count);
+        CHECK(r[i].int64_at(1) == exp.custdist);
+    }
+    // Verify ordering: custdist DESC, c_count DESC.
+    for (size_t i = 1; i < r.size(); ++i) {
+        if (r[i].int64_at(1) == r[i-1].int64_at(1)) {
+            CHECK(r[i].int64_at(0) <= r[i-1].int64_at(0));
+        } else {
+            CHECK(r[i].int64_at(1) <  r[i-1].int64_at(1));
+        }
+    }
+}
 
 // Q2 — 5-row top-K supplier listing with 8 columns each.
 TEST_CASE("TPC-H Q2 (rows)", "[tpch][q2]") {


### PR DESCRIPTION
## Summary

Continues from #98 (step 3: Q2/Q4/Q20). Q13 returns the customer order-count distribution after filtering out orders whose \`O_COMMENT\` matches \`.*express.*deposits.*\`; the OPTIONAL MATCH gives a \`c_count=0\` bucket holding the 500 customers with no orders — the largest bucket on the SF0.01 mini fixture.

| Case | Result | Cols verified |
|---|---|---|
| **Q13** | 32-bucket histogram | c_count (bigint), custdist (bigint), ordering invariant (custdist DESC, c_count DESC) |

DuckDB v1.5.2 was the oracle (custom SQL with our regex parameters since the Cypher uses \`express.*deposits\` rather than the standard TPC-H \`special.*requests\`).

\`[tpch]~[broken-mini]~[stress]\` on mini: **11 cases / 200 assertions** (was 105 in step 3 — +95 from Q13's 32 rows × 2 cols + REQUIRE + 31 ordering checks). LDBC unchanged.

## Test plan
- [x] Local build (mini config) succeeds.
- [x] All [tpch] mini tests pass.
- [ ] CI green.

## Remaining queries

| Query | Result rows on mini | Status |
|---|---|---|
| Q16 | 315 | TBD step 6 (largest passing on mini — likely top-K + ordering invariant pattern) |
| Q18 | 0 | TBD step 5 (parameter rewrite \`>300\` → \`>50\` — needs new \`benchmark/tpch/sf0.01/\` directory) |
| Q8 | — | Blocked on #97 |

Plus 11 cases gated as \`[broken-mini]\` for #69 SIGSEGV.