### PR TITLE
bulkload: close C API handles in PopulateLidToPidMap (#25)

### DIFF
--- a/src/loader/bulkload_pipeline.cpp
+++ b/src/loader/bulkload_pipeline.cpp
@@ -885,24 +885,45 @@ static inline void FillBwdAdjListBuffer(idx_t &begin_idx, idx_t &end_idx, idx_t 
 // ---------------------------------------------------------------------------
 
 static void PopulateLidToPidMap(BulkloadContext &bulkload_ctx, std::string &label_name, std::string &query, size_t num_id_columns) {
+    // Validate before allocating C API handles so the precondition check
+    // can't leak (issue #25).
+    if (num_id_columns > 2) throw InvalidInputException("Do not support # of compound keys >= 3 currently");
     spdlog::trace("[PopulateLidToPidMap] Query: {}", query);
-    turbolynx_prepared_statement* prep_stmt = turbolynx_prepare(bulkload_ctx.conn_id, const_cast<char*>(query.c_str()));
-    turbolynx_resultset_wrapper *resultset_wrapper;
-    turbolynx_num_rows rows = turbolynx_execute(bulkload_ctx.conn_id, prep_stmt, &resultset_wrapper);
+
+    turbolynx_prepared_statement *prep_stmt =
+        turbolynx_prepare(bulkload_ctx.conn_id, const_cast<char*>(query.c_str()));
+    if (!prep_stmt) {
+        throw InternalException(
+            "PopulateLidToPidMap: turbolynx_prepare failed for label " + label_name);
+    }
+    turbolynx_resultset_wrapper *resultset_wrapper = nullptr;
+    turbolynx_num_rows rows =
+        turbolynx_execute(bulkload_ctx.conn_id, prep_stmt, &resultset_wrapper);
+    if (rows == TURBOLYNX_ERROR) {
+        turbolynx_close_prepared_statement(prep_stmt);
+        throw InternalException(
+            "PopulateLidToPidMap: turbolynx_execute failed for label " + label_name);
+    }
     spdlog::trace("[PopulateLidToPidMap] Query returned {} rows", rows);
 
-    if (num_id_columns > 2) throw InvalidInputException("Do not support # of compound keys >= 3 currently");
+    try {
+        bulkload_ctx.lid_to_pid_map_index[label_name] = bulkload_ctx.lid_to_pid_map.size();
+        auto& lid_pid_map = bulkload_ctx.lid_to_pid_map.emplace_back(label_name, FlatHashMap<LidPair, idx_t, LidPairHash>()).second;
+        lid_pid_map.reserve(rows);
 
-    bulkload_ctx.lid_to_pid_map_index[label_name] = bulkload_ctx.lid_to_pid_map.size();
-    auto& lid_pid_map = bulkload_ctx.lid_to_pid_map.emplace_back(label_name, FlatHashMap<LidPair, idx_t, LidPairHash>()).second;
-    lid_pid_map.reserve(rows);
-
-    while (turbolynx_fetch_next(resultset_wrapper) != TURBOLYNX_END_OF_RESULT) {
-        uint64_t pid = turbolynx_get_id(resultset_wrapper, 0);
-        uint64_t id1 = turbolynx_get_uint64(resultset_wrapper, 1);
-        uint64_t id2 = (num_id_columns == 2) ? turbolynx_get_uint64(resultset_wrapper, 2) : 0;
-        lid_pid_map.emplace(LidPair(id1, id2), pid);
+        while (turbolynx_fetch_next(resultset_wrapper) != TURBOLYNX_END_OF_RESULT) {
+            uint64_t pid = turbolynx_get_id(resultset_wrapper, 0);
+            uint64_t id1 = turbolynx_get_uint64(resultset_wrapper, 1);
+            uint64_t id2 = (num_id_columns == 2) ? turbolynx_get_uint64(resultset_wrapper, 2) : 0;
+            lid_pid_map.emplace(LidPair(id1, id2), pid);
+        }
+    } catch (...) {
+        turbolynx_close_resultset(resultset_wrapper);
+        turbolynx_close_prepared_statement(prep_stmt);
+        throw;
     }
+    turbolynx_close_resultset(resultset_wrapper);
+    turbolynx_close_prepared_statement(prep_stmt);
 }
 
 static void PopulateLidToPidMap(FlatHashMap<LidPair, idx_t, LidPairHash> *lid_to_pid_map_instance, const vector<idx_t> &key_column_idxs, DataChunk &data, ExtentID new_eid) {


### PR DESCRIPTION
## Summary

Closes #25.

\`PopulateLidToPidMap\` (\`src/loader/bulkload_pipeline.cpp:864-883\`) prepared a statement and held a resultset wrapper for the duration of the lid→pid scan, but never released either. Bulkload calls this once per ID-bearing label / edge type, so handle state accumulates linearly with schema breadth and is multiplied across repeated loads.

- Move the \`num_id_columns > 2\` precondition check above the prepare call so it can't leak when the input is malformed.
- Treat \`turbolynx_prepare\` returning null and \`turbolynx_execute\` returning \`TURBOLYNX_ERROR\` as fatal: close any held handle and throw \`InternalException\` naming the label, instead of silently dereferencing a null resultset.
- Wrap the per-row fetch loop in try/catch so mid-loop exceptions (e.g. \`lid_pid_map.emplace\` OOM) still release the prepared statement and resultset before rethrowing.
- Close both handles on the normal exit path.

> Stacked on #123 (\`fix-issue44-validity-trailing\`) → #122 → #121 → #120 → #119 → #118.

## Verification status

The fix is verified **only by code inspection + behavioural regression** (\`unittest\` 204/814, \`[tpch]\` 833/0, \`[types]\` 95/0, \`[ldbc]\` 1566/126 fail — all unchanged from #123).

Runtime leak verification was attempted under ASan + LSan but the local environment could not run it:
- macOS \`AddressSanitizer\` returns *\"detect_leaks is not supported on this platform\"*
- The Linux repro container was unresponsive (Docker daemon stuck at OCI runtime level) and could not be revived without restarting Docker Desktop

A follow-up issue (#124) tracks adding an ASan/LSan CI variant so future leak-class fixes can be verified objectively.

## Test plan
- [x] macOS: \`unittest\` 204/814, \`[tpch]\` 833/0, \`[types]\` 95/0, \`[ldbc]\` 1566/126 fail (unchanged)
- [ ] Linux CI (behavioural)
- [ ] LSan verification (deferred — see #124)