### PR TITLE
labels() / keys(): stop treating lid==0 as a sentinel (#73)

### DIFF
--- a/src/function/scalar/nested_functions.cpp
+++ b/src/function/scalar/nested_functions.cpp
@@ -108,7 +108,10 @@ static uint64_t ResolveCurrentEntityPid(GraphMetaBindData &bind,
                                         uint64_t logical_id,
                                         const InsertBuffer **buf = nullptr,
                                         idx_t *row_idx = nullptr) {
-	if (!bind.context || !bind.context->db || logical_id == 0) {
+	// logical_id == 0 is a valid lid (first row of the first vertex partition),
+	// so don't gate on it. Genuine NULL inputs are filtered upstream via
+	// Value::IsNull() at the function entry.
+	if (!bind.context || !bind.context->db) {
 		if (buf) {
 			*buf = nullptr;
 		}
@@ -144,7 +147,7 @@ static uint64_t ResolveCurrentEntityPidByUserId(GraphMetaBindData &bind,
                                                 uint64_t user_id,
                                                 const InsertBuffer **buf = nullptr,
                                                 idx_t *row_idx = nullptr) {
-	if (!bind.context || !bind.context->db || user_id == 0) {
+	if (!bind.context || !bind.context->db) {
 		if (buf) {
 			*buf = nullptr;
 		}
@@ -216,13 +219,11 @@ static uint64_t ResolveCurrentEntityPidForMetaInput(
     const InsertBuffer **buf = nullptr, idx_t *row_idx = nullptr) {
 	auto pid = ResolveCurrentEntityPid(bind, input_id, buf, row_idx);
 	// PLAN.md Bug A: pid == 0 is the legitimate (extent 0, row 0) disk slot
-	// the first checkpointed row of the first vertex partition lands on. The
-	// previous `pid != 0` gate skipped the partition lookup for that row,
-	// causing labels()/keys() to fall straight through to the user-id
-	// fallback (which fails because freshly bootstrapped nodes have no `id`
-	// field) and return an empty list. Gate on the lid's liveness instead so
-	// pid == 0 keeps driving the partition_id extraction.
-	bool lid_alive = bind.context && bind.context->db && input_id != 0 &&
+	// the first checkpointed row of the first vertex partition lands on, and
+	// input_id == 0 is the matching lid. Gate on deletion only so both keep
+	// driving the partition_id extraction. NULL inputs are filtered upstream
+	// at the function entry via Value::IsNull().
+	bool lid_alive = bind.context && bind.context->db &&
 	                 !bind.context->db->delta_store.IsLogicalIdDeleted(input_id);
 	if (lid_alive) {
 		auto logical_pid = (uint16_t)(((uint32_t)(pid >> 32)) >> 16);
@@ -255,10 +256,11 @@ static PartitionCatalogEntry *ResolveCurrentPartition(GraphMetaBindData &bind,
                                                       uint64_t logical_id,
                                                       GraphMetaEntityKind kind) {
 	auto current_pid = ResolveCurrentEntityPidForMetaInput(bind, logical_id, kind);
-	// PLAN.md Bug A: pid == 0 is the legitimate (extent 0, row 0) disk slot.
-	// Treat the lookup as failed only when the lid is dead, otherwise extract
-	// partition_id from the (possibly zero) pid.
-	bool lid_alive = bind.context && bind.context->db && logical_id != 0 &&
+	// PLAN.md Bug A: pid == 0 is the legitimate (extent 0, row 0) disk slot
+	// and logical_id == 0 is the matching lid. Treat the lookup as failed
+	// only when the lid is dead, otherwise extract partition_id from the
+	// (possibly zero) pid.
+	bool lid_alive = bind.context && bind.context->db &&
 	                 !bind.context->db->delta_store.IsLogicalIdDeleted(logical_id);
 	if (!lid_alive) {
 		return nullptr;
@@ -270,7 +272,7 @@ static PartitionCatalogEntry *ResolveCurrentPartition(GraphMetaBindData &bind,
 static vector<string> ResolveCurrentEntityKeys(GraphMetaBindData &bind,
                                                uint64_t logical_id,
                                                GraphMetaEntityKind kind) {
-	if (!bind.context || !bind.context->db || logical_id == 0) {
+	if (!bind.context || !bind.context->db) {
 		return {};
 	}
 
@@ -278,7 +280,9 @@ static vector<string> ResolveCurrentEntityKeys(GraphMetaBindData &bind,
 	idx_t row_idx = 0;
 	auto current_pid = ResolveCurrentEntityPidForMetaInput(bind, logical_id, kind,
 	                                                       &buf, &row_idx);
-	if (current_pid != 0 && buf && buf->IsValid(row_idx)) {
+	// pid == 0 is a legitimate slot (extent 0, row 0); use buf/row_idx to
+	// detect whether the meta-input lookup actually matched a delta row.
+	if (buf && buf->IsValid(row_idx)) {
 		auto &schema_keys = buf->GetSchemaKeys();
 		if (!schema_keys.empty()) {
 			vector<string> live_keys;
@@ -317,16 +321,18 @@ static void NodeLabelsFunction(DataChunk &args, ExpressionState &state,
 	auto &mask = FlatVector::Validity(result);
 
 	for (idx_t row = 0; row < count; row++) {
-		auto logical_id = GetLogicalIdFromValue(args.data[0].GetValue(row));
+		auto val = args.data[0].GetValue(row);
+		if (val.IsNull()) {
+			mask.SetInvalid(row);
+			continue;
+		}
+		auto logical_id = GetLogicalIdFromValue(val);
 		auto *part =
 		    ResolveCurrentPartition(bind, logical_id, GraphMetaEntityKind::NODE);
 		auto labels =
 		    part ? ExtractPartitionLabels(part->GetName()) : vector<string>{};
 		result_data[row] =
 		    StringVector::AddString(result, FormatStringList(labels));
-		if (logical_id == 0) {
-			mask.SetInvalid(row);
-		}
 	}
 }
 
@@ -340,13 +346,15 @@ static void EntityKeysNodeFunction(DataChunk &args, ExpressionState &state,
 	auto &mask = FlatVector::Validity(result);
 
 	for (idx_t row = 0; row < count; row++) {
-		auto logical_id = GetLogicalIdFromValue(args.data[0].GetValue(row));
+		auto val = args.data[0].GetValue(row);
+		if (val.IsNull()) {
+			mask.SetInvalid(row);
+			continue;
+		}
+		auto logical_id = GetLogicalIdFromValue(val);
 		auto keys =
 		    ResolveCurrentEntityKeys(bind, logical_id, GraphMetaEntityKind::NODE);
 		result_data[row] = StringVector::AddString(result, FormatStringList(keys));
-		if (logical_id == 0) {
-			mask.SetInvalid(row);
-		}
 	}
 }
 
@@ -360,13 +368,15 @@ static void EntityKeysRelFunction(DataChunk &args, ExpressionState &state,
 	auto &mask = FlatVector::Validity(result);
 
 	for (idx_t row = 0; row < count; row++) {
-		auto logical_id = GetLogicalIdFromValue(args.data[0].GetValue(row));
+		auto val = args.data[0].GetValue(row);
+		if (val.IsNull()) {
+			mask.SetInvalid(row);
+			continue;
+		}
+		auto logical_id = GetLogicalIdFromValue(val);
 		auto keys =
 		    ResolveCurrentEntityKeys(bind, logical_id, GraphMetaEntityKind::REL);
 		result_data[row] = StringVector::AddString(result, FormatStringList(keys));
-		if (logical_id == 0) {
-			mask.SetInvalid(row);
-		}
 	}
 }
 
@@ -434,13 +444,18 @@ static void NodeLabelAtFunction(DataChunk &args, ExpressionState &state,
 	auto &mask = FlatVector::Validity(result);
 
 	for (idx_t row = 0; row < count; row++) {
-		auto logical_id = GetLogicalIdFromValue(args.data[0].GetValue(row));
+		auto val = args.data[0].GetValue(row);
+		auto idx_val = args.data[1].GetValue(row);
+		if (val.IsNull() || idx_val.IsNull()) {
+			mask.SetInvalid(row);
+			continue;
+		}
+		auto logical_id = GetLogicalIdFromValue(val);
 		auto *part =
 		    ResolveCurrentPartition(bind, logical_id, GraphMetaEntityKind::NODE);
 		auto labels =
 		    part ? ExtractPartitionLabels(part->GetName()) : vector<string>{};
-		auto idx_val = args.data[1].GetValue(row);
-		if (logical_id == 0 || idx_val.IsNull() || labels.empty()) {
+		if (labels.empty()) {
 			mask.SetInvalid(row);
 			continue;
 		}
@@ -463,11 +478,16 @@ static void EntityKeyAtNodeFunction(DataChunk &args, ExpressionState &state,
 	auto &mask = FlatVector::Validity(result);
 
 	for (idx_t row = 0; row < count; row++) {
-		auto logical_id = GetLogicalIdFromValue(args.data[0].GetValue(row));
+		auto val = args.data[0].GetValue(row);
+		auto idx_val = args.data[1].GetValue(row);
+		if (val.IsNull() || idx_val.IsNull()) {
+			mask.SetInvalid(row);
+			continue;
+		}
+		auto logical_id = GetLogicalIdFromValue(val);
 		auto keys =
 		    ResolveCurrentEntityKeys(bind, logical_id, GraphMetaEntityKind::NODE);
-		auto idx_val = args.data[1].GetValue(row);
-		if (logical_id == 0 || idx_val.IsNull() || keys.empty()) {
+		if (keys.empty()) {
 			mask.SetInvalid(row);
 			continue;
 		}
@@ -490,11 +510,16 @@ static void EntityKeyAtRelFunction(DataChunk &args, ExpressionState &state,
 	auto &mask = FlatVector::Validity(result);
 
 	for (idx_t row = 0; row < count; row++) {
-		auto logical_id = GetLogicalIdFromValue(args.data[0].GetValue(row));
+		auto val = args.data[0].GetValue(row);
+		auto idx_val = args.data[1].GetValue(row);
+		if (val.IsNull() || idx_val.IsNull()) {
+			mask.SetInvalid(row);
+			continue;
+		}
+		auto logical_id = GetLogicalIdFromValue(val);
 		auto keys =
 		    ResolveCurrentEntityKeys(bind, logical_id, GraphMetaEntityKind::REL);
-		auto idx_val = args.data[1].GetValue(row);
-		if (logical_id == 0 || idx_val.IsNull() || keys.empty()) {
+		if (keys.empty()) {
 			mask.SetInvalid(row);
 			continue;
 		}

--- a/test/query/test_ldbc_functions.cpp
+++ b/test/query/test_ldbc_functions.cpp
@@ -85,10 +85,7 @@ static void ExecuteStatement(qtest::QueryRunner* qr, const char* query) {
     if (!qr) { FAIL("Cannot open DB: " << g_ldbc_path); return; } \
     DeltaGuard _delta_guard(qr)
 
-// `[!mayfail]`: on the SF0.003 mini fixture this currently returns an
-// empty string instead of the label list (issue #73). Tagged so a
-// regression here doesn't fail CI; remove the tag when #73 is fixed.
-TEST_CASE("labels() returns node label list", "[ldbc][func][meta][!mayfail]") {
+TEST_CASE("labels() returns node label list", "[ldbc][func][meta]") {
     SKIP_IF_NO_DB();
     try {
         auto q = sample_person_query(" RETURN labels(n) AS lbl");
@@ -115,11 +112,7 @@ TEST_CASE("type() returns relationship type", "[ldbc][func][meta]") {
     }
 }
 
-// `[!mayfail]`: on the SF0.003 mini fixture this currently returns an
-// empty string instead of the key list (issue #73 — same root cause as
-// labels()). Tagged so a regression here doesn't fail CI; remove the
-// tag when #73 is fixed.
-TEST_CASE("keys() returns property key names for node", "[ldbc][func][meta][!mayfail]") {
+TEST_CASE("keys() returns property key names for node", "[ldbc][func][meta]") {
     SKIP_IF_NO_DB();
     try {
         auto q = sample_person_query(" RETURN keys(n) AS k");


### PR DESCRIPTION
## Summary

Closes #73.

The first vertex partition's first row has a legitimate `logical_id` of 0 (e.g. LDBC mini `Person {id:14}` → `_id=0`), but the resolvers and function entries in `nested_functions.cpp` treated `lid==0` as a NULL sentinel. The existing PLAN.md Bug A comment already acknowledged this for `pid==0` but the `lid==0` gate was still in place, so \`labels()\`/\`keys()\` returned NULL for the first row of the first vertex partition.

- Drop the \`lid==0\` / \`input_id!=0\` / \`user_id==0\` preconditions in five resolvers — \`IsLogicalIdDeleted(lid)\` and the \`buf\`/\`row_idx\` outputs are already sufficient to detect dead lids and missing delta rows.
- Move the NULL-input check to the function entry via \`args.data[0].GetValue(row).IsNull()\` in six functions (\`NodeLabels\`/\`EntityKeys{Node,Rel}\` and their \`*_at\` index variants). Real \`lid==0\` resolves through the partition lookup; genuine NULL inputs still produce NULL.
- Remove the \`[!mayfail]\` tags from the two LDBC test cases (the inline comments asked for removal once #73 was fixed).

> Stacked on #118 (\`fix-id-range-where\`). After #118 merges, retarget this PR's base to \`main\`.

## Test plan
- [x] \`MATCH (n:Person {id:14}) RETURN labels(n), keys(n)\` → \`[\"Person\"]\`, \`[\"creationDate\", \"deletionDate\", ...]\`
- [x] \`OPTIONAL MATCH (...)-[:KNOWS]->(f {id:99999999}) RETURN labels(f) IS NULL\` → TRUE (NULL still detected)
- [x] \`labels(null)\` literal → binder error \"requires a node variable\" (unchanged)
- [x] macOS: \`[tpch]\` 833/0, \`[types]\` 95/0, \`[ldbc]\` 1562/126 fail (unchanged), \`unittest\` 770/0
- [ ] Linux CI