### PR TITLE
test: TPC-H audit step 6 — strengthen Q16 (315-row supplier breakdown)

### DIFF
--- a/test/query/helpers/tpch_expected_counts.hpp
+++ b/test/query/helpers/tpch_expected_counts.hpp
@@ -118,6 +118,33 @@ inline constexpr Q13Row Q13_ROWS[] = {
     { 3,   2}, { 2,   2},
 };
 
+// Q16 — supplier-cardinality breakdown by (brand, type, size) tuple
+// excluding `Brand#51`, `PROMO PLATED%`, complaint-flagged suppliers.
+// 315 rows: top 4 distinct rows have supplier_cnt=8, the remaining
+// 311 all have supplier_cnt=4 (= partsupp wires each part to exactly
+// 4 distinct suppliers in TPC-H, modulo the rare 8-supplier overlaps).
+// Encoded as top-K + first/last cnt=4 row + the
+// `supplier_cnt + ordering` invariant rather than all 315 rows.
+inline constexpr int64_t Q16_NUM_ROWS = 315;
+struct Q16Row {
+    const char* p_brand;
+    const char* p_type;
+    int64_t     p_size;
+    int64_t     supplier_cnt;
+};
+inline constexpr Q16Row Q16_TOP4_ROWS[] = {
+    {"Brand#12", "STANDARD BRUSHED STEEL",   40, 8},
+    {"Brand#21", "ECONOMY POLISHED STEEL",   44, 8},
+    {"Brand#35", "SMALL POLISHED COPPER",    14, 8},
+    {"Brand#55", "STANDARD ANODIZED STEEL",  42, 8},
+};
+// First row of the long supplier_cnt=4 tail (= row index 4 in the
+// full result). Brand#11 sorts first among non-Brand#51 brands.
+inline constexpr Q16Row Q16_FIRST_TAIL_ROW =
+    {"Brand#11", "MEDIUM ANODIZED BRASS", 45, 4};
+inline constexpr Q16Row Q16_LAST_ROW =
+    {"Brand#55", "STANDARD PLATED TIN",   44, 4};
+
 // Q18 — large-order customer detail. Mini fixture caps sum_lquantity
 // at 305 so the SF1 `> 315` threshold returns 0 rows; sf0.01/q18.cql
 // uses `> 270` instead and yields 12 rows. O_ORDERDATE comes back as

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -109,7 +109,68 @@ TEST_CASE("TPC-H Q" #qnum " (broken on SF0.01, issue " issue ")", \
 #ifdef TURBOLYNX_TPCH_FIXTURE_MINI
 // SF0.01 mini fixture: 11 passing queries + 11 broken-mini.
 TPCH_TEST(8,  tpch::Q8)   // count-only — strengthening blocked on issue #97
-TPCH_TEST(16, tpch::Q16)
+
+// Q16 — 315-row supplier-cardinality breakdown. Pinning every row would
+// be 1260+ assertions of low marginal value (311 of 315 rows have
+// supplier_cnt=4 by design). Instead pin top-4 (the only cnt=8 rows),
+// the first / last cnt=4 rows, and verify the full result respects
+// the ORDER BY (supplier_cnt DESC, p_brand ASC, p_type ASC, p_size ASC).
+TEST_CASE("TPC-H Q16 (rows)", "[tpch][q16]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q16.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::STRING, qtest::ColType::STRING,
+         qtest::ColType::INT64,  qtest::ColType::INT64});
+    REQUIRE(r.size() == (size_t)tpch::Q16_NUM_ROWS);
+
+    constexpr size_t TOP_N = sizeof(tpch::Q16_TOP4_ROWS) / sizeof(tpch::Q16_TOP4_ROWS[0]);
+    for (size_t i = 0; i < TOP_N; ++i) {
+        INFO("top row " << i);
+        const auto& exp = tpch::Q16_TOP4_ROWS[i];
+        CHECK(r[i].str_at(0)   == exp.p_brand);
+        CHECK(r[i].str_at(1)   == exp.p_type);
+        CHECK(r[i].int64_at(2) == exp.p_size);
+        CHECK(r[i].int64_at(3) == exp.supplier_cnt);
+    }
+
+    // First cnt=4 tail row (index TOP_N) and last row.
+    {
+        const auto& exp = tpch::Q16_FIRST_TAIL_ROW;
+        CHECK(r[TOP_N].str_at(0)   == exp.p_brand);
+        CHECK(r[TOP_N].str_at(1)   == exp.p_type);
+        CHECK(r[TOP_N].int64_at(2) == exp.p_size);
+        CHECK(r[TOP_N].int64_at(3) == exp.supplier_cnt);
+    }
+    {
+        const auto& exp = tpch::Q16_LAST_ROW;
+        CHECK(r.size() > 0);
+        CHECK(r[r.size()-1].str_at(0)   == exp.p_brand);
+        CHECK(r[r.size()-1].str_at(1)   == exp.p_type);
+        CHECK(r[r.size()-1].int64_at(2) == exp.p_size);
+        CHECK(r[r.size()-1].int64_at(3) == exp.supplier_cnt);
+    }
+
+    // Ordering invariant: supplier_cnt DESC, then p_brand / p_type / p_size ASC.
+    for (size_t i = 1; i < r.size(); ++i) {
+        if (r[i].int64_at(3) == r[i-1].int64_at(3)) {
+            // Same supplier_cnt → strict order on (p_brand, p_type, p_size).
+            std::string b0 = r[i-1].str_at(0), b1 = r[i].str_at(0);
+            if (b0 == b1) {
+                std::string t0 = r[i-1].str_at(1), t1 = r[i].str_at(1);
+                if (t0 == t1) {
+                    CHECK(r[i].int64_at(2) >= r[i-1].int64_at(2));
+                } else {
+                    CHECK(t1 >= t0);
+                }
+            } else {
+                CHECK(b1 >= b0);
+            }
+        } else {
+            CHECK(r[i].int64_at(3) < r[i-1].int64_at(3));
+        }
+    }
+}
 
 // Q18 — large-order customer detail. Mini uses `sum_lquantity > 270`
 // (sf0.01/q18.cql); SF1 uses `> 315`. 12 rows ordered by


