### PR TITLE
ORCA: drop fully-pruned ProjectColumnar instead of returning NULL (#111 Bug 1)

### DIFF
--- a/src/optimizer/orca/gporca/libgpopt/operators/CExpressionPreprocessor.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/operators/CExpressionPreprocessor.cpp
@@ -2494,15 +2494,20 @@ CExpressionPreprocessor::PexprPruneProjListProjectOrGbAgg(
 	if (pcrsUnused->Size() == pcrsDefined->Size())
 	{
 		// the entire project list needs to be pruned
-		if (COperator::EopLogicalProject == pop->Eopid())
+		if (COperator::EopLogicalProject == pop->Eopid() ||
+			COperator::EopLogicalProjectColumnar == pop->Eopid())
 		{
+			// All defined columns are unused — drop the project node and
+			// surface its relational child to the parent. Triggered by
+			// e.g. `count(*)` / `sum(1)` with no grouping keys and no
+			// filter: the agg references no input columns, so the
+			// ProjectColumnar's only output is unused. Pre-fix the
+			// ProjectColumnar branch hit `GPOS_ASSERT(false)` (a no-op in
+			// release builds) and returned NULL, poisoning the parent
+			// GbAgg's relational child and crashing CNormalizer. (#111)
 			pexprRelationalNew = PexprPruneUnusedComputedColsRecursive(
 				mp, pexprRelational, pcrsReqdNew);
 			pexprResult = pexprRelationalNew;
-		}
-		else if(COperator::EopLogicalProjectColumnar == pop->Eopid()) {
-			// In columnar, this cannot happen. At least one projection should be alive.
-			GPOS_ASSERT(false);
 		}
 		else
 		{

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -498,12 +498,11 @@ TEST_CASE("Issue #106 — five aggs (max,min,count(DISTINCT),sum,count) "
 
 // ----------------------------------------------------------------------
 // Issue #111 — global aggregates (0 grouping keys) on TPC-H tables.
-// Bug 2 of #111 was a Linux-x86_64 SIGSEGV in
-// PhysicalHashAggregate::Sink for sum/min/max/avg with no grouping
-// keys; macOS happened to mask it. The cases below re-run the verbatim
-// reproducers from the issue, with oracles cross-checked against
-// DuckDB v1.5.2 over the same .tbl files. Bug 1 (count(*) global) is
-// still open, so we use count(l) / count(n) instead.
+// Bug 1 (count(*) / sum(1) / count(1) — ORCA Normalizer crash from a
+// NULL relational child) and Bug 2 (Sink SIGSEGV for sum/min/max/avg
+// on Linux x86_64). The cases below re-run the verbatim issue
+// reproducers, with oracles cross-checked against DuckDB v1.5.2 over
+// the same .tbl files.
 // ----------------------------------------------------------------------
 
 TEST_CASE("Issue #111 — global sum / min / max / avg over LINEITEM.L_QUANTITY",
@@ -548,6 +547,30 @@ TEST_CASE("Issue #111 — global aggregates over NATION",
     CHECK(r[0].int64_at(1) == 300);
     CHECK(r[0].str_at(2) == "ALGERIA");
     CHECK(r[0].str_at(3) == "VIETNAM");
+}
+
+TEST_CASE("Issue #111 — global count(*) / sum(1) / count(1) "
+          "(no input columns referenced)",
+          "[tpch][issue111][global-agg]") {
+    SKIP_IF_NO_DB();
+    // NATION (small) and LINEITEM (large multi-partition) both exercise
+    // the ProjectColumnar-pruned-to-zero path that pre-fix returned a
+    // NULL relational child to the parent GbAgg.
+    auto r1 = qr->run(
+        "MATCH (n:NATION) RETURN count(*) AS cs, sum(1) AS s1, "
+        "count(1) AS c1",
+        {qtest::ColType::INT64, qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r1.size() == 1);
+    CHECK(r1[0].int64_at(0) == 25);
+    CHECK(r1[0].int64_at(1) == 25);
+    CHECK(r1[0].int64_at(2) == 25);
+
+    auto r2 = qr->run(
+        "MATCH (l:LINEITEM) RETURN count(*) AS cs, sum(1) AS s1",
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r2.size() == 1);
+    CHECK(r2[0].int64_at(0) == 60175);
+    CHECK(r2[0].int64_at(1) == 60175);
 }
 
 // Q8 — ETHIOPIA market-share within AFRICA, by ship year. Two rows

--- a/test/query/test_types_correctness.cpp
+++ b/test/query/test_types_correctness.cpp
@@ -3,13 +3,12 @@
 // (CASE LCT, scalar-arithmetic widening, aggregate output type)
 // rather than any benchmark workload.
 //
-// Status of #111 sub-bugs in this file:
-//   Bug 2 (global sum/min/max/avg, 0 grouping keys): regression-locked
-//     via the [issue111][global-agg] cases below.
-//   Bug 3 (sum over bare INTEGER/UBIGINT): regression-locked via the
-//     existing by-category UBIGINT case + the new global cases.
-//   Bug 1 (count(*) global → ORCA Normalizer crash): still open. We
-//     use count(t) as a workaround in the global-agg cases.
+// All three #111 sub-bugs are regression-locked via the
+// [issue111][global-agg] cases below:
+//   Bug 1 (count(*) / sum(1) / count(1) with 0 grouping keys → ORCA
+//     Normalizer crash from a NULL relational child).
+//   Bug 2 (global sum/min/max/avg, 0 grouping keys → Sink SIGSEGV).
+//   Bug 3 (sum over bare INTEGER / UBIGINT property).
 
 #include "catch.hpp"
 #include "helpers/query_runner.hpp"
@@ -252,17 +251,24 @@ TEST_CASE("types: min / max DATE by category", "[types][agg]") {
 }
 
 // ---------- global aggregates (0 grouping keys) ------------------------
-// Locks #111 Bug 2: these previously SIGSEGV'd in
-// PhysicalHashAggregate::Sink under Linux x86_64 across every column /
-// agg combination. Bug 1 (count(*) with 0 grouping keys) is still
-// open, so the cases below use count(t) instead.
+// Locks #111 Bug 1 (count(*) / sum(1) / count(1) with no grouping keys
+// — agg child references no input columns, so PruneUnusedComputedCols
+// pruned the only ProjectColumnar element to zero, returning NULL into
+// the parent GbAgg) and Bug 2 (Sink SIGSEGV on Linux x86_64).
 
-TEST_CASE("types: global count over node", "[types][agg][issue111][global-agg]") {
+TEST_CASE("types: global count over node / count(*) / count(literal)",
+          "[types][agg][issue111][global-agg]") {
     SKIP_IF_NO_TYPES_DB();
-    auto r = qr->run("MATCH (t:TypeRow) RETURN count(t) AS v",
-                     {qtest::ColType::INT64});
+    auto r = qr->run(
+        "MATCH (t:TypeRow) RETURN count(t) AS cn, count(*) AS cs, "
+        "count(1) AS c1, sum(1) AS s1",
+        {qtest::ColType::INT64, qtest::ColType::INT64,
+         qtest::ColType::INT64, qtest::ColType::INT64});
     REQUIRE(r.size() == 1);
     CHECK(r[0].int64_at(0) == 20);
+    CHECK(r[0].int64_at(1) == 20);
+    CHECK(r[0].int64_at(2) == 20);
+    CHECK(r[0].int64_at(3) == 20);
 }
 
 TEST_CASE("types: global sum / min / max over INTEGER",


### PR DESCRIPTION
## Summary

Closes Bug 1 of [#111](https://github.com/turbolynx-dslab/TurboLynx/issues/111). Stacked on [#114](https://github.com/turbolynx-dslab/TurboLynx/pull/114) (regression tests for Bug 2).

## Root cause

\`PexprPruneProjListProjectOrGbAgg\`'s ProjectColumnar branch had a leftover invariant from upstream ORCA:

\`\`\`cpp
else if(COperator::EopLogicalProjectColumnar == pop->Eopid()) {
    // In columnar, this cannot happen. At least one projection should be alive.
    GPOS_ASSERT(false);
}
\`\`\`

In release builds \`GPOS_ASSERT(false)\` is a no-op, so the function fell through with the local \`pexprResult\` still NULL. The caller plugged the NULL straight into the parent \`CLogicalGbAgg\`'s relational-child slot. The next preprocess pass invoked \`CNormalizer::PexprNormalize\`, which walks children unconditionally → \`"null child expression in normalizer"\` → \`ORCA optimizer error (major=1, minor=1)\`.

## Trigger

Aggregates whose child references no input columns, sitting above a ProjectColumnar that has no other consumers:

\`\`\`cypher
MATCH (n:NATION) RETURN count(*)        -- crash
MATCH (l:LINEITEM) RETURN sum(1)        -- crash
MATCH (l:LINEITEM) RETURN count(1)      -- crash
\`\`\`

Adding a \`WHERE\` (keeps another column alive) or a grouping key (puts that column in \`pcrsReqd\`) masks the bug — which is why TPC-H queries (all have GROUP BY) and the LDBC suite (all have filters) never tripped it.

## Fix

Mirror the existing \`LogicalProject\` branch one above: when every defined column is unused, drop the project node and surface its relational child to the parent. The defined columns are unused by definition, so removing the rename layer is value-preserving. The exact same class of bug was patched once before for \`LogicalUnionAll\` (~line 2347 of the same file) — that comment was the breadcrumb that pinpointed this one.

\`\`\`cpp
if (COperator::EopLogicalProject == pop->Eopid() ||
    COperator::EopLogicalProjectColumnar == pop->Eopid())
{
    pexprRelationalNew = PexprPruneUnusedComputedColsRecursive(
        mp, pexprRelational, pcrsReqdNew);
    pexprResult = pexprRelationalNew;
}
\`\`\`

## Out of scope

The 10-year-old TODO at line 2523 — \"if there is no grouping cols, we could remove the entire GbAgg and plug in a ConstTableGet instead\" — is a separate optimization (catalog-cardinality lookup). Tracked as [#115](https://github.com/turbolynx-dslab/TurboLynx/issues/115). The current fix is correctness-only; it still runs the scan + agg, just without crashing.

## Test plan
- [x] Bug 1 reproducers from #111 all return correct values
- [x] \`query_test "[issue111][global-agg]"\` — 9/9 cases / 38 assertions pass on macOS
- [x] \`query_test "[tpch]~[broken-mini]~[stress]"\` — 49 cases / 818 assertions pass
- [x] \`query_test "[ldbc]"\` — 1428 / 1562 (unchanged baseline)
- [x] \`unittest\` — 200 cases / 770 assertions pass
- [ ] Linux CI green (Bug 2 was Linux-only — this Bug 1 reproduces on both, but CI is the canonical signal)