### PR TITLE
test: lock #111 Bug 2 (global aggregates) with regression tests

### DIFF
--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -496,6 +496,60 @@ TEST_CASE("Issue #106 — five aggs (max,min,count(DISTINCT),sum,count) "
     }
 }
 
+// ----------------------------------------------------------------------
+// Issue #111 — global aggregates (0 grouping keys) on TPC-H tables.
+// Bug 2 of #111 was a Linux-x86_64 SIGSEGV in
+// PhysicalHashAggregate::Sink for sum/min/max/avg with no grouping
+// keys; macOS happened to mask it. The cases below re-run the verbatim
+// reproducers from the issue, with oracles cross-checked against
+// DuckDB v1.5.2 over the same .tbl files. Bug 1 (count(*) global) is
+// still open, so we use count(l) / count(n) instead.
+// ----------------------------------------------------------------------
+
+TEST_CASE("Issue #111 — global sum / min / max / avg over LINEITEM.L_QUANTITY",
+          "[tpch][issue111][global-agg]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN sum(l.L_QUANTITY) AS s, "
+        "min(l.L_QUANTITY) AS mn, max(l.L_QUANTITY) AS mx, "
+        "avg(l.L_QUANTITY) AS a",
+        {qtest::ColType::AUTO, qtest::ColType::AUTO,
+         qtest::ColType::AUTO, qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == "1536127.00");
+    CHECK(r[0].str_at(1) == "1.00");
+    CHECK(r[0].str_at(2) == "50.00");
+    CHECK(r[0].str_at(3) == "25.527661");
+}
+
+TEST_CASE("Issue #111 — global sum over LINEITEM bare-INT property",
+          "[tpch][issue111][global-agg]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) RETURN sum(l.L_LINENUMBER) AS s, "
+        "sum(l.L_EXTENDEDPRICE) AS p, count(l.L_QUANTITY) AS c",
+        {qtest::ColType::INT64, qtest::ColType::AUTO, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 180782);
+    CHECK(r[0].str_at(1) == "2152189760.47");
+    CHECK(r[0].int64_at(2) == 60175);
+}
+
+TEST_CASE("Issue #111 — global aggregates over NATION",
+          "[tpch][issue111][global-agg]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (n:NATION) RETURN count(n) AS c, sum(n.N_NATIONKEY) AS s, "
+        "min(n.N_NAME) AS mn, max(n.N_NAME) AS mx",
+        {qtest::ColType::INT64, qtest::ColType::INT64,
+         qtest::ColType::STRING, qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 25);
+    CHECK(r[0].int64_at(1) == 300);
+    CHECK(r[0].str_at(2) == "ALGERIA");
+    CHECK(r[0].str_at(3) == "VIETNAM");
+}
+
 // Q8 — ETHIOPIA market-share within AFRICA, by ship year. Two rows
 // (1995 / 1996). Values verified against DuckDB SF0.01.
 TEST_CASE("TPC-H Q8 (rows)", "[tpch][q8]") {

--- a/test/query/test_types_correctness.cpp
+++ b/test/query/test_types_correctness.cpp
@@ -3,9 +3,13 @@
 // (CASE LCT, scalar-arithmetic widening, aggregate output type)
 // rather than any benchmark workload.
 //
-// Bugs in #111 (global aggregate / sum(bare INT)) are intentionally
-// avoided here so the suite stays green; the same fixture will host
-// regression tests once #111 ships.
+// Status of #111 sub-bugs in this file:
+//   Bug 2 (global sum/min/max/avg, 0 grouping keys): regression-locked
+//     via the [issue111][global-agg] cases below.
+//   Bug 3 (sum over bare INTEGER/UBIGINT): regression-locked via the
+//     existing by-category UBIGINT case + the new global cases.
+//   Bug 1 (count(*) global → ORCA Normalizer crash): still open. We
+//     use count(t) as a workaround in the global-agg cases.
 
 #include "catch.hpp"
 #include "helpers/query_runner.hpp"
@@ -245,4 +249,63 @@ TEST_CASE("types: min / max DATE by category", "[types][agg]") {
         INFO("row " << i);
         CHECK(r[i].int64_at(1) <= r[i].int64_at(2));
     }
+}
+
+// ---------- global aggregates (0 grouping keys) ------------------------
+// Locks #111 Bug 2: these previously SIGSEGV'd in
+// PhysicalHashAggregate::Sink under Linux x86_64 across every column /
+// agg combination. Bug 1 (count(*) with 0 grouping keys) is still
+// open, so the cases below use count(t) instead.
+
+TEST_CASE("types: global count over node", "[types][agg][issue111][global-agg]") {
+    SKIP_IF_NO_TYPES_DB();
+    auto r = qr->run("MATCH (t:TypeRow) RETURN count(t) AS v",
+                     {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 20);
+}
+
+TEST_CASE("types: global sum / min / max over INTEGER",
+          "[types][agg][issue111][global-agg]") {
+    SKIP_IF_NO_TYPES_DB();
+    auto r = qr->run(
+        "MATCH (t:TypeRow) RETURN sum(t.t_int) AS s, "
+        "min(t.t_int) AS mn, max(t.t_int) AS mx",
+        {qtest::ColType::INT64, qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 2147483851);
+    CHECK(r[0].int64_at(1) == -1000);
+    CHECK(r[0].int64_at(2) == 2147483647);
+}
+
+TEST_CASE("types: global sum / avg over DOUBLE",
+          "[types][agg][issue111][global-agg]") {
+    SKIP_IF_NO_TYPES_DB();
+    auto r = qr->run(
+        "MATCH (t:TypeRow) RETURN sum(t.t_double) AS s, avg(t.t_double) AS a",
+        {qtest::ColType::AUTO, qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == "208.141593");
+    CHECK(r[0].str_at(1) == "10.407080");
+}
+
+TEST_CASE("types: global sum over DECIMAL",
+          "[types][agg][issue111][global-agg]") {
+    SKIP_IF_NO_TYPES_DB();
+    auto r = qr->run(
+        "MATCH (t:TypeRow) RETURN sum(t.t_dec_default) AS s",
+        {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == "1000000210.81");
+}
+
+TEST_CASE("types: global min / max over VARCHAR",
+          "[types][agg][issue111][global-agg]") {
+    SKIP_IF_NO_TYPES_DB();
+    auto r = qr->run(
+        "MATCH (t:TypeRow) RETURN min(t.t_str) AS mn, max(t.t_str) AS mx",
+        {qtest::ColType::STRING, qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == "eight");
+    CHECK(r[0].str_at(1) == "zero");
 }


### PR DESCRIPTION
## Summary

While verifying the [#111](https://github.com/turbolynx-dslab/TurboLynx/issues/111) bug 3 fix from [#113](https://github.com/turbolynx-dslab/TurboLynx/pull/113), I tried to reproduce **Bug 2** (global `sum`/`min`/`max`/`avg` SIGSEGV in `PhysicalHashAggregate::Sink`, 0 grouping keys) and **could not** — neither on macOS x86_64, nor on Linux x86_64 (50/50 runs clean inside the `turbolynx-ubuntu-repro` container).

I bisected back to `753bf70c6` (the commit cited in the issue body as the reproducer baseline) and Bug 2 still didn't reproduce on either platform. Conclusion: it disappeared incidentally somewhere in the `#108`–`#113` stack — no targeted fix landed for it. Without a regression test, the bug is one careless change away from coming back.

This PR adds those regression tests so the next regression breaks CI immediately.

## Coverage

**`test/query/test_types_correctness.cpp`** — 5 new global-agg cases tagged `[issue111][global-agg]`:
- count over node
- sum / min / max over INTEGER (incl. negative + INT32_MAX)
- sum / avg over DOUBLE
- sum over DECIMAL(12,2) (oracle from DuckDB)
- min / max over VARCHAR

**`test/query/test_tpch_correctness.cpp`** — 3 cases that re-run the verbatim issue reproducers:
- `sum/min/max/avg(L_QUANTITY)` global
- `sum(L_LINENUMBER)` (bare INT, also exercises bug 3 with 0 grouping keys), `sum(L_EXTENDEDPRICE)`, `count(L_QUANTITY)`
- `count/sum/min/max` over NATION

All oracles cross-checked against DuckDB v1.5.2 reading the same `.tbl` files.

## Out of scope

Bug 1 of #111 (`count(*)` global → `gpopt::CNormalizer::PexprRecursiveNormalize` crash) is **still open**. The new cases use `count(node)` to avoid it. Will address in a separate PR.

## Test plan
- [x] `query_test "[issue111][global-agg]"` — 8/8 cases pass on macOS
- [x] `query_test "[tpch]~[broken-mini]~[stress]"` — 49 cases / 818 assertions pass on macOS
- [x] `query_test "[types]"` — 20 cases / 78 assertions pass on macOS
- [ ] Linux CI green (the main signal — we want Bug 2's "fix" verified on the platform that originally crashed)