### PR DESCRIPTION
## Summary

Continues from #103 (step 5). Q16 returns 315 rows of (p_brand, p_type, p_size, supplier_cnt) with the top 4 rows at supplier_cnt=8 and the remaining 311 all at supplier_cnt=4 (TPC-H partsupp wires each part to exactly 4 distinct suppliers, modulo overlaps the filter creates).

Pinning every row would be ~1260 assertions of low marginal value. Strengthening pattern instead:

| Check | What |
|---|---|
| **Row count** | exactly 315 |
| **Top-4 rows** | full (brand, type, size, cnt) match — the only cnt=8 rows |
| **First cnt=4 row** | Brand#11, MEDIUM ANODIZED BRASS, 45, 4 |
| **Last row** | Brand#55, STANDARD PLATED TIN, 44, 4 |
| **Ordering invariant** | every row pair: supplier_cnt DESC, then (p_brand, p_type, p_size) ASC |

DuckDB v1.5.2 was the oracle (custom SQL with our IN list \`[11, 44, 42, 8, 45, 14, 40, 46]\` and excluded brand \`Brand#51\` / type prefix \`PROMO PLATED\` matching the Cypher).

\`[tpch]~[broken-mini]~[stress]\` on mini: **11 cases / 612 assertions** (was 273 in step 5 — +339 from Q16's fixed-row checks + 314-step ordering invariant). LDBC unchanged.

## Test plan
- [x] Local build (mini config) succeeds.
- [x] All [tpch] mini tests pass.
- [ ] CI green.

## TPC-H audit completion status

| Query | Status |
|---|---|
| Q2, Q4, Q12, Q13, Q16, Q17, Q18, Q20, Q21, Q22 | ✅ row-by-row strengthened |
| Q8 | ⚠️ count-only — blocked on [#97](https://github.com/turbolynx-dslab/TurboLynx/issues/97) (CASE LCT promotion) |
| Q1/3/5/6/7/9/10/11/14/15/19 | — \`[broken-mini]\` gated for [#69](https://github.com/turbolynx-dslab/TurboLynx/issues/69) SIGSEGV |

10 of 11 mini-passing queries now have row-by-row checks; only Q8 remains count-only behind an engine bug. The audit's primary goal — moving beyond pure count checks — is achieved for the workloads that actually run today.