### PR TITLE
converter: resolve LogicalType via ORCA scalar / schema colref (resolves #69)

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -2131,8 +2131,23 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanProjectionBody(
                 auto inner = e->Copy();
                 inner->SetAlias(tmp_alias);
                 agg_projs.push_back(inner);
+                // Resolve the new variable's LogicalType. The binder may
+                // leave the aggregate's data_type as ANY (e.g. max(x)
+                // where x is itself an alias of a previous-WITH agg);
+                // downstream scalar binders like BindDecimalRoundPrecision
+                // crash on a malformed DECIMAL/ANY input. Convert the agg
+                // through ORCA to recover the real type (#69).
+                LogicalType resolved_lt = e->GetDataType();
+                if (resolved_lt.id() == LogicalTypeId::ANY ||
+                    resolved_lt.id() == LogicalTypeId::UNKNOWN ||
+                    resolved_lt.id() == LogicalTypeId::SQLNULL) {
+                    CExpression *agg_orca = ConvertExpression(*e, plan);
+                    if (agg_orca && agg_orca->Pop() && agg_orca->Pop()->FScalar()) {
+                        resolved_lt = LogicalTypeFromCExpr(agg_orca);
+                    }
+                }
                 return make_shared<BoundVariableExpression>(
-                    tmp_alias, e->GetDataType(), tmp_alias);
+                    tmp_alias, resolved_lt, tmp_alias);
             }
             if (e->GetExprType() == BoundExpressionType::FUNCTION) {
                 auto &fn = static_cast<const CypherBoundFunctionExpression &>(*e);
@@ -2475,8 +2490,15 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanGroupBy(
             pre_arr->Append(GPOS_NEW(mp_) CExpression(
                 mp_, GPOS_NEW(mp_) CScalarProjectElement(mp_, new_colref), c_expr));
             prev_plan->getSchema()->appendColumn(cname, new_colref);
-            // Replace the aggregate's child with a variable pointing to the pre-projected column
-            auto new_child = make_shared<BoundVariableExpression>(cname, child->GetDataType(), cname);
+            // Replace the aggregate's child with a variable pointing to the
+            // pre-projected column. Derive the new variable's type from the
+            // ORCA-resolved scalar (LogicalTypeFromCExpr) rather than the
+            // binder's data_type — for arithmetic like `a * (1 - b)` the
+            // binder leaves the result as ANY, which would later cause
+            // downstream agg binders (e.g. BindDecimalSum) to crash on
+            // missing TypeInfo (#69).
+            auto resolved_lt = LogicalTypeFromCExpr(c_expr);
+            auto new_child = make_shared<BoundVariableExpression>(cname, resolved_lt, cname);
             // Reconstruct the aggregate with the new child
             auto new_agg = make_shared<BoundAggFunctionExpression>(
                 agg.GetFuncName(), agg.GetDataType(), std::move(new_child),

--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -249,6 +249,11 @@ INT Cypher2OrcaConverter::GetTypeModFromCExpr(CExpression *expr)
     return CScalar::PopConvert(expr->Pop())->TypeModifier();
 }
 
+LogicalType Cypher2OrcaConverter::LogicalTypeFromCExpr(CExpression *expr)
+{
+    return OidToLogicalType(GetTypeOidFromCExpr(expr), GetTypeModFromCExpr(expr));
+}
+
 IMDType::ECmpType Cypher2OrcaConverter::MapCmpType(ExpressionType t, bool swap)
 {
     if (!swap) {
@@ -975,7 +980,7 @@ CExpression *Cypher2OrcaConverter::ConvertFunction(const CypherBoundFunctionExpr
 
     vector<unique_ptr<duckdb::Expression>> duckdb_children;
     for (idx_t i = 0; i < expr.GetNumChildren(); i++) {
-        auto ce = ConvertExpressionDuckDB(*expr.GetChild(i));
+        auto ce = ConvertExpressionDuckDB(*expr.GetChild(i), plan);
         if (expr.GetChild(i)->HasAlias()) ce->alias = expr.GetChild(i)->GetAlias();
         duckdb_children.push_back(std::move(ce));
     }
@@ -1095,7 +1100,7 @@ CExpression *Cypher2OrcaConverter::ConvertAggFunc(const BoundAggFunctionExpressi
 
     vector<unique_ptr<duckdb::Expression>> duckdb_children;
     if (expr.HasChild()) {
-        duckdb_children.push_back(ConvertExpressionDuckDB(*expr.GetChild()));
+        duckdb_children.push_back(ConvertExpressionDuckDB(*expr.GetChild(), plan));
     }
     if (function.bind) {
         function.bind(*context_, function, duckdb_children);
@@ -1210,7 +1215,7 @@ CExpression *Cypher2OrcaConverter::ConvertCase(const CypherBoundCaseExpression &
 // ============================================================
 
 unique_ptr<duckdb::Expression> Cypher2OrcaConverter::ConvertExpressionDuckDB(
-    const BoundExpression &expr)
+    const BoundExpression &expr, turbolynx::LogicalPlan *plan)
 {
     switch (expr.GetExprType()) {
     case BoundExpressionType::LITERAL:
@@ -1218,18 +1223,18 @@ unique_ptr<duckdb::Expression> Cypher2OrcaConverter::ConvertExpressionDuckDB(
     case BoundExpressionType::PROPERTY:
         return ConvertPropertyDuckDB(static_cast<const BoundPropertyExpression &>(expr));
     case BoundExpressionType::FUNCTION:
-        return ConvertFunctionDuckDB(static_cast<const CypherBoundFunctionExpression &>(expr));
+        return ConvertFunctionDuckDB(static_cast<const CypherBoundFunctionExpression &>(expr), plan);
     case BoundExpressionType::AGG_FUNCTION:
-        return ConvertAggFuncDuckDB(static_cast<const BoundAggFunctionExpression &>(expr));
+        return ConvertAggFuncDuckDB(static_cast<const BoundAggFunctionExpression &>(expr), plan);
     case BoundExpressionType::COMPARISON:
         return ConvertComparisonDuckDB(static_cast<const CypherBoundComparisonExpression &>(expr));
     case BoundExpressionType::BOOL_OP:
-        return ConvertBoolOpDuckDB(static_cast<const BoundBoolExpression &>(expr));
+        return ConvertBoolOpDuckDB(static_cast<const BoundBoolExpression &>(expr), plan);
     case BoundExpressionType::CASE: {
         // Infer CASE return type from THEN/ELSE branches
         const auto &case_expr = static_cast<const CypherBoundCaseExpression &>(expr);
         for (const auto &check : case_expr.GetChecks()) {
-            auto then_de = ConvertExpressionDuckDB(*check.then_expr);
+            auto then_de = ConvertExpressionDuckDB(*check.then_expr, plan);
             if (then_de->return_type.id() != LogicalTypeId::ANY &&
                 then_de->return_type.id() != LogicalTypeId::UNKNOWN &&
                 then_de->return_type.id() != LogicalTypeId::SQLNULL) {
@@ -1237,7 +1242,7 @@ unique_ptr<duckdb::Expression> Cypher2OrcaConverter::ConvertExpressionDuckDB(
             }
         }
         if (case_expr.HasElse()) {
-            auto else_de = ConvertExpressionDuckDB(*case_expr.GetElse());
+            auto else_de = ConvertExpressionDuckDB(*case_expr.GetElse(), plan);
             if (else_de->return_type.id() != LogicalTypeId::ANY &&
                 else_de->return_type.id() != LogicalTypeId::UNKNOWN &&
                 else_de->return_type.id() != LogicalTypeId::SQLNULL) {
@@ -1247,8 +1252,26 @@ unique_ptr<duckdb::Expression> Cypher2OrcaConverter::ConvertExpressionDuckDB(
         return make_unique<BoundConstantExpression>(duckdb::Value(expr.GetDataType()));
     }
     case BoundExpressionType::VARIABLE: {
-        // Whole-node/rel reference — use the data type
-        return make_unique<BoundReferenceExpression>(expr.GetDataType(), 0);
+        // Variable refs come from previous WITH/RETURN aliases. The
+        // binder may carry data_type=ANY for aliases of aggregates or
+        // arithmetic; if so, recover the resolved type via the schema
+        // colref so downstream DuckDB binders (e.g.
+        // BindDecimalRoundPrecision, BindDecimalSum) get a well-formed
+        // LogicalType (#69). Without `plan` we can only fall back to
+        // the binder's data_type.
+        LogicalType lt = expr.GetDataType();
+        if (plan && (lt.id() == LogicalTypeId::ANY ||
+                     lt.id() == LogicalTypeId::UNKNOWN ||
+                     lt.id() == LogicalTypeId::SQLNULL)) {
+            const auto &var = static_cast<const BoundVariableExpression &>(expr);
+            CColRef *cr = plan->getSchema()->getColRefOfKey(
+                var.GetVarName(), std::numeric_limits<uint64_t>::max());
+            if (cr) {
+                OID oid = (OID)CMDIdGPDB::CastMdid(cr->RetrieveType()->MDId())->Oid();
+                lt = OidToLogicalType(oid, cr->TypeModifier());
+            }
+        }
+        return make_unique<BoundReferenceExpression>(lt, 0);
     }
     default:
         // Fallback: constant placeholder with matching type
@@ -1277,7 +1300,7 @@ unique_ptr<duckdb::Expression> Cypher2OrcaConverter::ConvertPropertyDuckDB(
 }
 
 unique_ptr<duckdb::Expression> Cypher2OrcaConverter::ConvertFunctionDuckDB(
-    const CypherBoundFunctionExpression &expr)
+    const CypherBoundFunctionExpression &expr, turbolynx::LogicalPlan *plan)
 {
     string func_name = expr.GetFuncName();
     if (IsCastingFunction(func_name)) {
@@ -1293,7 +1316,7 @@ unique_ptr<duckdb::Expression> Cypher2OrcaConverter::ConvertFunctionDuckDB(
     vector<LogicalType> child_types;
     vector<unique_ptr<duckdb::Expression>> duckdb_children;
     for (idx_t i = 0; i < expr.GetNumChildren(); i++) {
-        auto ce = ConvertExpressionDuckDB(*expr.GetChild(i));
+        auto ce = ConvertExpressionDuckDB(*expr.GetChild(i), plan);
         // Preserve aliases from bound expressions (struct_pack uses them for field names)
         if (expr.GetChild(i)->HasAlias()) {
             ce->alias = expr.GetChild(i)->GetAlias();
@@ -1318,7 +1341,7 @@ unique_ptr<duckdb::Expression> Cypher2OrcaConverter::ConvertFunctionDuckDB(
 }
 
 unique_ptr<duckdb::Expression> Cypher2OrcaConverter::ConvertAggFuncDuckDB(
-    const BoundAggFunctionExpression &expr)
+    const BoundAggFunctionExpression &expr, turbolynx::LogicalPlan *plan)
 {
     string func_name = expr.GetFuncName();
     std::transform(func_name.begin(), func_name.end(), func_name.begin(), ::tolower);
@@ -1326,7 +1349,7 @@ unique_ptr<duckdb::Expression> Cypher2OrcaConverter::ConvertAggFuncDuckDB(
     vector<LogicalType> child_types;
     vector<unique_ptr<duckdb::Expression>> duckdb_children;
     if (expr.HasChild()) {
-        auto ce = ConvertExpressionDuckDB(*expr.GetChild());
+        auto ce = ConvertExpressionDuckDB(*expr.GetChild(), plan);
         child_types.push_back(ce->return_type);
         duckdb_children.push_back(std::move(ce));
     }
@@ -1358,12 +1381,12 @@ unique_ptr<duckdb::Expression> Cypher2OrcaConverter::ConvertComparisonDuckDB(
 }
 
 unique_ptr<duckdb::Expression> Cypher2OrcaConverter::ConvertBoolOpDuckDB(
-    const BoundBoolExpression &expr)
+    const BoundBoolExpression &expr, turbolynx::LogicalPlan *plan)
 {
     if (expr.GetOpType() == BoundBoolOpType::NOT) {
         auto bound_op = make_unique<BoundOperatorExpression>(
             ExpressionType::OPERATOR_NOT, LogicalType::BOOLEAN);
-        bound_op->children.push_back(ConvertExpressionDuckDB(*expr.GetChild(0)));
+        bound_op->children.push_back(ConvertExpressionDuckDB(*expr.GetChild(0), plan));
         return bound_op;
     }
     duckdb::ExpressionType conj_type = (expr.GetOpType() == BoundBoolOpType::AND)
@@ -1371,7 +1394,7 @@ unique_ptr<duckdb::Expression> Cypher2OrcaConverter::ConvertBoolOpDuckDB(
         : ExpressionType::CONJUNCTION_OR;
     auto conjunction = make_unique<BoundConjunctionExpression>(conj_type);
     for (idx_t i = 0; i < expr.GetNumChildren(); i++) {
-        conjunction->children.push_back(ConvertExpressionDuckDB(*expr.GetChild(i)));
+        conjunction->children.push_back(ConvertExpressionDuckDB(*expr.GetChild(i), plan));
     }
     return conjunction;
 }

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -296,18 +296,27 @@ private:
                                         turbolynx::LogicalPlan *plan);
 
     // DuckDB expression for function type resolution
-    unique_ptr<duckdb::Expression> ConvertExpressionDuckDB(const BoundExpression &expr);
+    // `plan` is optional — when supplied, VARIABLE expressions whose
+    // binder data_type is ANY/UNKNOWN/SQLNULL will look up the colref
+    // type from the plan's schema (#69). When nullptr, falls back to
+    // the binder's data_type.
+    unique_ptr<duckdb::Expression> ConvertExpressionDuckDB(const BoundExpression &expr,
+                                                           turbolynx::LogicalPlan *plan = nullptr);
     unique_ptr<duckdb::Expression> ConvertLiteralDuckDB(const BoundLiteralExpression &expr);
     unique_ptr<duckdb::Expression> ConvertPropertyDuckDB(const BoundPropertyExpression &expr);
-    unique_ptr<duckdb::Expression> ConvertFunctionDuckDB(const CypherBoundFunctionExpression &expr);
-    unique_ptr<duckdb::Expression> ConvertAggFuncDuckDB(const BoundAggFunctionExpression &expr);
+    unique_ptr<duckdb::Expression> ConvertFunctionDuckDB(const CypherBoundFunctionExpression &expr,
+                                                         turbolynx::LogicalPlan *plan = nullptr);
+    unique_ptr<duckdb::Expression> ConvertAggFuncDuckDB(const BoundAggFunctionExpression &expr,
+                                                        turbolynx::LogicalPlan *plan = nullptr);
     unique_ptr<duckdb::Expression> ConvertComparisonDuckDB(const CypherBoundComparisonExpression &expr);
-    unique_ptr<duckdb::Expression> ConvertBoolOpDuckDB(const BoundBoolExpression &expr);
+    unique_ptr<duckdb::Expression> ConvertBoolOpDuckDB(const BoundBoolExpression &expr,
+                                                       turbolynx::LogicalPlan *plan = nullptr);
 
     // Type helpers
     INT GetTypeMod(const LogicalType &type);
     OID GetTypeOidFromCExpr(CExpression *expr);
     INT GetTypeModFromCExpr(CExpression *expr);
+    LogicalType LogicalTypeFromCExpr(CExpression *expr);
     IMDType::ECmpType MapCmpType(ExpressionType t, bool swap);
 
     // ---- catalog helpers ----

--- a/test/query/helpers/tpch_expected_counts.hpp
+++ b/test/query/helpers/tpch_expected_counts.hpp
@@ -21,17 +21,34 @@ namespace tpch {
 
 #ifdef TURBOLYNX_TPCH_FIXTURE_MINI
 // SF0.01 mini fixture (test/data/tpch-mini/).
-// Q1, Q3, Q5, Q6, Q7, Q9, Q10, Q11, Q14, Q15, Q19 currently SIGSEGV
-// inside the engine on this fixture (issue #69) and are wrapped with
-// `TPCH_TEST_BROKEN_MINI` in the test file — no expected count needed.
+// Q1/Q3/Q5/Q6/Q7/Q9/Q10/Q11/Q14/Q15/Q19 originally SIGSEGV'd (#69)
+// from BindDecimalSum / BindDecimalRoundPrecision crashes when the
+// converter passed ANY-typed expressions into DuckDB's DECIMAL bind
+// functions; resolved by deriving the LogicalType from the ORCA
+// scalar / schema colref instead of the binder's stale data_type.
+inline constexpr int64_t Q1  = 4;
 inline constexpr int64_t Q2  = 5;
+inline constexpr int64_t Q3  = 10;
 inline constexpr int64_t Q4  = 5;
+inline constexpr int64_t Q5  = 5;
+inline constexpr int64_t Q6  = 1;
+inline constexpr int64_t Q7  = 4;
 inline constexpr int64_t Q8  = 2;
+inline constexpr int64_t Q9  = 175;
+inline constexpr int64_t Q10 = 20;
+inline constexpr int64_t Q11 = 357;
 inline constexpr int64_t Q12 = 2;
 inline constexpr int64_t Q13 = 32;
+// Q14 currently returns the right row but a value 100x the DuckDB
+// oracle (1734.31 vs 17.34) — a separate scalar-arithmetic bug that
+// is *not* the SIGSEGV path fixed here. Tracked as future work; row
+// count remains 1.
+inline constexpr int64_t Q14 = 1;
+inline constexpr int64_t Q15 = 1;
 inline constexpr int64_t Q16 = 315;
 inline constexpr int64_t Q17 = 1;
 inline constexpr int64_t Q18 = 12;  // sf0.01/q18.cql uses `> 270` (mini max sum is 305; SF1 uses `> 315`)
+inline constexpr int64_t Q19 = 1;   // single row, NULL revenue (no parts match the brand+container+size filter on mini)
 inline constexpr int64_t Q20 = 2;
 inline constexpr int64_t Q21 = 1;
 inline constexpr int64_t Q22 = 7;

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -751,17 +751,22 @@ TEST_CASE("TPC-H Q22 (rows)", "[tpch][q22]") {
         CHECK(r[i].str_at(2)   == exp.totacctbal);
     }
 }
-TPCH_TEST_BROKEN_MINI(1,  "#69")
-TPCH_TEST_BROKEN_MINI(3,  "#69")
-TPCH_TEST_BROKEN_MINI(5,  "#69")
-TPCH_TEST_BROKEN_MINI(6,  "#69")
-TPCH_TEST_BROKEN_MINI(7,  "#69")
-TPCH_TEST_BROKEN_MINI(9,  "#69")
-TPCH_TEST_BROKEN_MINI(10, "#69")
-TPCH_TEST_BROKEN_MINI(11, "#69")
-TPCH_TEST_BROKEN_MINI(14, "#69")
-TPCH_TEST_BROKEN_MINI(15, "#69")
-TPCH_TEST_BROKEN_MINI(19, "#69")
+// Previously SIGSEGV'd on the SF0.01 fixture (#69) — all 11 unblocked
+// by the converter type-resolution fix; now exercised as count-only
+// smoke tests. Future PRs can promote individual queries to row-by-row
+// value tests against the DuckDB oracle (already done for Q8 / Q12 /
+// Q13 / Q16-Q22).
+TPCH_TEST(1,  tpch::Q1)
+TPCH_TEST(3,  tpch::Q3)
+TPCH_TEST(5,  tpch::Q5)
+TPCH_TEST(6,  tpch::Q6)
+TPCH_TEST(7,  tpch::Q7)
+TPCH_TEST(9,  tpch::Q9)
+TPCH_TEST(10, tpch::Q10)
+TPCH_TEST(11, tpch::Q11)
+TPCH_TEST(14, tpch::Q14)
+TPCH_TEST(15, tpch::Q15)
+TPCH_TEST(19, tpch::Q19)
 #else
 // SF1 (full benchmark): all 22 queries exercised.
 TPCH_TEST(1,  tpch::Q1)


### PR DESCRIPTION
## Summary

Fixes the SIGSEGV that affected eleven TPC-H queries (Q1, Q3, Q5, Q6, Q7, Q9, Q10, Q11, Q14, Q15, Q19) on the SF0.01 mini fixture. Crash was inside DuckDB DECIMAL bind functions (\`BindDecimalSum\`, \`BindDecimalRoundPrecision\`) dereferencing null TypeInfo on an ANY-typed argument.

## Root cause

Cypher binder leaves the LogicalType of arithmetic results (e.g. \`a * (1 - b)\`) and aggregate outputs (e.g. \`max(total_revenue)\` where \`total_revenue\` is itself a previous-WITH alias) as \`ANY\` with no TypeInfo. The converter forwarded that ANY directly into DuckDB binders. Three places leaked the bad type:

1. \`PlanGroupBy\` pre-projection — replaced complex agg children with \`BoundVariableExpression(child->GetDataType(), ...)\` (= ANY for arithmetic).
2. \`extractAggs\` (#106 path) — replaced \`max(...)\`/\`sum(...)\` etc. with \`BoundVariableExpression(e->GetDataType(), ...)\` (= ANY when input was an alias).
3. \`ConvertExpressionDuckDB(VARIABLE)\` — emitted \`BoundReferenceExpression(expr.GetDataType(), 0)\` (= ANY) for aliased columns.

## Fix

- Added helper \`LogicalTypeFromCExpr(CExpression*)\` wrapping the existing OID/typemod → LogicalType pipeline.
- (1) and (2): resolve the new variable's type from the ORCA scalar via that helper.
- (3): when binder type is ANY/UNKNOWN/SQLNULL and \`plan\` is available, look up the colref in the schema and rebuild the LogicalType from its MdId/TypeModifier. Threaded \`plan\` through \`ConvertFunctionDuckDB\` / \`ConvertAggFuncDuckDB\` / \`ConvertBoolOpDuckDB\` / CASE recursion (default \`nullptr\` to keep call sites without a plan working).

## Test impact

- All eleven \`TPCH_TEST_BROKEN_MINI(.., \"#69\")\` flipped back to \`TPCH_TEST\` with row counts measured against the fixture and cross-checked against DuckDB v1.5.2 dbgen(sf=0.01) where Cypher and SQL filters align.
- Q14 still returns a value 100× the DuckDB oracle (1734.31 vs 17.34) — a separate scalar-arithmetic bug, not the SIGSEGV path. Row count of 1 is correct, so the smoke test passes; pinning the value is left for follow-up.
- Q19 returns a single NULL row on the mini fixture (no parts match the brand/container/size filter), matching DuckDB.

## Test plan

- [x] \`query_test \"[tpch]\" --tpch-path /tmp/tpch-mini-ws ~\"[bench]\"\` → 42 cases / 853 assertions all pass (was 31 / 831 in #108)
- [x] \`query_test \"[ldbc]\" --ldbc-path /tmp/ldbc-mini-ws\` → 1428 / 1562 unchanged
- [x] \`unittest\` → 200 cases / 770 assertions, all pass
- [x] \`query_test \"[tpch][bench]\"\` no SIGSEGV (no new regression — bench was already running but several queries now actually complete instead of crashing)

Closes #69. Stacked on #108.