### PR TITLE
fn: register unsigned-integer overloads for sum/avg (part of #111)

### DIFF
--- a/src/function/aggregate/algebraic/avg.cpp
+++ b/src/function/aggregate/algebraic/avg.cpp
@@ -171,6 +171,15 @@ AggregateFunction GetAverageAggregate(PhysicalType type) {
 	case PhysicalType::INT128:
 		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, hugeint_t, double, HugeintAverageOperation>(
 		    LogicalType::HUGEINT, LogicalType::DOUBLE, true);
+	case PhysicalType::UINT16:
+		return AggregateFunction::UnaryAggregate<AvgState<int64_t>, uint16_t, double, IntegerAverageOperation>(
+		    LogicalType::USMALLINT, LogicalType::DOUBLE, true);
+	case PhysicalType::UINT32:
+		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, uint32_t, double, IntegerAverageOperationHugeint>(
+		    LogicalType::UINTEGER, LogicalType::DOUBLE, true);
+	case PhysicalType::UINT64:
+		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, uint64_t, double, IntegerAverageOperationHugeint>(
+		    LogicalType::UBIGINT, LogicalType::DOUBLE, true);
 	default:
 		throw InternalException("Unimplemented average aggregate");
 	}
@@ -198,6 +207,9 @@ void AvgFun::RegisterFunction(BuiltinFunctions &set) {
 	avg.AddFunction(GetAverageAggregate(PhysicalType::INT32));
 	avg.AddFunction(GetAverageAggregate(PhysicalType::INT64));
 	avg.AddFunction(GetAverageAggregate(PhysicalType::INT128));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::UINT16));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::UINT32));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::UINT64));
 	avg.AddFunction(AggregateFunction::UnaryAggregate<AvgState<double>, double, double, NumericAverageOperation>(
 	    LogicalType::DOUBLE, LogicalType::DOUBLE, true));
 	set.AddFunction(avg);

--- a/src/function/aggregate/distributive/sum.cpp
+++ b/src/function/aggregate/distributive/sum.cpp
@@ -160,6 +160,18 @@ AggregateFunction SumFun::GetSumAggregate(PhysicalType type) {
 	case PhysicalType::INT128:
 		return AggregateFunction::UnaryAggregate<SumState<hugeint_t>, hugeint_t, hugeint_t, HugeintSumOperation>(
 		    LogicalType::HUGEINT, LogicalType::HUGEINT, true);
+	case PhysicalType::UINT8:
+		return AggregateFunction::UnaryAggregate<SumState<int64_t>, uint8_t, hugeint_t, IntegerSumOperation>(
+		    LogicalType::UTINYINT, LogicalType::HUGEINT, true);
+	case PhysicalType::UINT16:
+		return AggregateFunction::UnaryAggregate<SumState<int64_t>, uint16_t, hugeint_t, IntegerSumOperation>(
+		    LogicalType::USMALLINT, LogicalType::HUGEINT, true);
+	case PhysicalType::UINT32:
+		return AggregateFunction::UnaryAggregate<SumState<hugeint_t>, uint32_t, hugeint_t, SumToHugeintOperation>(
+		    LogicalType::UINTEGER, LogicalType::HUGEINT, true);
+	case PhysicalType::UINT64:
+		return AggregateFunction::UnaryAggregate<SumState<hugeint_t>, uint64_t, hugeint_t, SumToHugeintOperation>(
+		    LogicalType::UBIGINT, LogicalType::HUGEINT, true);
 	case PhysicalType::DOUBLE:
 		return AggregateFunction::UnaryAggregate<SumState<double>, double, double, NumericSumOperation>(
 	    	LogicalType::DOUBLE, LogicalType::DOUBLE, true);
@@ -189,6 +201,10 @@ void SumFun::RegisterFunction(BuiltinFunctions &set) {
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT32));
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT64));
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT128));
+	sum.AddFunction(GetSumAggregate(PhysicalType::UINT8));
+	sum.AddFunction(GetSumAggregate(PhysicalType::UINT16));
+	sum.AddFunction(GetSumAggregate(PhysicalType::UINT32));
+	sum.AddFunction(GetSumAggregate(PhysicalType::UINT64));
 	sum.AddFunction(AggregateFunction::UnaryAggregate<SumState<double>, double, double, NumericSumOperation>(
 	    LogicalType::DOUBLE, LogicalType::DOUBLE, true));
 

--- a/test/query/test_types_correctness.cpp
+++ b/test/query/test_types_correctness.cpp
@@ -201,6 +201,36 @@ TEST_CASE("types: count by category", "[types][agg]") {
     }
 }
 
