### PR TITLE
converter: promote int literals to column type in numeric comparisons

### DIFF
--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -566,40 +566,91 @@ CExpression *Cypher2OrcaConverter::ConvertComparison(const CypherBoundComparison
                      : CUtils::PexprIsNotNull(mp_, child);
     }
 
-    CExpression *lhs, *rhs;
+    CExpression *lhs = ConvertExpression(*l_expr, plan);
+    CExpression *rhs = ConvertExpression(*r_expr, plan);
+
+    // Literal-side type promotion within the numeric category. Cypher's
+    // "numerical order" rule means `5 < 5.5` and `id <= 5` must compare
+    // correctly across INTEGER and FLOAT / DuckDB's UBIGINT / DECIMAL.
+    // The literal is parsed with its narrowest fitting type (e.g. INT
+    // for `5`); when paired with a wider column type, downstream
+    // consumers — notably planner_physical's range-filter pushdown via
+    // `Value::MinimumValue(literal_type)` — observe the literal's OID
+    // and produce a degenerate range (e.g. INT_MIN reinterpreted as a
+    // huge unsigned on a UBIGINT :ID column wipes out `<` / `<=`).
+    //
+    // We restrict promotion to (1) only the literal side, and (2) only
+    // when the column type is the wider numeric (LCT == column_type),
+    // so the cast is always lossless. Column-side and same-LogicalTypeId
+    // (e.g. DECIMAL(12,2) vs DECIMAL(10,2)) cases are deferred to ORCA's
+    // own `GetScCmpMdIdConsiderCasts`, which knows how to find an
+    // appropriate cmp function across types without relying on the
+    // catalog's `Pmdcast` table (which is sparsely populated for some
+    // pairs like DECIMAL → DOUBLE).
+    //
+    // Non-numeric category mismatches (STRING vs INT, DATE vs INT) are
+    // left alone; Cypher's graceful NULL/FALSE behavior there is closer
+    // to the current path and is a separate concern.
+    // Scope limited to the integer family for this pass. DECIMAL /
+    // FLOAT / DOUBLE participate in numeric comparisons too, but
+    // promoting them here would activate latent bugs in the storage
+    // pruning path (extent_iterator.cpp's DECIMAL filter helpers read
+    // the *semantic* value via `GetValue<int64_t>` instead of the
+    // unscaled internal integer). Those paths are tracked separately;
+    // for the float/decimal family the previous behavior — ORCA's own
+    // `CMDAccessorUtils::GetScCmpMdIdConsiderCasts` inserting an
+    // implicit cast — is preserved untouched.
+    auto is_integer = [](LogicalTypeId id) {
+        switch (id) {
+        case LogicalTypeId::TINYINT:   case LogicalTypeId::SMALLINT:
+        case LogicalTypeId::INTEGER:   case LogicalTypeId::BIGINT:
+        case LogicalTypeId::HUGEINT:
+        case LogicalTypeId::UTINYINT:  case LogicalTypeId::USMALLINT:
+        case LogicalTypeId::UINTEGER:  case LogicalTypeId::UBIGINT:
+            return true;
+        default:
+            return false;
+        }
+    };
+    auto rebuild_literal_as = [&](const BoundExpression &src,
+                                   const LogicalType &target) -> CExpression * {
+        const Value &raw =
+            static_cast<const BoundLiteralExpression &>(src).GetValue();
+        Value casted;
+        string err;
+        if (raw.TryCastAs(target, casted, &err, false)) {
+            BoundLiteralExpression rebuilt(std::move(casted), src.GetUniqueName());
+            return ConvertLiteral(rebuilt);
+        }
+        return nullptr;  // unsupported cast — caller falls back
+    };
+    {
+        LogicalType l_type = LogicalTypeFromCExpr(lhs);
+        LogicalType r_type = LogicalTypeFromCExpr(rhs);
+        bool l_is_lit = (l_expr->GetExprType() == BoundExpressionType::LITERAL);
+        bool r_is_lit = (r_expr->GetExprType() == BoundExpressionType::LITERAL);
+        if (is_integer(l_type.id()) && is_integer(r_type.id()) &&
+            l_type.id() != r_type.id() && (l_is_lit ^ r_is_lit)) {
+            LogicalType lct = LogicalType::MaxLogicalType(l_type, r_type);
+            if (l_is_lit && lct.id() == r_type.id()) {
+                if (CExpression *promoted = rebuild_literal_as(*l_expr, r_type)) {
+                    lhs = promoted;
+                }
+            } else if (r_is_lit && lct.id() == l_type.id()) {
+                if (CExpression *promoted = rebuild_literal_as(*r_expr, l_type)) {
+                    rhs = promoted;
+                }
+            }
+        }
+    }
+
+    // Const-on-left → swap+flip so the predicate has the canonical
+    // ident/const orientation downstream consumers expect.
     bool swap = false;
