### PR TITLE
ORCA: CScalarIf carries type modifier so CASE preserves DECIMAL scale

### DIFF
--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -1194,6 +1194,7 @@ CExpression *Cypher2OrcaConverter::ConvertCase(const CypherBoundCaseExpression &
     // 4. Build nested CScalarIf from bottom up using ret_type as the
     //    declared output of every level:
     //    If(cond_n, then_n, If(cond_n-1, then_n-1, ... If(cond_1, then_1, else) ...))
+    INT if_type_mod = GetTypeMod(ret_type);
     CExpression *result = else_expr;
     for (int i = (int)checks.size() - 1; i >= 0; i--) {
         uint32_t if_type_id = LOGICAL_TYPE_BASE_ID + (OID)ret_type.id();
@@ -1204,7 +1205,7 @@ CExpression *Cypher2OrcaConverter::ConvertCase(const CypherBoundCaseExpression &
         if_children->Append(then_exprs[i]);                                   // true value
         if_children->Append(result);                                          // false value
         result = GPOS_NEW(mp_) CExpression(
-            mp_, GPOS_NEW(mp_) CScalarIf(mp_, if_mdid), if_children);
+            mp_, GPOS_NEW(mp_) CScalarIf(mp_, if_mdid, if_type_mod), if_children);
     }
 
     return result;

--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CScalarIf.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CScalarIf.h
@@ -45,6 +45,8 @@ private:
 	// metadata id in the catalog
 	IMDId *m_mdid_type;
 
+	INT m_type_modifier;
+
 	// is operator return type BOOL?
 	BOOL m_fBoolReturnType;
 
@@ -53,7 +55,7 @@ private:
 
 public:
 	// ctor
-	CScalarIf(CMemoryPool *mp, IMDId *mdid);
+	CScalarIf(CMemoryPool *mp, IMDId *mdid, INT type_modifier = default_type_modifier);
 
 	// dtor
 	virtual ~CScalarIf()
@@ -81,6 +83,13 @@ public:
 	MdidType() const
 	{
 		return m_mdid_type;
+	}
+
+	// the type modifier of the scalar expression
+	virtual INT
+	TypeModifier() const
+	{
+		return m_type_modifier;
 	}
 
 	// operator specific hash function

--- a/src/optimizer/orca/gporca/libgpopt/operators/CScalarIf.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/operators/CScalarIf.cpp
@@ -31,8 +31,9 @@ using namespace gpmd;
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CScalarIf::CScalarIf(CMemoryPool *mp, IMDId *mdid)
-	: CScalar(mp), m_mdid_type(mdid), m_fBoolReturnType(false)
+CScalarIf::CScalarIf(CMemoryPool *mp, IMDId *mdid, INT type_modifier)
+	: CScalar(mp), m_mdid_type(mdid), m_type_modifier(type_modifier),
+	  m_fBoolReturnType(false)
 {
 	GPOS_ASSERT(mdid->IsValid());
 

--- a/test/query/helpers/tpch_expected_counts.hpp
+++ b/test/query/helpers/tpch_expected_counts.hpp
@@ -39,11 +39,9 @@ inline constexpr int64_t Q10 = 20;
 inline constexpr int64_t Q11 = 357;
 inline constexpr int64_t Q12 = 2;
 inline constexpr int64_t Q13 = 32;
-// Q14 currently returns the right row but a value 100x the DuckDB
-// oracle (1734.31 vs 17.34) — a separate scalar-arithmetic bug that
-// is *not* the SIGSEGV path fixed here. Tracked as future work; row
-// count remains 1.
 inline constexpr int64_t Q14 = 1;
+// DuckDB SF0.01 oracle: 17.34314126450495.
+inline constexpr const char* Q14_PROMO_REVENUE_STR = "17.343141";
 inline constexpr int64_t Q15 = 1;
 inline constexpr int64_t Q16 = 315;
 inline constexpr int64_t Q17 = 1;

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -764,9 +764,100 @@ TPCH_TEST(7,  tpch::Q7)
 TPCH_TEST(9,  tpch::Q9)
 TPCH_TEST(10, tpch::Q10)
 TPCH_TEST(11, tpch::Q11)
-TPCH_TEST(14, tpch::Q14)
 TPCH_TEST(15, tpch::Q15)
 TPCH_TEST(19, tpch::Q19)
+
+// Q14 — value test: 100*SUM(CASE...) / SUM(...) PROMO revenue.
+// Pre-fix this returned 1734.31 (100x) because CScalarIf had no
+// type_modifier so DECIMAL(15,4) result fell back to DECIMAL(12,2).
+TEST_CASE("TPC-H Q14 (rows)", "[tpch][q14]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q14.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(), {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == tpch::Q14_PROMO_REVENUE_STR);
+}
+
+// ----------------------------------------------------------------------
+// Issue (CScalarIf type_modifier) — exercise CASE-inside-SUM with a
+// variety of THEN/ELSE type combinations beyond DECIMAL(12,2). All
+// values cross-checked against DuckDB v1.5.2 dbgen(sf=0.01).
+// ----------------------------------------------------------------------
+
+TEST_CASE("CASE-in-SUM — INTEGER literal branches (1/0)",
+          "[tpch][issue110][i110-1]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN sum(CASE WHEN l.L_RETURNFLAG = \"R\" "
+        "THEN 1 ELSE 0 END) AS v",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 14902);
+}
+
+TEST_CASE("CASE-in-SUM — DECIMAL THEN with wider scale "
+          "(L_EXTENDEDPRICE * L_QUANTITY)",
+          "[tpch][issue110][i110-2]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN sum(CASE WHEN l.L_RETURNFLAG = \"R\" "
+        "THEN l.L_EXTENDEDPRICE * l.L_QUANTITY ELSE 0 END) AS v",
+        {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == "17993342580.7300");
+}
+
+TEST_CASE("CASE-in-SUM — DOUBLE branch (tofloat / 2)",
+          "[tpch][issue110][i110-3]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN sum(CASE WHEN l.L_RETURNFLAG = \"R\" "
+        "THEN tofloat(l.L_QUANTITY) / 2 ELSE 0 END) AS v",
+        {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == "190724.500000");
+}
+
+TEST_CASE("CASE-in-SUM — DATE-predicate WHEN, DECIMAL THEN",
+          "[tpch][issue110][i110-4]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN sum(CASE WHEN l.L_SHIPDATE >= "
+        "date(\"1997-01-01\") THEN l.L_EXTENDEDPRICE * (1 - l.L_DISCOUNT) "
+        "ELSE 0 END) AS v",
+        {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == "541382560.7292");
+}
+
+TEST_CASE("CASE-in-SUM — DECIMAL THEN with non-zero DECIMAL ELSE",
+          "[tpch][issue110][i110-5]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN sum(CASE WHEN l.L_RETURNFLAG = \"R\" "
+        "THEN l.L_EXTENDEDPRICE * (1 - l.L_DISCOUNT) ELSE 0.5 END) AS v",
+        {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    // DuckDB oracle 508019090.9067; QueryRunner formats DOUBLE/DECIMAL
+    // with 6 decimal digits, so trailing 99 reflects rounding of the
+    // DECIMAL(.,6)-ish output.
+    CHECK(r[0].str_at(0) == "508019090.906699");
+}
+
+TEST_CASE("CASE-in-SUM-over-SUM ratio — DECIMAL Q14-shape (sanity)",
+          "[tpch][issue110][i110-6]") {
+    SKIP_IF_NO_DB();
+    // Same shape as Q14 but with a different selectivity (R-flag) so
+    // a regression here is independent of Q14's specific date filter.
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN 100 * sum(CASE WHEN l.L_RETURNFLAG = \"R\" "
+        "THEN l.L_EXTENDEDPRICE * (1 - l.L_DISCOUNT) ELSE 0 END) "
+        "/ sum(l.L_EXTENDEDPRICE * (1 - l.L_DISCOUNT)) AS v",
+        {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == "24.839263");
+}
 #else
 // SF1 (full benchmark): all 22 queries exercised.
 TPCH_TEST(1,  tpch::Q1)


### PR DESCRIPTION
## Summary

TPC-H Q14 returned 1734.31 instead of the DuckDB-verified 17.34 — off by exactly 100×. Same shape (\`100 * sum(...) / sum(...)\`) without the CASE produced the right value, so the bug was specific to CASE with a DECIMAL THEN of higher scale than (12, 2).

## Root cause

\`CScalarIf\` stored only the type id (mdid). Its \`TypeModifier()\` inherited the CScalar default \`-1\`, so every downstream consumer that converted the operator's output type via \`OidToLogicalType(oid, mod)\` fell into the \`mod <= 0\` fallback and got \`LogicalType::DECIMAL(12, 2)\`. For Q14 the CASE result was DECIMAL(*, 4) — \`L_EXTENDEDPRICE * (1 - L_DISCOUNT)\` widens scale from 2 to 4 — so SUM saw the right integer value but interpreted it at scale 2, formatting it 100× larger.

## Fix

- Add \`INT m_type_modifier\` to \`CScalarIf\`, extend the ctor to accept it (defaulting to \`default_type_modifier\` so existing callers compile unchanged), override \`TypeModifier()\`.
- In \`ConvertCase\`, pass \`GetTypeMod(ret_type)\` — the encoded width/scale of the LCT computed from the converted THEN/ELSE branches — into the new ctor.

## Test impact

- Q14 promoted from count-only to value test (\`17.343141\`).
- Six new \`[tpch][issue110]\` cases exercise CASE-inside-SUM beyond DECIMAL(12,2):
  - i110-1: INTEGER literal branches (\`THEN 1 ELSE 0\`)
  - i110-2: DECIMAL THEN with wider scale (\`ext * qty\`)
  - i110-3: DOUBLE branch (\`tofloat / 2\`)
  - i110-4: DATE-predicate WHEN with DECIMAL THEN
  - i110-5: DECIMAL THEN with non-zero DECIMAL ELSE
  - i110-6: Q14-shape ratio with a different selectivity (R-flag)
- Values cross-checked against DuckDB v1.5.2 \`CALL dbgen(sf=0.01)\`.
- Two related shapes (\`sum(L_LINENUMBER)\` standalone) hit a separate \`sum(INTEGER)\` SIGSEGV that reproduces on \`main\` without this patch — orthogonal pre-existing bug, not in scope.

## Test plan

- [x] \`query_test \"[tpch]\" --tpch-path /tmp/tpch-mini-ws ~\"[bench]\"\` → 48 cases / 866 assertions all pass (was 42 / 853)
- [x] \`query_test \"[ldbc]\" --ldbc-path /tmp/ldbc-mini-ws\` → 1428 / 1562 unchanged
- [x] \`unittest\` → 200 cases / 770 assertions, all pass

## Follow-up

Type coverage today is limited to types reachable from TPC-H/LDBC schemas. Adding a small \`test/data/types-mini\` fixture with TINYINT/SMALLINT/BIGINT/FLOAT/various-DECIMAL/TIMESTAMP/etc. would let us bracket type-promotion bugs more aggressively. Out of scope for this PR.