### PR TITLE
UNWIND []: stop crashing on empty-list / ANY element type (#76)

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -610,7 +610,18 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanUnwindClause(
         release_elem_mdid = true;
     };
     if (unwind_type.id() == LogicalTypeId::LIST) {
-        make_elem_mdid(ListType::GetChildType(unwind_type));
+        auto child_type = ListType::GetChildType(unwind_type);
+        // Empty / untyped list literals (e.g. `UNWIND [] AS x`) carry an
+        // ANY/UNKNOWN element type that has no MDAccessor entry, so
+        // RetrieveType() below would crash. The list is guaranteed empty,
+        // so the colref's element type is purely structural — default to
+        // BIGINT (matching the fallback in list_extract / list_slice).
+        if (child_type.id() == LogicalTypeId::ANY ||
+            child_type.id() == LogicalTypeId::UNKNOWN ||
+            child_type.id() == LogicalTypeId::SQLNULL) {
+            child_type = LogicalType::BIGINT;
+        }
+        make_elem_mdid(child_type);
     }
 
     INT list_mod = scalar_op->TypeModifier();

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -219,24 +219,13 @@ TEST_CASE("UNWIND string list", "[ldbc][filter][unwind]") {
     CHECK(r[1].str_at(0) == ldbc::SAMPLE_COUNTRY_NAME_2);
 }
 
-// Gated SF1-only: on the SF0.003 mini fixture this query SIGSEGVs
-// inside the engine (issue #76). A try/catch cannot intercept a
-// segfault — Catch2 sees the process die and stops scheduling further
-// cases — so we exclude the case from the mini build entirely until
-// #76 is fixed. SF1 dev runs still exercise it (was passing pre-migration).
-#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
 TEST_CASE("UNWIND empty list", "[ldbc][filter][unwind]") {
     SKIP_IF_NO_DB();
-    try {
-        auto r = qr->run(
-            "UNWIND [] AS x RETURN x",
-            {qtest::ColType::INT64});
-        CHECK(r.size() == 0);
-    } catch (...) {
-        SUCCEED();
-    }
+    auto r = qr->run(
+        "UNWIND [] AS x RETURN x",
+        {qtest::ColType::INT64});
+    CHECK(r.size() == 0);
 }
-#endif
 
 TEST_CASE("UNWIND null produces zero rows", "[ldbc][filter][unwind]") {
     SKIP_IF_NO_DB();


### PR DESCRIPTION
## Summary

Closes #76.

\`PlanUnwindClause\` built the output colref's element type from the bound list's element type, but \`UNWIND [] AS x\` binds to \`LIST(ANY)\` — and the MDAccessor has no entry for \`ANY\`, so \`GetMDAccessor()->RetrieveType(ANY_mdid)\` SIGSEGVed during plan construction (the crash happened before the \`[LOGICAL PLAN]\` trace even printed).

An empty list produces no output rows regardless of element type, so the colref's element type is purely structural. Default \`ANY\` / \`UNKNOWN\` / \`SQLNULL\` element types to \`BIGINT\` — matching the existing fallback in the \`list_extract\` / \`list_slice\` paths in \`cypher2orca_scalar.cpp\`.

Un-gates the existing #76 reproducer (\`UNWIND empty list\` in \`test_ldbc_filter.cpp\`); it now runs cleanly on the SF0.003 mini fixture without the segfault-shield wrapper.

> Stacked on #119 (\`fix-issue73-labels-keys\`), which is stacked on #118 (\`fix-id-range-where\`). Retarget to \`main\` after parents merge.

## Test plan
- [x] \`UNWIND [] AS x RETURN x\` → 0 rows
- [x] \`WITH [] AS xs UNWIND xs AS x RETURN x\` → 0 rows
- [x] \`UNWIND [1,2,3] AS x RETURN x\` → 3 rows (sanity, unchanged)
- [x] \`UNWIND null AS x RETURN count(*)\` → 0 (sanity, unchanged)
- [x] macOS: \`[tpch]\` 833/0, \`[types]\` 95/0, \`[ldbc]\` 1563/126 fail (unchanged), \`unittest\` 770/0
- [ ] Linux CI