-
-    bool l_is_lit = (l_expr->GetExprType() == BoundExpressionType::LITERAL);
-    bool r_is_lit = (r_expr->GetExprType() == BoundExpressionType::LITERAL);
-
-    if (l_is_lit && !r_is_lit) {
-        // Build RHS first to determine target type for literal
-        rhs = ConvertExpression(*r_expr, plan);
-        OID target_oid = GetTypeOidFromCExpr(rhs);
-        // Re-build LHS literal with the same type as RHS for type matching
-        lhs = ConvertLiteral(static_cast<const BoundLiteralExpression &>(*l_expr));
-        swap = true;  // const on left → swap operands
-    } else if (!l_is_lit && r_is_lit) {
-        lhs = ConvertExpression(*l_expr, plan);
-        rhs = ConvertLiteral(static_cast<const BoundLiteralExpression &>(*r_expr));
-    } else {
-        lhs = ConvertExpression(*l_expr, plan);
-        rhs = ConvertExpression(*r_expr, plan);
-    }
-
-    // If literal was on the left, swap operands so const is on the right
-    if (swap) {
-        std::swap(lhs, rhs);
-    }
-
-    // Check if const is still on left after potential swap → swap+flip
-    bool const_on_left = (lhs->Pop()->Eopid() == COperator::EopScalarConst &&
-                          rhs->Pop()->Eopid() == COperator::EopScalarIdent);
-    if (const_on_left) {
+    if (lhs->Pop()->Eopid() == COperator::EopScalarConst &&
+        rhs->Pop()->Eopid() == COperator::EopScalarIdent) {
         std::swap(lhs, rhs);
         swap = true;
-    } else {
-        swap = false;
     }
 
     IMDType::ECmpType cmp = MapCmpType(expr.GetCmpType(), swap);

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -550,6 +550,40 @@ TEST_CASE("Issue #111 — global aggregates over NATION",
     CHECK(r[0].str_at(3) == "VIETNAM");
 }
 
+// Range cmp on UBIGINT :ID columns. Pre-fix `<` / `<=` returned 0
+// because the planner derived range bounds from the literal's INT type,
+// and INT_MIN reinterpreted in the UBIGINT domain wiped the entire
+// match set.
+TEST_CASE("Range cmp on UBIGINT :ID column",
+          "[tpch][cmp][cmp-int]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (n:NATION) WHERE n.N_NATIONKEY <= 5 RETURN count(n) AS v",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 6);
+
+    r = qr->run(
+        "MATCH (n:NATION) WHERE n.N_NATIONKEY < 5 RETURN count(n) AS v",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 5);
+
+    r = qr->run(
+        "MATCH (n:NATION) WHERE n.N_NATIONKEY > 5 RETURN count(n) AS v",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 19);
+
+    // LINEITEM is multi-partition over UBIGINT L_ORDERKEY — exercises
+    // the multi-partition NodeScan range-filter path.
+    r = qr->run(
+        "MATCH (l:LINEITEM) WHERE l.L_ORDERKEY <= 5 RETURN count(l) AS v",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 17);
+}
+
 // Q8 — ETHIOPIA market-share within AFRICA, by ship year. Two rows
 // (1995 / 1996). Values verified against DuckDB SF0.01.
 TEST_CASE("TPC-H Q8 (rows)", "[tpch][q8]") {

--- a/test/query/test_types_correctness.cpp
+++ b/test/query/test_types_correctness.cpp
@@ -28,11 +28,6 @@ extern qtest::QueryRunner* get_types_runner();
 
 // ---------- baseline: per-type passthrough -----------------------------
 
-// Note: range comparisons on `t.id` (ID-typed primary key) currently
-// return zero rows on this fixture; equality works. Tests therefore
-// filter on `t.t_int` / `t.t_str` instead, which are regular property
-// columns. (This is an orthogonal issue tracked separately.)
-
 TEST_CASE("types: integer columns round-trip", "[types][passthru]") {
     SKIP_IF_NO_TYPES_DB();
     auto r = qr->run(
@@ -308,4 +303,73 @@ TEST_CASE("types: global min / max over VARCHAR",
     REQUIRE(r.size() == 1);
     CHECK(r[0].str_at(0) == "eight");
     CHECK(r[0].str_at(1) == "zero");
+}
+
+// ---------- comparisons across the integer family ----------------------
+// Locks the planner_physical range-pushdown bug: when a literal's
+// narrowest fitting type (e.g. INT for `5`) was paired with a wider
+// column type (e.g. UBIGINT :ID), `Value::MinimumValue(literal_type)`
+// produced INT_MIN, which reinterpreted to a huge unsigned in the
+// storage range comparator and wiped out `<` / `<=` (returned 0 rows).
+// The fix promotes the literal up to the column's logical type before
+// the cmp expression leaves the converter.
+
+TEST_CASE("types: range cmp on :ID-typed column",
+          "[types][cmp][cmp-int]") {
+    SKIP_IF_NO_TYPES_DB();
+    // 20 rows, t.id ∈ {1..20}. Pre-fix every `<` / `<=` returned 0.
+    auto r = qr->run(
+        "MATCH (t:TypeRow) WHERE t.id <= 5 RETURN count(t) AS v",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 5);
+
+    r = qr->run("MATCH (t:TypeRow) WHERE t.id < 5 RETURN count(t) AS v",
+                {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 4);
+
+    r = qr->run("MATCH (t:TypeRow) WHERE t.id > 5 RETURN count(t) AS v",
+                {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 15);
+
+    r = qr->run("MATCH (t:TypeRow) WHERE t.id >= 5 RETURN count(t) AS v",
+                {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 16);
+}
+
+TEST_CASE("types: range cmp with literal on the left "
+          "(swap-and-flip path)",
+          "[types][cmp][cmp-int]") {
+    SKIP_IF_NO_TYPES_DB();
+    // 5 >= t.id  ↔  t.id <= 5 — exercises the converter's swap+flip
+    // path so that const-on-left also promotes through the literal arm.
+    auto r = qr->run(
+        "MATCH (t:TypeRow) WHERE 5 >= t.id RETURN count(t) AS v",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 5);
+
+    r = qr->run("MATCH (t:TypeRow) WHERE 5 < t.id RETURN count(t) AS v",
+                {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 15);
+}
+
+TEST_CASE("types: integer cmp across signed widths",
+          "[types][cmp][cmp-int]") {
+    SKIP_IF_NO_TYPES_DB();
+    // t_long is BIGINT; literal `5` parses to INT. Pre-fix this worked
+    // by accident (BIGINT range covers INT range, MaximumValue(INT)
+    // didn't truncate the dataset); the case is locked here so the
+    // promotion path doesn't silently degrade.
+    auto r = qr->run(
+        "MATCH (t:TypeRow) WHERE t.t_long <= 5 RETURN count(t) AS v",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    // t_long values <= 5: row 1=0, 2=1, 3=-1, 7=-1000, 9=2, 10=3, 11=4,
+    // 12=5 → 8 rows.
+    CHECK(r[0].int64_at(0) == 8);
 }


### PR DESCRIPTION
## Problem

\`\`\`cypher
MATCH (n:NATION) WHERE n.N_NATIONKEY <= 5 RETURN count(n)   -- returns 0 (expected 6)
MATCH (n:NATION) WHERE n.N_NATIONKEY < 5  RETURN count(n)   -- returns 0 (expected 5)
\`\`\`

\`<\` / \`<=\` on a UBIGINT (or any wider unsigned) :ID column with a small INT literal returned 0 rows. \`>\` / \`>=\` / \`=\` / \`<>\` all worked.

## Root cause

`planner_physical.cpp` derives the open-ended range-filter bound via:

\`\`\`cpp
duckdb::Value::MinimumValue(literal_val.type())
\`\`\`

The literal \`5\` parses to INT (signed). \`MinimumValue(INT)\` is INT_MIN (-2147483648), which the storage range comparator reinterprets as a huge unsigned in the UBIGINT domain — wiping out the entire match set. \`MaximumValue(INT)\` happens to fall inside the UBIGINT range we exercise, so the \`>\` / \`>=\` direction was undetectably wrong (works by luck).

Any non-trivial WHERE filter or grouping key masked the bug, because ORCA rewrote the comparison through \`CScalarCast\` and the predicate fell out of the simple-pushdown path (executor path is correct).

## Fix

In \`ConvertComparison\` ([cypher2orca_scalar.cpp:542](src/converter/cypher2orca_scalar.cpp:542)): when one side is a literal, the other a column, and both are in the integer family with the column the strictly wider type, rebuild the literal with the column's type before handing the expression to ORCA. Downstream consumers then see a literal whose OID matches the column's, and \`MinimumValue\` / \`MaximumValue\` are well-defined.

\`\`\`cpp
auto is_integer = [](LogicalTypeId id) { /* TINYINT … HUGEINT, signed+unsigned */ };
if (is_integer(l_type.id()) && is_integer(r_type.id()) &&
    l_type.id() != r_type.id() && (l_is_lit ^ r_is_lit)) {
    LogicalType lct = LogicalType::MaxLogicalType(l_type, r_type);
    if (r_is_lit && lct.id() == l_type.id()) rhs = rebuild_literal_as(*r_expr, l_type);
    // mirror for l_is_lit
}
\`\`\`

## Why integer-family only (this PR)

DECIMAL / FLOAT / DOUBLE participate in numeric comparisons too, and Cypher's \"numerical order\" rule would have them follow the same promotion principle. Extending the predicate to cover them activates **latent storage-side bugs** in [extent_iterator.cpp](src/storage/extent/extent_iterator.cpp)'s DECIMAL filter helpers (they read \`GetValue<int64_t>\` which returns the semantic value 24 instead of the unscaled internal 2400 that the column stores). On \`main\` those paths never run for cross-category cmps because ORCA inserts a cast and the predicate is routed through the executor; promoting in the converter routes it through the simple-filter pushdown instead, surfacing the latent bug.

Tracked separately as [#117](https://github.com/turbolynx-dslab/TurboLynx/issues/117). Once that lands, the \`is_integer\` predicate here can extend to DECIMAL / FLOAT / DOUBLE.

## Cypher-vs-DuckDB note

Neo4j's documented semantics is \"no implicit cast, type mismatch errors or returns NULL.\" Production behavior is more permissive: \`5 = 5.0\` is TRUE and \`5 < 5.5\` is TRUE — i.e. **numerical order within the number category**. This PR follows that production behavior (lossless widening within integers). Non-numeric category mismatches (STRING/DATE/BOOL vs number) are left at the existing behavior, which is close to Cypher's graceful NULL/FALSE.

## Test plan
- [x] \`[cmp-int]\` — 4 cases / 22 assertions, all pass
- [x] \`[tpch]~[broken-mini]~[stress]\` — 50/50 cases, 826 assertions (was 49/818, no regression)
- [x] \`[types]\` — 23/20 cases, 92 assertions (was 20/78, no regression)
- [x] \`[ldbc]\` — 1428/1562 (baseline unchanged, LDBC #1011 robustness DATE vs BIGINT case still graceful-fails)
- [x] \`unittest\` — 770/200 (unchanged)
- [ ] Linux CI green