+TEST_CASE("types: sum/avg over UBIGINT property by category",
+          "[types][agg][issue111]") {
+    SKIP_IF_NO_TYPES_DB();
+    // Pre-fix `sum(t.t_ulong)` (UBIGINT) crashed: no UBIGINT sum
+    // overload existed, the dispatcher fell back to DOUBLE, and
+    // CastToFunctionArguments wrapped the agg child in a CAST that
+    // PhysicalHashAggregate::Sink couldn't handle (#111).
+    auto r = qr->run(
+        "MATCH (t:TypeRow) RETURN t.category AS c, "
+        "sum(t.t_ulong) AS s, avg(t.t_ulong) AS a ORDER BY c",
+        {qtest::ColType::STRING, qtest::ColType::INT64, qtest::ColType::AUTO});
+    REQUIRE(r.size() == 5);
+    // Per typerow.tbl, t_ulong by category:
+    //   A: 0,1,0,10                    → sum 11,    avg 2.75
+    //   B: 100,1000,0                  → sum 1100,  avg 366.67
+    //   C: 9223372036854775807,2,3,4,5 → overflows-to-hugeint (skip exact)
+    //   D: 6,7,8,9,11                  → sum 41,    avg 8.20
+    //   E: 12,13,14                    → sum 39,    avg 13.00
+    CHECK(r[0].str_at(0) == "A");
+    CHECK(r[0].int64_at(1) == 11);
+    CHECK(r[1].str_at(0) == "B");
+    CHECK(r[1].int64_at(1) == 1100);
+    CHECK(r[3].str_at(0) == "D");
+    CHECK(r[3].int64_at(1) == 41);
+    CHECK(r[3].str_at(2) == "8.200000");
+    CHECK(r[4].str_at(0) == "E");
+    CHECK(r[4].int64_at(1) == 39);
+    CHECK(r[4].str_at(2) == "13.000000");
+}
+
 TEST_CASE("types: min / max DATE by category", "[types][agg]") {
     SKIP_IF_NO_TYPES_DB();
     auto r = qr->run(


### PR DESCRIPTION
## Summary

Modern DuckDB has \`sum\` / \`avg\` variants for UTINYINT / USMALLINT / UINTEGER / UBIGINT (all returning HUGEINT or DOUBLE). Our forked copy only had the signed variants. Combined with our property-key handling (composite-ID parts on TPC-H, every node's \`id\` column → UBIGINT), \`sum(prop)\` over those properties hit a SIGSEGV.

Fixes Bug 3 of #111. Bugs 1 (\`count(*)\` Normalizer crash) and 2 (global \`sum\` runtime crash) remain open.

## Root cause chain (Bug 3)

1. Schema types L_LINENUMBER (and most node \`id\` properties) as UBIGINT (loader force for ID-marked columns).
2. \`pTransformScalarAggFunc\` looks up sum overloads, finds no UBIGINT match, falls back to the DOUBLE variant.
3. \`function.CastToFunctionArguments\` wraps the agg child in \`BoundCastExpression(UBIGINT → DOUBLE)\`.
4. At runtime, \`PhysicalHashAggregate::Sink\` reinterprets the cast expression as \`BoundReferenceExpression\` and reads the \`unique_ptr<Expression> child\` field's pointer bytes as a \`size_t\` index. Garbage index → \`input.data[OOB]\` → SEGV.

## Why this approach (Option B)

Verified in upstream DuckDB:

\`\`\`
SELECT typeof(sum(v)) FROM (SELECT 1::UBIGINT v);  -- HUGEINT
SELECT typeof(avg(v)) FROM (SELECT 1::UBIGINT v);  -- DOUBLE
\`\`\`

Upstream registers all unsigned variants. We were just missing them.

\`EXPLAIN\` on a CAST-needing aggregate also shows DuckDB inserts a Projection node above the input scan, so the agg child stays a simple BoundReferenceExpression at runtime. Our planner currently bakes the CAST into the agg child instead — that architectural mismatch is the root reason this class of bug exists. Adding the missing overloads sidesteps it for the common UINT case; restructuring the planner to insert the Projection itself is the broader fix and is filed as a follow-up on #111.

## Files changed

- \`src/function/aggregate/distributive/sum.cpp\`: add UINT8 / UINT16 / UINT32 / UINT64 cases to \`SumFun::GetSumAggregate\` and register them in \`RegisterFunction\`.
- \`src/function/aggregate/algebraic/avg.cpp\`: add UINT16 / UINT32 / UINT64 to \`GetAverageAggregate\` and \`AvgFun::RegisterFunction\` (matches the signed pattern, which omits INT8 — DuckDB itself promotes TINYINT to SMALLINT for \`avg\`).
- \`test/query/test_types_correctness.cpp\`: new types-mini case \`sum(t_ulong) / avg(t_ulong)\` grouped by category.

## Test plan

- [x] \`query_test \"[types]\" --types-path /tmp/types-mini-ws\` → 15 cases / 64 assertions all pass (was 14 / 53)
- [x] \`query_test \"[tpch]\" --tpch-path /tmp/tpch-mini-ws ~\"[bench]\"\` → 48 / 866 unchanged
- [x] \`query_test \"[ldbc]\" --ldbc-path /tmp/ldbc-mini-ws\` → 1428 / 1562 unchanged
- [x] \`unittest\` → 200 / 770 unchanged

Stacked on #112 (add-types-mini) so the new test case has the fixture available.