### PR TITLE
ValidityMask: mask trailing bits in CheckAll* (#44)

### DIFF
--- a/src/include/common/types/validity_mask.hpp
+++ b/src/include/common/types/validity_mask.hpp
@@ -88,12 +88,23 @@ public:
 		if (AllValid()) {
 			return true;
 		}
-		idx_t entry_count = ValidityBuffer::EntryCount(count);
-		idx_t valid_count = 0;
-		for (idx_t i = 0; i < entry_count; i++) {
-			valid_count += validity_mask[i] == ValidityBuffer::MAX_ENTRY;
+		// Full entries: compare against MAX_ENTRY directly.
+		idx_t full_entries = count / BITS_PER_VALUE;
+		for (idx_t i = 0; i < full_entries; i++) {
+			if (validity_mask[i] != ValidityBuffer::MAX_ENTRY) return false;
 		}
-		return valid_count == entry_count;
+		// Partial trailing entry: only the low `trailing` bits are active —
+		// SetAllValid zeroes the unused bits, so a full-entry equality check
+		// would spuriously fail when the buffer's active rows are all valid.
+		idx_t trailing = count - full_entries * BITS_PER_VALUE;
+		if (trailing > 0) {
+			V active_mask =
+			    ValidityBuffer::MAX_ENTRY >> (BITS_PER_VALUE - trailing);
+			if ((validity_mask[full_entries] & active_mask) != active_mask) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	inline bool CheckAllValid(idx_t to, idx_t from) const {
@@ -112,9 +123,19 @@ public:
 		if (AllValid()) {
 			return false;
 		}
-		idx_t entry_count = ValidityBuffer::EntryCount(count);
-		for (idx_t i = 0; i < entry_count; i++) {
+		// Full entries: must be zero across the board.
+		idx_t full_entries = count / BITS_PER_VALUE;
+		for (idx_t i = 0; i < full_entries; i++) {
 			if (validity_mask[i] != 0) return false;
+		}
+		// Partial trailing entry: SetAllInvalid leaves unused bits set to 1,
+		// so a raw non-zero check would spuriously fail when the buffer's
+		// active rows are all invalid. Mask off the unused bits first.
+		idx_t trailing = count - full_entries * BITS_PER_VALUE;
+		if (trailing > 0) {
+			V active_mask =
+			    ValidityBuffer::MAX_ENTRY >> (BITS_PER_VALUE - trailing);
+			if ((validity_mask[full_entries] & active_mask) != 0) return false;
 		}
 		return true;
 	}

--- a/test/common/test_validity_mask.cpp
+++ b/test/common/test_validity_mask.cpp
@@ -1,0 +1,82 @@
+// =============================================================================
+// [validity-mask] CheckAllValid / CheckAllInValid trailing-bit handling
+// =============================================================================
+// Tag: [common][validity-mask]
+//
+// SetAllValid(count) / SetAllInvalid(count) only touch active bits inside
+// the last validity entry — unused trailing bits are left in the opposite
+// state (zero after SetAllValid, one after SetAllInvalid). The whole-entry
+// fast-path checks used to compare the entire entry, so a buffer whose
+// active rows were uniformly valid or invalid could fail the "all valid"
+// or "all invalid" check whenever `count` was not a multiple of 64.
+// Regression coverage for issue #44.
+// =============================================================================
+
+#include "catch.hpp"
+#include "common/types/validity_mask.hpp"
+
+using duckdb::ValidityMask;
+
+namespace {
+
+ValidityMask MakeMask(duckdb::idx_t count) {
+    return ValidityMask(count);
+}
+
+} // namespace
+
+TEST_CASE("ValidityMask: SetAllValid(count) → CheckAllValid is true",
+          "[common][validity-mask]") {
+    // Cover full entry (64), one trailing bit (65), one trailing bit in the
+    // first entry (63), and a full two-entry buffer (128).
+    for (duckdb::idx_t count : {(duckdb::idx_t)1, (duckdb::idx_t)63, (duckdb::idx_t)64,
+                                (duckdb::idx_t)65, (duckdb::idx_t)127,
+                                (duckdb::idx_t)128, (duckdb::idx_t)129}) {
+        INFO("count=" << count);
+        auto m = MakeMask(count);
+        m.SetAllValid(count);
+        CHECK(m.CheckAllValid(count));
+        CHECK_FALSE(m.CheckAllInValid(count));
+    }
+}
+
+TEST_CASE("ValidityMask: SetAllInvalid(count) → CheckAllInValid is true",
+          "[common][validity-mask]") {
+    for (duckdb::idx_t count : {(duckdb::idx_t)1, (duckdb::idx_t)63, (duckdb::idx_t)64,
+                                (duckdb::idx_t)65, (duckdb::idx_t)127,
+                                (duckdb::idx_t)128, (duckdb::idx_t)129}) {
+        INFO("count=" << count);
+        auto m = MakeMask(count);
+        m.SetAllInvalid(count);
+        CHECK(m.CheckAllInValid(count));
+        CHECK_FALSE(m.CheckAllValid(count));
+    }
+}
+
+TEST_CASE("ValidityMask: single invalid row breaks CheckAllValid",
+          "[common][validity-mask]") {
+    // Confirms the partial-entry path doesn't accidentally allow an active
+    // invalid bit to slip through.
+    for (duckdb::idx_t count : {(duckdb::idx_t)63, (duckdb::idx_t)64,
+                                (duckdb::idx_t)65, (duckdb::idx_t)128}) {
+        INFO("count=" << count);
+        auto m = MakeMask(count);
+        m.SetAllValid(count);
+        m.SetInvalid(count - 1);
+        CHECK_FALSE(m.CheckAllValid(count));
+        CHECK_FALSE(m.CheckAllInValid(count));
+    }
+}
+
+TEST_CASE("ValidityMask: single valid row breaks CheckAllInValid",
+          "[common][validity-mask]") {
+    for (duckdb::idx_t count : {(duckdb::idx_t)63, (duckdb::idx_t)64,
+                                (duckdb::idx_t)65, (duckdb::idx_t)128}) {
+        INFO("count=" << count);
+        auto m = MakeMask(count);
+        m.SetAllInvalid(count);
+        m.SetValid(count - 1);
+        CHECK_FALSE(m.CheckAllInValid(count));
+        CHECK_FALSE(m.CheckAllValid(count));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #44.

\`SetAllValid(count)\` zeroes the unused trailing bits in the final partial entry and \`SetAllInvalid(count)\` leaves them set to 1, so a whole-entry equality / non-zero check could spuriously fail for any \`count\` that wasn't a multiple of \`BITS_PER_VALUE\` (64). The all-null / all-valid fast paths in downstream operators could then mis-classify a buffer whose active rows were uniformly valid or invalid.

\`CheckAllValid(count)\` and \`CheckAllInValid(count)\` now:
- iterate the full entries \`[0, count/64)\` with a per-entry single-compare fast path — **and early-exit on the first mismatch** (the old code summed match counts and never early-exited)
- mask the final partial entry to the active bits before comparing, so unused trailing bits no longer poison the result

No performance regression: the only added work is a single shift + AND for the trailing entry when \`count % 64 != 0\`. The early-exit makes the common "not all valid / not all invalid" case meaningfully faster.

Adds \`test/common/test_validity_mask.cpp\` covering counts 1, 63, 64, 65, 127, 128, 129 across:
- \`SetAllValid → CheckAllValid\` is true / \`CheckAllInValid\` is false
- \`SetAllInvalid → CheckAllInValid\` is true / \`CheckAllValid\` is false
- A single \`SetInvalid(count-1)\` after \`SetAllValid\` breaks \`CheckAllValid\`
- A single \`SetValid(count-1)\` after \`SetAllInvalid\` breaks \`CheckAllInValid\`

> Stacked on #122 (\`fix-issue80-followup-alias\`) → #121 → #120 → #119 → #118.

## Test plan
- [x] New \`[validity-mask]\` cases: 44 assertions, all pass
- [x] macOS: \`unittest\` 204/814 (was 200/770; +44 from new tests), 0 fail
- [x] macOS: \`[tpch]\` 833/0, \`[types]\` 95/0, \`[ldbc]\` 1566/126 fail (unchanged)
- [ ] Linux CI