### PR TITLE
binder+converter: CASE result type now uses LCT across all branches (resolves #97 type promotion; stacked on #105)

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -2886,20 +2886,31 @@ shared_ptr<BoundExpression> Binder::BindCaseExpression(const CaseExpression& exp
     if (expr.else_expr) {
         else_expr = BindExpression(*expr.else_expr, ctx);
     }
-    // Infer CASE return type from THEN/ELSE branches instead of leaving as ANY
+    // Infer CASE return type as the SQL-standard least common type (LCT)
+    // across every THEN branch and the ELSE branch. The previous
+    // implementation picked the first non-NULL THEN type and silently
+    // dropped a wider ELSE — Q8's `CASE WHEN n=… THEN volume(DOUBLE)
+    // ELSE 0(INT) END` thus picked INT (because the THEN's `volume`
+    // column-reference reports ANY at bind time, falling through to the
+    // ELSE INT literal), and the surrounding SUM aggregated against
+    // INT-byte-reinterpreted DOUBLE values to produce 0 instead of the
+    // expected DOUBLE total (issue #97).
     LogicalType result_type = LogicalType::ANY;
+    auto promote = [&](const LogicalType& candidate) {
+        auto cid = candidate.id();
+        if (cid == LogicalTypeId::ANY || cid == LogicalTypeId::UNKNOWN ||
+            cid == LogicalTypeId::SQLNULL) {
+            return;
+        }
+        result_type = (result_type.id() == LogicalTypeId::ANY)
+                          ? candidate
+                          : LogicalType::MaxLogicalType(result_type, candidate);
+    };
     for (auto& bc : checks) {
-        auto tid = bc.then_expr->GetDataType().id();
-        if (tid != LogicalTypeId::ANY && tid != LogicalTypeId::UNKNOWN && tid != LogicalTypeId::SQLNULL) {
-            result_type = bc.then_expr->GetDataType();
-            break;
-        }
+        promote(bc.then_expr->GetDataType());
     }
-    if (result_type.id() == LogicalTypeId::ANY && else_expr) {
-        auto tid = else_expr->GetDataType().id();
-        if (tid != LogicalTypeId::ANY && tid != LogicalTypeId::UNKNOWN && tid != LogicalTypeId::SQLNULL) {
-            result_type = else_expr->GetDataType();
-        }
+    if (else_expr) {
+        promote(else_expr->GetDataType());
     }
     return make_shared<CypherBoundCaseExpression>(result_type, std::move(checks),
                                              std::move(else_expr), GenExprName(expr));

--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -1118,36 +1118,64 @@ CExpression *Cypher2OrcaConverter::ConvertAggFunc(const BoundAggFunctionExpressi
 CExpression *Cypher2OrcaConverter::ConvertCase(const CypherBoundCaseExpression &expr,
                                                 turbolynx::LogicalPlan *plan)
 {
-    // Infer return type from THEN/ELSE branches (binder sets ANY).
-    LogicalType ret_type = expr.GetDataType();
-    if (ret_type.id() == LogicalTypeId::ANY || ret_type.id() == LogicalTypeId::UNKNOWN) {
-        for (const auto &check : expr.GetChecks()) {
-            auto t = check.then_expr->GetDataType();
-            if (t.id() != LogicalTypeId::ANY && t.id() != LogicalTypeId::UNKNOWN &&
-                t.id() != LogicalTypeId::SQLNULL) {
-                ret_type = t;
-                break;
-            }
-        }
-        if ((ret_type.id() == LogicalTypeId::ANY || ret_type.id() == LogicalTypeId::UNKNOWN) &&
-            expr.HasElse()) {
-            auto t = expr.GetElse()->GetDataType();
-            if (t.id() != LogicalTypeId::ANY && t.id() != LogicalTypeId::UNKNOWN &&
-                t.id() != LogicalTypeId::SQLNULL) {
-                ret_type = t;
-            }
-        }
-        if (ret_type.id() == LogicalTypeId::ANY || ret_type.id() == LogicalTypeId::UNKNOWN) {
-            ret_type = LogicalType::BOOLEAN;
-        }
-    }
+    // ret_type for the CScalarIf must be the SQL-standard least common
+    // type (LCT) across every THEN and the ELSE branch. The binder's
+    // own LCT pass falls short for column-references whose
+    // GetDataType() reports ANY at bind time (e.g. an alias defined by
+    // a previous WITH SUM(...)) — those branches contribute nothing,
+    // and a literal-only ELSE / THEN can dominate the LCT with the
+    // wrong type. Recompute here against the post-conversion ORCA
+    // children's actually-resolved types (issue #97).
+    const auto &checks = expr.GetChecks();
 
-    // Build ELSE value (bottom of the nested if-chain)
-    CExpression *else_expr;
+    // 1. Convert all THEN expressions and the ELSE up-front so we have
+    //    their ORCA types available for the LCT pass.
+    std::vector<CExpression *> then_exprs;
+    then_exprs.reserve(checks.size());
+    for (const auto &check : checks) {
+        then_exprs.push_back(ConvertExpression(*check.then_expr, plan));
+    }
+    CExpression *else_expr = nullptr;
+    bool synthetic_null_else = false;
     if (expr.HasElse()) {
         else_expr = ConvertExpression(*expr.GetElse(), plan);
     } else {
-        // NULL literal
+        synthetic_null_else = true;  // built once ret_type is known
+    }
+
+    // 2. Compute LCT across converted THEN + ELSE ORCA types. Skip
+    //    ANY / UNKNOWN / SQLNULL / BOOLEAN which carry no numeric
+    //    promotion info. The binder's binder-level type, if it is
+    //    something other than ANY/UNKNOWN, is a starting hint.
+    LogicalType ret_type = expr.GetDataType();
+    auto skip = [](LogicalTypeId id) {
+        return id == LogicalTypeId::ANY || id == LogicalTypeId::UNKNOWN ||
+               id == LogicalTypeId::SQLNULL || id == LogicalTypeId::BOOLEAN;
+    };
+    if (skip(ret_type.id())) {
+        ret_type = LogicalType::ANY;
+    }
+    auto promote = [&](CExpression *e) {
+        if (!e) return;
+        OID oid = GetTypeOidFromCExpr(e);
+        INT mod = GetTypeModFromCExpr(e);
+        LogicalType lt = OidToLogicalType(oid, mod);
+        if (skip(lt.id())) return;
+        ret_type = (ret_type.id() == LogicalTypeId::ANY)
+                       ? lt
+                       : LogicalType::MaxLogicalType(ret_type, lt);
+    };
+    for (CExpression *e : then_exprs) promote(e);
+    if (else_expr) promote(else_expr);
+    if (ret_type.id() == LogicalTypeId::ANY) {
+        // No usable type from any branch — fall back to BOOLEAN so the
+        // CScalarIf metadata is at least well-formed.
+        ret_type = LogicalType::BOOLEAN;
+    }
+
+    // 3. Now that ret_type is known, materialise the synthetic NULL
+    //    ELSE if needed, typed to ret_type.
+    if (synthetic_null_else) {
         uint32_t null_type_id = LOGICAL_TYPE_BASE_ID + (OID)ret_type.id();
         CMDIdGPDB *null_mdid = GPOS_NEW(mp_) CMDIdGPDB(IMDId::EmdidGeneral, null_type_id, 1, 0);
         null_mdid->AddRef();
@@ -1158,22 +1186,9 @@ CExpression *Cypher2OrcaConverter::ConvertCase(const CypherBoundCaseExpression &
             mp_, GPOS_NEW(mp_) CScalarConst(mp_, (IDatum *)null_datum));
     }
 
-    // If binder-level ret_type is still indeterminate (ANY/UNKNOWN/BOOLEAN fallback),
-    // re-infer from the actually-converted ELSE expression's ORCA type.
-    if (ret_type.id() == LogicalTypeId::BOOLEAN || ret_type.id() == LogicalTypeId::ANY ||
-        ret_type.id() == LogicalTypeId::UNKNOWN) {
-        OID else_oid = GetTypeOidFromCExpr(else_expr);
-        INT else_mod = GetTypeModFromCExpr(else_expr);
-        LogicalType else_lt = OidToLogicalType(else_oid, else_mod);
-        if (else_lt.id() != LogicalTypeId::ANY && else_lt.id() != LogicalTypeId::UNKNOWN &&
-            else_lt.id() != LogicalTypeId::SQLNULL && else_lt.id() != LogicalTypeId::BOOLEAN) {
-            ret_type = else_lt;
-        }
-    }
-
-    // Build nested CScalarIf from bottom up:
-    // If(cond_n, then_n, If(cond_n-1, then_n-1, ... If(cond_1, then_1, else) ...))
-    const auto &checks = expr.GetChecks();
+    // 4. Build nested CScalarIf from bottom up using ret_type as the
+    //    declared output of every level:
+    //    If(cond_n, then_n, If(cond_n-1, then_n-1, ... If(cond_1, then_1, else) ...))
     CExpression *result = else_expr;
     for (int i = (int)checks.size() - 1; i >= 0; i--) {
         uint32_t if_type_id = LOGICAL_TYPE_BASE_ID + (OID)ret_type.id();
@@ -1181,7 +1196,7 @@ CExpression *Cypher2OrcaConverter::ConvertCase(const CypherBoundCaseExpression &
 
         CExpressionArray *if_children = GPOS_NEW(mp_) CExpressionArray(mp_);
         if_children->Append(ConvertExpression(*checks[i].when_expr, plan));  // condition
-        if_children->Append(ConvertExpression(*checks[i].then_expr, plan));  // true value
+        if_children->Append(then_exprs[i]);                                   // true value
         if_children->Append(result);                                          // false value
         result = GPOS_NEW(mp_) CExpression(
             mp_, GPOS_NEW(mp_) CScalarIf(mp_, if_mdid), if_children);


### PR DESCRIPTION
> **Stacked on [#105](https://github.com/turbolynx-dslab/TurboLynx/pull/105).** Base is \`fix-lineitem-quantity-decimal\`. Once #105 merges, change base to \`main\`.

## Summary

Resolves the type-promotion half of [#97](https://github.com/turbolynx-dslab/TurboLynx/issues/97). The old \`BindCaseExpression\` picked the first non-NULL THEN type and never compared it against the other THENs / ELSE. For column references whose \`GetDataType()\` returns ANY at bind time (e.g. \`volume\` aliased from a previous WITH SUM(...)), the THEN walk fell through and the ELSE INTEGER literal \`0\` won — \`CASE WHEN cond THEN volume(DOUBLE) ELSE 0 END\` was bound as INTEGER.

## Changes

1. **[\`binder.cpp::BindCaseExpression\`](src/binder/binder.cpp:2877)** — walk every THEN and the ELSE through \`LogicalType::MaxLogicalType\`, skipping ANY / UNKNOWN / SQLNULL. SQL-standard LCT.
2. **[\`cypher2orca_scalar.cpp::ConvertCase\`](src/converter/cypher2orca_scalar.cpp:1118)** — re-do the LCT pass against post-conversion ORCA types. Column references that reported ANY at bind time now resolve to a real type via \`GetTypeOidFromCExpr\`, so the converter has stronger info than the binder. The CScalarIf metadata and the synthetic NULL ELSE constant (when there's no explicit ELSE) are built using the LCT'd \`ret_type\`.

## Verification (ad-hoc probes)

| Probe | Before | After |
|---|---|---|
| \`sum(CASE WHEN n=ETHIOPIA THEN volume ELSE 0 END)\` | \`int64(0)\` ❌ | \`string('12262.201000')\` ✓ |
| \`sum(CASE WHEN n=ETHIOPIA THEN 0 ELSE volume END)\` | \`int64(5587648456)\` (garbage) ❌ | \`string('283393.090500')\` ✓ |

Full regression on mini:
- \`[tpch]~[broken-mini]~[stress]\` — 11 cases / 612 assertions pass.
- \`[ldbc][...]\` suites — 1422 / 1426 / 4 skipped (unchanged).
- \`ctest -R turbolynx_(common|catalog|storage|execution)\` — 4/4 pass.

## Q8 status — partial

After this fix, the inner \`sum(CASE …)\` and outer \`sum(volume)\` aggregates each return correct DOUBLE values matching DuckDB. But the projection-level \`sum(…) / sum(…)\` division operator is still dropped — Q8's \`mkt_share\` returns \`12262.20\` (numerator only) instead of the expected \`0.04147\`. That is a separate engine bug, filed as **[#106](https://github.com/turbolynx-dslab/TurboLynx/issues/106)** (projection-level arithmetic on aggregates is silently dropped). Q8 strengthening stays count-only behind that issue.

## Notes for review

- The two LCT passes are intentionally redundant: the binder's pass catches branches whose types are statically known, and the converter's pass catches column references that needed conversion to resolve. Either alone is insufficient for Q8.
- No tests change row counts; only the CASE result type changes from INT to DOUBLE in cases where THEN and ELSE differ.