### PR TITLE
UNWIND: catch WITH-aliased property too (#80 follow-up)

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -595,8 +595,20 @@ unique_ptr<BoundUnwindClause> Binder::BindUnwindClause(const UnwindClause& unwin
     // in the bound tree.
     const auto& dtype = expr->GetDataType();
     const auto tid = dtype.id();
-    const bool is_property_ref =
+    // Direct property reference (`UNWIND p.speaks`) — caught at the parsed
+    // AST level so the SQLNULL fallback for unknown keys is also covered.
+    bool is_property_ref =
         dynamic_cast<const ParsedPropertyExpression*>(unwind.GetExpression()) != nullptr;
+    // Variable that aliases a property reference, possibly via a WITH chain
+    // (`WITH p.speaks AS xs UNWIND xs`, `WITH p.x AS a WITH a AS b UNWIND b`).
+    // BindProjectionBody propagates the property-origin mark through alias
+    // chains until the source is wrapped in an expression.
+    if (!is_property_ref) {
+        if (auto *var = dynamic_cast<const ParsedVariableExpression*>(
+                unwind.GetExpression())) {
+            is_property_ref = ctx.IsAliasPropertyRef(var->GetVariableName());
+        }
+    }
     const bool is_list_like =
         (tid == LogicalTypeId::LIST ||
          (!is_property_ref && (tid == LogicalTypeId::ANY ||
@@ -1573,6 +1585,23 @@ unique_ptr<BoundProjectionBody> Binder::BindProjectionBody(const ProjectionBody&
             // Always register alias — even for ANY-typed expressions (e.g., sum(expr)).
             // Downstream query parts need to resolve these aliases by name.
             ctx.AddAliasType(alias, bound_type);
+
+            // Propagate property-reference origin through alias chains.
+            // `WITH p.speaks AS xs` marks xs as property-aliased; a later
+            // `WITH xs AS ys` propagates the mark. BindUnwindClause uses
+            // this to reject `UNWIND xs` (issue #80 follow-up) the same
+            // way it rejects the direct `UNWIND p.speaks` form. Stop
+            // propagating once the alias is wrapped in a function or
+            // expression (e.g. `coalesce(xs, [])`) — at that point the
+            // user has explicitly handled the null/scalar case.
+            if (dynamic_cast<const ParsedPropertyExpression*>(item_expr.get())) {
+                ctx.MarkAliasAsPropertyRef(alias);
+            } else if (auto *src_var =
+                       dynamic_cast<const ParsedVariableExpression*>(item_expr.get())) {
+                if (ctx.IsAliasPropertyRef(src_var->GetVariableName())) {
+                    ctx.MarkAliasAsPropertyRef(alias);
+                }
+            }
             if (bound_type.id() == LogicalTypeId::PATH) {
                 ctx.AddPath(alias);
             }

--- a/src/include/binder/bind_context.hpp
+++ b/src/include/binder/bind_context.hpp
@@ -111,6 +111,20 @@ public:
 
     bool HasVar(const string& name) const { return HasNode(name) || HasRel(name) || HasPath(name); }
 
+    // ---- Property-origin tracking for alias chains ----
+    // Marks aliases whose ultimate source is a node/rel property reference
+    // (e.g. `WITH p.speaks AS xs`). Used by BindUnwindClause to reject
+    // `UNWIND xs` for the same reason it rejects `UNWIND p.speaks`: the
+    // alias would carry a non-LIST property's value (or a SQLNULL fallback
+    // for unknown keys), which would silently produce zero rows.
+    void MarkAliasAsPropertyRef(const string& name) {
+        property_aliased_names_.insert(name);
+    }
+    bool IsAliasPropertyRef(const string& name) const {
+        if (property_aliased_names_.count(name)) return true;
+        return outer_ ? outer_->IsAliasPropertyRef(name) : false;
+    }
+
     // ---- All visible node/rel names (for RETURN *) ----
     vector<string> GetAllNodeNames() const {
         vector<string> result;
@@ -143,6 +157,7 @@ private:
     unordered_map<string, PathMeta> path_meta_;
     unordered_map<string, string> path_rels_aliases_;
     unordered_map<string, LogicalType> alias_types_;
+    unordered_set<string> property_aliased_names_;
     const BindContext* outer_ = nullptr;
 };
 

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -48,6 +48,31 @@ TEST_CASE("R1 UNWIND on VARCHAR property returns clean binder error",
     REQUIRE(caught);
 }
 
+TEST_CASE("R1b UNWIND on WITH-aliased property still throws",
+          "[ldbc][robustness][regression][unwind]") {
+    SKIP_IF_NO_DB();
+    // Issue #80 follow-up: `WITH p.speaks AS xs UNWIND xs` used to slip
+    // through because the UNWIND target is a BoundVariableExpression, not
+    // a property reference at the parsed AST level. BindProjectionBody now
+    // propagates the property-origin mark through alias chains so the
+    // BindUnwindClause guard fires the same way.
+    bool caught = false;
+    try {
+        qr->run("MATCH (p:Person) WHERE p.firstName = '" SAMPLE_FN_MATCH_LITERAL
+                "' WITH p.speaks AS xs UNWIND xs AS lang RETURN lang;");
+    } catch (const std::exception&) { caught = true; }
+    REQUIRE(caught);
+
+    // Two-hop alias chain: WITH xs AS ys should also propagate the mark.
+    caught = false;
+    try {
+        qr->run("MATCH (p:Person) WHERE p.firstName = '" SAMPLE_FN_MATCH_LITERAL
+                "' WITH p.speaks AS xs WITH xs AS ys UNWIND ys AS lang "
+                "RETURN lang;");
+    } catch (const std::exception&) { caught = true; }
+    REQUIRE(caught);
+}
+
 TEST_CASE("R2 UNWIND on list literal still works",
           "[ldbc][robustness][regression][unwind]") {
     SKIP_IF_NO_DB();


### PR DESCRIPTION
## Summary

Follow-up to #121. The direct form \`UNWIND p.speaks\` is now rejected at the parsed-AST level, but \`WITH p.speaks AS xs UNWIND xs\` still slipped through because the UNWIND target is a \`BoundVariableExpression\` — no property reference at parse time.

Propagate the property-reference origin through alias chains:

- \`BindContext\` gains a \`property_aliased_names_\` set with \`MarkAliasAsPropertyRef\` / \`IsAliasPropertyRef\` (outer-traversed like the other binding maps).
- \`BindProjectionBody\` marks an alias as property-origin when the source ParsedExpression is a \`ParsedPropertyExpression\`, and propagates the mark when the source is a \`ParsedVariableExpression\` whose name is already marked. Wrapping in a function (\`coalesce(xs, [...])\`, arithmetic, etc.) stops propagation — the user has explicitly handled the null/scalar case there.
- \`BindUnwindClause\` additionally rejects when the parsed target is a \`ParsedVariableExpression\` whose name is marked.

Adds R1b regression test covering one-hop (\`xs\`) and two-hop (\`xs → ys\`) alias chains.

> Stacked on #121 (\`fix-issue80-unwind-varchar\`) → #120 → #119 → #118.

## Test plan
- [x] \`WITH p.speaks AS xs UNWIND xs\` → BinderException (was: 0 rows)
- [x] \`WITH p.speaks AS xs WITH xs AS ys UNWIND ys\` → BinderException (chain propagation)
- [x] \`WITH p.speaks AS xs UNWIND coalesce(xs, [1,2])\` → accepted (mark stops at function wrap)
- [x] \`UNWIND null AS x RETURN count(*)\` → 0 (literal still works)
- [x] macOS: \`[tpch]\` 833/0, \`[types]\` 95/0, \`[ldbc]\` 1566/126 fail (unchanged failures), \`unittest\` 770/0
- [ ] Linux CI