### PR TITLE
converter: post-agg projection drops intermediate _agg_N (resolves #106)

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -2100,13 +2100,6 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanProjectionBody(
         bound_expression_vector post_agg_projs;
         bool has_func_over_agg = false;
 
-        // Count how many non-agg expressions there are (GROUP BY keys)
-        idx_t num_non_agg = 0;
-        for (auto &ep : proj.GetProjections()) {
-            if (ep->GetExprType() != BoundExpressionType::AGG_FUNCTION &&
-                ep->GetExprType() != BoundExpressionType::FUNCTION) num_non_agg++;
-        }
-
         // Helper: recursively check if an expression tree contains aggregates
         std::function<bool(const BoundExpression &)> containsAgg =
             [&](const BoundExpression &e) -> bool {
@@ -2162,21 +2155,22 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanProjectionBody(
             return e;
         };
 
+        // Mirror layout: post_agg_projs[i] corresponds to projection element
+        // i. Pre-existing AGG_FUNCTION / passthrough Variables get a Copy()
+        // entry; func-over-agg gets the rewritten expression (extractAggs may
+        // also push extra `_agg_N` aggregates to agg_projs).
         for (auto &ep : proj.GetProjections()) {
             if (ep->GetExprType() == BoundExpressionType::AGG_FUNCTION) {
-                // Pure aggregate — goes directly to GROUP BY
                 agg_projs.push_back(ep);
-                if (has_func_over_agg) post_agg_projs.push_back(ep->Copy());
+                post_agg_projs.push_back(ep->Copy());
             } else if (containsAgg(*ep)) {
-                // Expression containing aggregates — split
                 has_func_over_agg = true;
                 auto post = extractAggs(ep);
                 if (ep->HasAlias()) post->SetAlias(ep->GetAlias());
                 post_agg_projs.push_back(post);
             } else {
-                // Non-aggregate expression (GROUP BY key)
                 agg_projs.push_back(ep);
-                if (has_func_over_agg) post_agg_projs.push_back(ep->Copy());
+                post_agg_projs.push_back(ep->Copy());
             }
         }
 
@@ -2228,44 +2222,14 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanProjectionBody(
 
         plan = PlanGroupBy(agg_projs, plan);
 
-        // Apply post-agg projection.
-        // When there are GROUP BY keys (node variables etc.), use CLogicalProject
-        // which passes through child columns. Without keys, use PlanProjection
-        // (ProjectColumnar) which only outputs projected columns.
-        if (has_func_over_agg && num_non_agg == 0) {
-            // Pure aggregate — use PlanProjection (no passthrough needed)
+        // Apply post-agg projection. Use CLogicalProjectColumnar via
+        // PlanProjection so the explicit list (passthrough GROUP BY keys
+        // + computed func-over-agg results) is the operator's only output;
+        // a bare CLogicalProject would leak the synthetic intermediate
+        // aggregates `_agg_N` injected by extractAggs as additional
+        // user-visible columns (#106).
+        if (has_func_over_agg) {
             plan = PlanProjection(post_agg_projs, plan);
-        } else if (has_func_over_agg) {
-            CColumnFactory *post_cf = COptCtxt::PoctxtFromTLS()->Pcf();
-            CExpressionArray *post_arr = GPOS_NEW(mp_) CExpressionArray(mp_);
-            for (auto &pep : post_agg_projs) {
-                // Only process func-over-agg results (skip passthrough vars)
-                if (pep->GetExprType() != BoundExpressionType::FUNCTION) continue;
-                CExpression *ce = ConvertExpression(*pep, plan);
-                CScalar *so = static_cast<CScalar *>(ce->Pop());
-                string cn = pep->HasAlias() ? pep->GetAlias() : pep->GetUniqueName();
-                std::wstring wn(cn.begin(), cn.end());
-                const CWStringConst ws(wn.c_str());
-                CName nm(&ws);
-                CColRef *ncr = post_cf->PcrCreate(
-                    GetMDAccessor()->RetrieveType(so->MdidType()),
-                    so->TypeModifier(), nm);
-                post_arr->Append(GPOS_NEW(mp_) CExpression(
-                    mp_, GPOS_NEW(mp_) CScalarProjectElement(mp_, ncr), ce));
-                plan->getSchema()->appendColumn(cn, ncr);
-                if (pep->HasAlias())
-                    plan->getSchema()->registerAlias(pep->GetAlias(), ncr);
-            }
-            if (post_arr->Size() > 0) {
-                CExpression *pl = GPOS_NEW(mp_) CExpression(
-                    mp_, GPOS_NEW(mp_) CScalarProjectList(mp_), post_arr);
-                CExpression *pe = GPOS_NEW(mp_) CExpression(
-                    mp_, GPOS_NEW(mp_) CLogicalProject(mp_),
-                    plan->getPlanExpr(), pl);
-                plan->addUnaryParentOp(pe);
-            } else {
-                post_arr->Release();
-            }
         }
     } else {
         plan = PlanProjection(augmented_projs, plan);

--- a/test/query/helpers/tpch_expected_counts.hpp
+++ b/test/query/helpers/tpch_expected_counts.hpp
@@ -222,10 +222,16 @@ inline constexpr Q4Row Q4_ROWS[] = {
     {"5-LOW",            94},
 };
 
-// Q8 — strengthening deferred (issue #97: mkt_share returns int64(0)
-// instead of the DuckDB-verified double 0.041475 / 0.0). The CASE
-// expression promotes integer literal 0 over DOUBLE volume, truncating
-// every contribution to 0. Re-enable Q8_ROWS comparison once #97 ships.
+// Q8 — ETHIOPIA market-share within AFRICA region for the
+// "ECONOMY BRUSHED BRASS" part type, by ship year. 2 rows.
+struct Q8Row {
+    int64_t     o_year;
+    const char* mkt_share;   // double, formatted "%f"
+};
+inline constexpr Q8Row Q8_ROWS[] = {
+    {1995, "0.041475"},
+    {1996, "0.000000"},
+};
 
 // Q20 — BRAZIL suppliers shipping "smoke%" parts in 1997 in
 // quantities exceeding 0.5× the lineitem total. 2 rows.

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -246,6 +246,256 @@ TEST_CASE("Issue #106 — leading constant scaling a nested agg ratio",
     }
 }
 
+// ----------------------------------------------------------------------
+// Issue #106 — non-sum aggregates (avg / min / max / count(distinct))
+// follow the same extractAggs path; verify the fix is agg-agnostic.
+// Pre-fix every one of these leaked the synthetic `_agg_N` columns.
+// ----------------------------------------------------------------------
+
+TEST_CASE("Issue #106 — passthrough col + nested avg expression",
+          "[tpch][issue106][i106-7]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN l.L_LINESTATUS AS status, "
+        "avg(l.L_QUANTITY) * 2 AS double_avg ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    struct Row { const char* status; const char* double_avg; };
+    constexpr Row expected[] = {{"F", "51.176791"}, {"O", "50.933542"}};
+    REQUIRE(r.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 2);
+        CHECK(r[i].str_at(0) == expected[i].status);
+        CHECK(r[i].str_at(1) == expected[i].double_avg);
+    }
+}
+
+TEST_CASE("Issue #106 — max minus min in one expression",
+          "[tpch][issue106][i106-8]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN l.L_LINESTATUS AS status, "
+        "max(l.L_QUANTITY) - min(l.L_QUANTITY) AS spread ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    REQUIRE(r.size() == 2);
+    CHECK(r[0].cols.size() == 2);
+    CHECK(r[0].str_at(0) == "F"); CHECK(r[0].str_at(1) == "49.00");
+    CHECK(r[1].cols.size() == 2);
+    CHECK(r[1].str_at(0) == "O"); CHECK(r[1].str_at(1) == "49.00");
+}
+
+TEST_CASE("Issue #106 — count(DISTINCT) inside scalar expression",
+          "[tpch][issue106][i106-9]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN l.L_LINESTATUS AS status, "
+        "count(DISTINCT l.L_PARTKEY) * 2 AS dpk_doubled ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::INT64});
+    REQUIRE(r.size() == 2);
+    CHECK(r[0].cols.size() == 2);
+    CHECK(r[0].str_at(0) == "F"); CHECK(r[0].int64_at(1) == 4000);
+    CHECK(r[1].cols.size() == 2);
+    CHECK(r[1].str_at(0) == "O"); CHECK(r[1].int64_at(1) == 4000);
+}
+
+TEST_CASE("Issue #106 — three heterogeneous aggs in one expression "
+          "(max - min) / avg",
+          "[tpch][issue106][i106-10]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN l.L_LINESTATUS AS status, "
+        "(max(l.L_QUANTITY) - min(l.L_QUANTITY)) * 1.0 / avg(l.L_QUANTITY) "
+        "AS norm_range ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    struct Row { const char* status; const char* norm_range; };
+    constexpr Row expected[] = {{"F", "1.914931"}, {"O", "1.924076"}};
+    REQUIRE(r.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 2);
+        CHECK(r[i].str_at(0) == expected[i].status);
+        CHECK(r[i].str_at(1) == expected[i].norm_range);
+    }
+}
+
+TEST_CASE("Issue #106 — avg / avg ratio across two columns",
+          "[tpch][issue106][i106-11]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN l.L_RETURNFLAG AS rf, "
+        "avg(l.L_QUANTITY) / avg(l.L_EXTENDEDPRICE) AS qpp ORDER BY rf",
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    struct Row { const char* rf; const char* qpp; };
+    constexpr Row expected[] = {
+        {"A", "0.000715"}, {"N", "0.000713"}, {"R", "0.000714"},
+    };
+    REQUIRE(r.size() == 3);
+    for (size_t i = 0; i < 3; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 2);
+        CHECK(r[i].str_at(0) == expected[i].rf);
+        CHECK(r[i].str_at(1) == expected[i].qpp);
+    }
+}
+
+// ----------------------------------------------------------------------
+// Issue #106 — harder shapes: deeper nesting / many aggs / mixing.
+// ----------------------------------------------------------------------
+
+TEST_CASE("Issue #106 — four mixed aggs in nested arithmetic "
+          "(sum + max) * (count - min)",
+          "[tpch][issue106][i106-12]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN l.L_LINESTATUS AS status, "
+        "(sum(l.L_QUANTITY) + max(l.L_QUANTITY)) * "
+        "(count(*) - min(l.L_QUANTITY)) AS v ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    struct Row { const char* status; const char* v; };
+    constexpr Row expected[] = {
+        {"F", "23224145750.0000"}, {"O", "22995764448.0000"},
+    };
+    REQUIRE(r.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 2);
+        CHECK(r[i].str_at(0) == expected[i].status);
+        CHECK(r[i].str_at(1) == expected[i].v);
+    }
+}
+
+TEST_CASE("Issue #106 — aggregate result fed into scalar function abs(...)",
+          "[tpch][issue106][i106-13]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN l.L_LINESTATUS AS status, "
+        "abs(sum(l.L_EXTENDEDPRICE) - sum(l.L_QUANTITY) * 1000.0) AS v "
+        "ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    struct Row { const char* status; const char* v; };
+    constexpr Row expected[] = {
+        {"F", "308451458.370000"}, {"O", "307611302.100000"},
+    };
+    REQUIRE(r.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 2);
+        CHECK(r[i].str_at(0) == expected[i].status);
+        CHECK(r[i].str_at(1) == expected[i].v);
+    }
+}
+
+TEST_CASE("Issue #106 — two passthroughs + three nested-agg expressions "
+          "(GROUP BY rf, ls; sum/count, max-min, avg*100)",
+          "[tpch][issue106][i106-14]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN l.L_RETURNFLAG AS rf, l.L_LINESTATUS AS ls, "
+        "sum(l.L_QUANTITY) * 1.0 / count(*) AS r1, "
+        "max(l.L_QUANTITY) - min(l.L_QUANTITY) AS r2, "
+        "avg(l.L_EXTENDEDPRICE) * 100 AS r3 "
+        "ORDER BY rf, ls",
+        {qtest::ColType::STRING, qtest::ColType::STRING,
+         qtest::ColType::AUTO, qtest::ColType::AUTO, qtest::ColType::AUTO});
+    struct Row { const char* rf; const char* ls; const char* r1; const char* r2; const char* r3; };
+    constexpr Row expected[] = {
+        {"A", "F", "25.575155", "49.00", "3578570.930694"},
+        {"N", "F", "25.778736", "49.00", "3558850.968391"},
+        {"N", "O", "25.466771", "49.00", "3570376.059436"},
+        {"R", "F", "25.597168", "49.00", "3587400.653268"},
+    };
+    REQUIRE(r.size() == 4);
+    for (size_t i = 0; i < 4; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 5);
+        CHECK(r[i].str_at(0) == expected[i].rf);
+        CHECK(r[i].str_at(1) == expected[i].ls);
+        CHECK(r[i].str_at(2) == expected[i].r1);
+        CHECK(r[i].str_at(3) == expected[i].r2);
+        CHECK(r[i].str_at(4) == expected[i].r3);
+    }
+}
+
+TEST_CASE("Issue #106 — depth-3 nested arithmetic with four aggs "
+          "((sum-min)*2 + max) / (count + 1)",
+          "[tpch][issue106][i106-15]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN l.L_LINESTATUS AS status, "
+        "((sum(l.L_QUANTITY) - min(l.L_QUANTITY)) * 2 + max(l.L_QUANTITY)) "
+        "* 1.0 / (count(*) + 1) AS v ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    struct Row { const char* status; const char* v; };
+    constexpr Row expected[] = {{"F", "51.176685"}, {"O", "50.933444"}};
+    REQUIRE(r.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 2);
+        CHECK(r[i].str_at(0) == expected[i].status);
+        CHECK(r[i].str_at(1) == expected[i].v);
+    }
+}
+
+TEST_CASE("Issue #106 — count(DISTINCT)/count(*) selectivity ratio",
+          "[tpch][issue106][i106-16]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN l.L_LINESTATUS AS status, "
+        "count(DISTINCT l.L_PARTKEY) * 1.0 / count(*) AS selectivity "
+        "ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    struct Row { const char* status; const char* selectivity; };
+    constexpr Row expected[] = {{"F", "0.066388"}, {"O", "0.066558"}};
+    REQUIRE(r.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 2);
+        CHECK(r[i].str_at(0) == expected[i].status);
+        CHECK(r[i].str_at(1) == expected[i].selectivity);
+    }
+}
+
+TEST_CASE("Issue #106 — five aggs (max,avg,count(DISTINCT),sum,count) "
+          "in depth-3 mixed expression with abs(...)",
+          "[tpch][issue106][i106-17]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN l.L_LINESTATUS AS status, "
+        "abs((max(l.L_QUANTITY) - avg(l.L_QUANTITY)) * 1.0 / "
+        "count(DISTINCT l.L_PARTKEY)) - sum(l.L_QUANTITY) * 1.0 / count(*) "
+        "AS v ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    struct Row { const char* status; const char* v; };
+    constexpr Row expected[] = {{"F", "-25.576190"}, {"O", "-25.454504"}};
+    REQUIRE(r.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 2);
+        CHECK(r[i].str_at(0) == expected[i].status);
+        CHECK(r[i].str_at(1) == expected[i].v);
+    }
+}
+
+TEST_CASE("Issue #106 — five aggs (max,min,count(DISTINCT),sum,count) "
+          "via two parenthesized subexpressions",
+          "[tpch][issue106][i106-18]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN l.L_LINESTATUS AS status, "
+        "((max(l.L_QUANTITY) + min(l.L_QUANTITY)) * count(DISTINCT l.L_PARTKEY)) "
+        "- (sum(l.L_QUANTITY) + count(*)) AS v ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    struct Row { const char* status; const char* v; };
+    constexpr Row expected[] = {{"F", "-699002.00"}, {"O", "-693300.00"}};
+    REQUIRE(r.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 2);
+        CHECK(r[i].str_at(0) == expected[i].status);
+        CHECK(r[i].str_at(1) == expected[i].v);
+    }
+}
+
 // Q8 — ETHIOPIA market-share within AFRICA, by ship year. Two rows
 // (1995 / 1996). Values verified against DuckDB SF0.01.
 TEST_CASE("TPC-H Q8 (rows)", "[tpch][q8]") {

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -108,7 +108,24 @@ TEST_CASE("TPC-H Q" #qnum " (broken on SF0.01, issue " issue ")", \
 
 #ifdef TURBOLYNX_TPCH_FIXTURE_MINI
 // SF0.01 mini fixture: 11 passing queries + 11 broken-mini.
-TPCH_TEST(8,  tpch::Q8)   // count-only — strengthening blocked on issue #97
+
+// Q8 — ETHIOPIA market-share within AFRICA, by ship year. Two rows
+// (1995 / 1996). Values verified against DuckDB SF0.01.
+TEST_CASE("TPC-H Q8 (rows)", "[tpch][q8]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q8.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::AUTO});
+    constexpr size_t N = sizeof(tpch::Q8_ROWS) / sizeof(tpch::Q8_ROWS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = tpch::Q8_ROWS[i];
+        CHECK(r[i].int64_at(0) == exp.o_year);
+        CHECK(r[i].str_at(1)   == exp.mkt_share);
+    }
+}
 
 // Q16 — 315-row supplier-cardinality breakdown. Pinning every row would
 // be 1260+ assertions of low marginal value (311 of 315 rows have

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -109,6 +109,143 @@ TEST_CASE("TPC-H Q" #qnum " (broken on SF0.01, issue " issue ")", \
 #ifdef TURBOLYNX_TPCH_FIXTURE_MINI
 // SF0.01 mini fixture: 11 passing queries + 11 broken-mini.
 
+// Issue #106 — broader func-over-agg coverage. Each of these has at
+// least one projection element where containsAgg=true (the aggregate
+// is nested inside a scalar expression at RETURN/WITH level), so they
+// hit the extractAggs path. Pre-fix all six leaked the synthetic
+// `_agg_N` intermediates as extra output columns; the fix makes the
+// emitted column count match the user's RETURN list. Oracles cross-
+// checked against DuckDB v1.5.2 (`CALL dbgen(sf=0.01)` on the same
+// LINEITEM table).
+TEST_CASE("Issue #106 — passthrough col + nested agg/agg ratio",
+          "[tpch][issue106][i106-1]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) WHERE l.L_RETURNFLAG = \"R\" "
+        "RETURN l.L_LINESTATUS AS status, "
+        "sum(l.L_QUANTITY) * 1.0 / count(*) AS ratio "
+        "ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].cols.size() == 2);
+    CHECK(r[0].str_at(0) == "F");
+    CHECK(r[0].str_at(1) == "25.597168");
+}
+
+TEST_CASE("Issue #106 — nested agg/agg ratio + passthrough col (reverse order)",
+          "[tpch][issue106][i106-2]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) WHERE l.L_RETURNFLAG = \"R\" "
+        "RETURN sum(l.L_QUANTITY) * 1.0 / count(*) AS ratio, "
+        "l.L_LINESTATUS AS status "
+        "ORDER BY status",
+        {qtest::ColType::AUTO, qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].cols.size() == 2);
+    CHECK(r[0].str_at(0) == "25.597168");
+    CHECK(r[0].str_at(1) == "F");
+}
+
+TEST_CASE("Issue #106 — passthrough cols sandwiching nested agg expr",
+          "[tpch][issue106][i106-3]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) "
+        "RETURN l.L_RETURNFLAG AS rf, "
+        "sum(l.L_EXTENDEDPRICE) * 1.0 / count(*) AS avg_price, "
+        "l.L_LINESTATUS AS ls "
+        "ORDER BY rf, ls",
+        {qtest::ColType::STRING, qtest::ColType::AUTO, qtest::ColType::STRING});
+    struct Row { const char* rf; const char* avg_price; const char* ls; };
+    constexpr Row expected[] = {
+        {"A", "35785.709307", "F"},
+        {"N", "35588.509684", "F"},
+        {"N", "35703.760594", "O"},
+        {"R", "35874.006533", "F"},
+    };
+    REQUIRE(r.size() == 4);
+    for (size_t i = 0; i < 4; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 3);
+        CHECK(r[i].str_at(0) == expected[i].rf);
+        CHECK(r[i].str_at(1) == expected[i].avg_price);
+        CHECK(r[i].str_at(2) == expected[i].ls);
+    }
+}
+
+TEST_CASE("Issue #106 — passthrough col + two distinct nested agg exprs",
+          "[tpch][issue106][i106-4]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) "
+        "RETURN l.L_LINESTATUS AS status, "
+        "sum(l.L_QUANTITY) * 1.0 / count(*) AS avg_qty, "
+        "sum(l.L_EXTENDEDPRICE) * 1.0 / count(*) AS avg_price "
+        "ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::AUTO, qtest::ColType::AUTO});
+    struct Row { const char* status; const char* avg_qty; const char* avg_price; };
+    constexpr Row expected[] = {
+        {"F", "25.588395", "35827.108092"},
+        {"O", "25.466771", "35703.760594"},
+    };
+    REQUIRE(r.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 3);
+        CHECK(r[i].str_at(0) == expected[i].status);
+        CHECK(r[i].str_at(1) == expected[i].avg_qty);
+        CHECK(r[i].str_at(2) == expected[i].avg_price);
+    }
+}
+
+TEST_CASE("Issue #106 — three aggregates inside one scalar expression",
+          "[tpch][issue106][i106-5]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) "
+        "RETURN l.L_LINESTATUS AS status, "
+        "(sum(l.L_QUANTITY) + sum(l.L_EXTENDEDPRICE)) * 1.0 / sum(l.L_QUANTITY) "
+        "AS combined "
+        "ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    struct Row { const char* status; const char* combined; };
+    constexpr Row expected[] = {
+        {"F", "1401.131095"},
+        {"O", "1402.974388"},
+    };
+    REQUIRE(r.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 2);
+        CHECK(r[i].str_at(0) == expected[i].status);
+        CHECK(r[i].str_at(1) == expected[i].combined);
+    }
+}
+
+TEST_CASE("Issue #106 — leading constant scaling a nested agg ratio",
+          "[tpch][issue106][i106-6]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) "
+        "RETURN l.L_LINESTATUS AS status, "
+        "100.0 * sum(l.L_QUANTITY) / sum(l.L_EXTENDEDPRICE) AS pct "
+        "ORDER BY status",
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    struct Row { const char* status; const char* pct; };
+    constexpr Row expected[] = {
+        {"F", "0.071422"},
+        {"O", "0.071328"},
+    };
+    REQUIRE(r.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].cols.size() == 2);
+        CHECK(r[i].str_at(0) == expected[i].status);
+        CHECK(r[i].str_at(1) == expected[i].pct);
+    }
+}
+
 // Q8 — ETHIOPIA market-share within AFRICA, by ship year. Two rows
 // (1995 / 1996). Values verified against DuckDB SF0.01.
 TEST_CASE("TPC-H Q8 (rows)", "[tpch][q8]") {


### PR DESCRIPTION
## Summary

- TPC-H Q8 returned 4 columns (year, sum_case, sum_volume, mkt_share) instead of 2; the divide was computed correctly but the synthetic `_agg_N` aggregates that `extractAggs` introduces leaked into the user-visible output. Q8 now returns the expected `(year, mkt_share)`.
- Two-bug fix in `PlanProjectionBody`'s aggregation path:
  - Symmetric loop population: passthrough Variables that appear *before* any func-over-agg expression were silently dropped (e.g. `WITH lineitem, 0.2 * avg(...) as avg_quantity` lost `lineitem`). Always copy them into `post_agg_projs`.
  - Replace bare `CLogicalProject` (which passes through all child columns) with `PlanProjection` → `CLogicalProjectColumnar` so the explicit list is the only output, dropping the `_agg_N` intermediates.
- Q8 strengthened from count-only to row-by-row value comparison against the DuckDB SF0.01 oracle (ETHIOPIA market share 0.041475 in 1995, 0.0 in 1996).

## Test plan

- [x] `query_test \"[tpch]\" --tpch-path /tmp/tpch-mini-ws ~\"[broken-mini]\" ~\"[bench]\"` → 13/13 cases, 678 assertions (was 11 / 612)
- [x] `query_test \"[ldbc]\" --ldbc-path /tmp/ldbc-mini-ws` → 1428 / 1562 unchanged
- [x] `unittest` → 200/200 cases, 770 assertions
- [x] Q14 SIGSEGV is unrelated (BindDecimalSum / #69 area, pre-existing) — still tagged `[broken-mini]`

Closes #106.