### PR TITLE
UNWIND: reject property references with non-LIST type (#80)

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -585,14 +585,22 @@ unique_ptr<BoundUnwindClause> Binder::BindUnwindClause(const UnwindClause& unwin
     // UNWIND requires a LIST-typed expression. Reject clearly-scalar inputs with
     // a clean error in the binder instead of letting PhysicalUnwind assert on
     // ListValue::GetChildren at runtime (value.cpp:1546). ANY and SQLNULL are
-    // allowed through: ANY means the type will be resolved later (e.g. list
-    // literals before element-type inference), and SQLNULL supports the valid
-    // `UNWIND null AS x` idiom.
+    // allowed only when the parsed expression isn't a property access: the
+    // literal `UNWIND null` idiom, function calls returning ANY, and variables
+    // aliased by an earlier WITH all stay supported. A property reference
+    // (e.g. `UNWIND p.speaks`) is rejected for any non-LIST type — including
+    // the SQLNULL fallback that LookupPropertyOnNode returns for unknown keys
+    // (issue #80). We check the parsed AST directly because the catalog-miss
+    // path collapses to a BoundLiteralExpression, hiding the property origin
+    // in the bound tree.
     const auto& dtype = expr->GetDataType();
     const auto tid = dtype.id();
-    const bool is_list_like = (tid == LogicalTypeId::LIST ||
-                               tid == LogicalTypeId::ANY ||
-                               tid == LogicalTypeId::SQLNULL);
+    const bool is_property_ref =
+        dynamic_cast<const ParsedPropertyExpression*>(unwind.GetExpression()) != nullptr;
+    const bool is_list_like =
+        (tid == LogicalTypeId::LIST ||
+         (!is_property_ref && (tid == LogicalTypeId::ANY ||
+                               tid == LogicalTypeId::SQLNULL)));
     if (!is_list_like) {
         throw BinderException(
             "UNWIND expression must be of LIST type, but got " +

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -32,20 +32,14 @@ extern qtest::QueryRunner* get_ldbc_runner();
 
 // ============================================================
 // Regression: UNWIND on a scalar must not crash (was value.cpp:1546)
-// ============================================================
-// Gated SF1-only: on the SF0.003 mini fixture the binder does not
-// reject this query (issue #80) — likely because Person.speaks ends
-// up with a different type encoding under the mini load path. The
-// regression is specifically about the SF1 VARCHAR-stored-as-list
-// path; we keep it for SF1 dev and exclude it from the mini suite.
-#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
 TEST_CASE("R1 UNWIND on VARCHAR property returns clean binder error",
           "[ldbc][robustness][regression][unwind]") {
     SKIP_IF_NO_DB();
     // Person.speaks is stored as a ';'-joined VARCHAR (not a real LIST) on
-    // the LDBC SF1 load path. Previously UNWIND p.speaks hit an assertion in
-    // ListValue::GetChildren at runtime; now the binder rejects the query
-    // with a clean BinderException.
+    // the LDBC SF1 load path; on the SF0.003 mini fixture the column is
+    // absent and the binder used to fall back to SQLNULL, slipping through
+    // the LIST guard. The binder now rejects any property reference whose
+    // type is not LIST regardless of fixture (issue #80).
     bool caught = false;
     try {
         qr->run("MATCH (p:Person) WHERE p.firstName = '" SAMPLE_FN_MATCH_LITERAL
@@ -53,7 +47,6 @@ TEST_CASE("R1 UNWIND on VARCHAR property returns clean binder error",
     } catch (const std::exception&) { caught = true; }
     REQUIRE(caught);
 }
-#endif
 
 TEST_CASE("R2 UNWIND on list literal still works",
           "[ldbc][robustness][regression][unwind]") {


### PR DESCRIPTION
## Summary

Closes #80 (the direct-property form). Follow-up issue/PR will cover the WITH-aliased variant.

\`LookupPropertyOnNode\` (\`binder.cpp:1882\`) collapses an unknown property key to \`BoundLiteralExpression(SQLNULL)\` to preserve Neo4j's NULL-on-unknown semantics for expression contexts like \`COALESCE(p.email, ...)\`. On the SF0.003 mini fixture \`Person.speaks\` isn't in the catalog at all, so \`UNWIND p.speaks AS lang\` reached the binder as a SQLNULL literal and slipped through the existing LIST-or-{ANY,SQLNULL} guard — the clause silently produced zero rows. SF1 has \`speaks\` declared as VARCHAR, so the guard fired there and the regression test was gated \`#ifndef TURBOLYNX_LDBC_FIXTURE_MINI\`.

Fix: inspect the parsed AST directly (\`ParsedPropertyExpression\`) rather than the bound expression's type tag. That preserves the property origin even when the binder later collapses the lookup to a literal. The guard now rejects any property reference whose type isn't LIST, regardless of fixture or catalog state.

Un-gates the R1 regression test.

> Stacked on #120 (\`fix-issue76-unwind-empty\`) → #119 (\`fix-issue73-labels-keys\`) → #118 (\`fix-id-range-where\`). Retarget after parents merge.

## Known limitation (follow-up)

\`WITH p.speaks AS xs UNWIND xs\` still slips through because the UNWIND target is a \`BoundVariableExpression\`, not a property reference at the parsed AST level. Carrying the property origin through WITH aliases requires tagging the source bound expression on the variable and propagating it through projection-list binding — separate PR to follow.

## Test plan
- [x] \`UNWIND p.speaks AS lang ...\` → BinderException (was: 0 rows)
- [x] \`UNWIND [1,2,3] AS x RETURN x\` → 3 rows (sanity, unchanged)
- [x] \`UNWIND null AS x RETURN count(*)\` → 0 (literal, unchanged)
- [x] \`UNWIND [] AS x RETURN x\` → 0 rows (#76 fix preserved)
- [x] macOS: \`[tpch]\` 833/0, \`[types]\` 95/0, \`[ldbc]\` 1564/126 fail (unchanged), \`unittest\` 770/0
- [ ] Linux CI