### PR TITLE
chore: trim verbose comments in recently touched files

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -582,27 +582,19 @@ unique_ptr<BoundMatchClause> Binder::BindMatchClause(const MatchClause& match, B
 
 unique_ptr<BoundUnwindClause> Binder::BindUnwindClause(const UnwindClause& unwind, BindContext& ctx) {
     auto expr = BindExpression(*unwind.GetExpression(), ctx);
-    // UNWIND requires a LIST-typed expression. Reject clearly-scalar inputs with
-    // a clean error in the binder instead of letting PhysicalUnwind assert on
-    // ListValue::GetChildren at runtime (value.cpp:1546). ANY and SQLNULL are
-    // allowed only when the parsed expression isn't a property access: the
-    // literal `UNWIND null` idiom, function calls returning ANY, and variables
-    // aliased by an earlier WITH all stay supported. A property reference
-    // (e.g. `UNWIND p.speaks`) is rejected for any non-LIST type — including
-    // the SQLNULL fallback that LookupPropertyOnNode returns for unknown keys
-    // (issue #80). We check the parsed AST directly because the catalog-miss
-    // path collapses to a BoundLiteralExpression, hiding the property origin
-    // in the bound tree.
+    // Reject scalar UNWIND in the binder so the physical operator doesn't
+    // assert on a non-list value at runtime. ANY/SQLNULL stay allowed for
+    // `UNWIND null`, ANY-returning functions, and WITH-aliased variables.
+    //
+    // Property references are the exception: `UNWIND p.speaks` on an
+    // unknown key collapses to a literal SQLNULL during binding, hiding
+    // the property origin from the bound tree. We detect it on the parsed
+    // AST instead — directly via ParsedPropertyExpression, and through
+    // alias chains tracked in BindContext (#80, #80 follow-up).
     const auto& dtype = expr->GetDataType();
     const auto tid = dtype.id();
-    // Direct property reference (`UNWIND p.speaks`) — caught at the parsed
-    // AST level so the SQLNULL fallback for unknown keys is also covered.
     bool is_property_ref =
         dynamic_cast<const ParsedPropertyExpression*>(unwind.GetExpression()) != nullptr;
-    // Variable that aliases a property reference, possibly via a WITH chain
-    // (`WITH p.speaks AS xs UNWIND xs`, `WITH p.x AS a WITH a AS b UNWIND b`).
-    // BindProjectionBody propagates the property-origin mark through alias
-    // chains until the source is wrapped in an expression.
     if (!is_property_ref) {
         if (auto *var = dynamic_cast<const ParsedVariableExpression*>(
                 unwind.GetExpression())) {
@@ -1586,14 +1578,11 @@ unique_ptr<BoundProjectionBody> Binder::BindProjectionBody(const ProjectionBody&
             // Downstream query parts need to resolve these aliases by name.
             ctx.AddAliasType(alias, bound_type);
 
-            // Propagate property-reference origin through alias chains.
-            // `WITH p.speaks AS xs` marks xs as property-aliased; a later
-            // `WITH xs AS ys` propagates the mark. BindUnwindClause uses
-            // this to reject `UNWIND xs` (issue #80 follow-up) the same
-            // way it rejects the direct `UNWIND p.speaks` form. Stop
-            // propagating once the alias is wrapped in a function or
-            // expression (e.g. `coalesce(xs, [])`) — at that point the
-            // user has explicitly handled the null/scalar case.
+            // Propagate property-reference origin through WITH-alias chains
+            // so BindUnwindClause can reject `UNWIND xs` after `WITH p.speaks
+            // AS xs` (#80 follow-up). Propagation stops at any wrapper
+            // (function call, arithmetic) — wrapping signals the user has
+            // taken responsibility for the scalar/null case.
             if (dynamic_cast<const ParsedPropertyExpression*>(item_expr.get())) {
                 ctx.MarkAliasAsPropertyRef(alias);
             } else if (auto *src_var =
@@ -2923,15 +2912,12 @@ shared_ptr<BoundExpression> Binder::BindCaseExpression(const CaseExpression& exp
     if (expr.else_expr) {
         else_expr = BindExpression(*expr.else_expr, ctx);
     }
-    // Infer CASE return type as the SQL-standard least common type (LCT)
-    // across every THEN branch and the ELSE branch. The previous
-    // implementation picked the first non-NULL THEN type and silently
-    // dropped a wider ELSE — Q8's `CASE WHEN n=… THEN volume(DOUBLE)
-    // ELSE 0(INT) END` thus picked INT (because the THEN's `volume`
-    // column-reference reports ANY at bind time, falling through to the
-    // ELSE INT literal), and the surrounding SUM aggregated against
-    // INT-byte-reinterpreted DOUBLE values to produce 0 instead of the
-    // expected DOUBLE total (issue #97).
+    // CASE return type = LCT across every THEN + ELSE branch. The earlier
+    // first-non-NULL-THEN approach silently dropped wider ELSE types —
+    // e.g. THEN DOUBLE / ELSE 0(INT) inferred as INT, and a SUM over the
+    // result read the DOUBLE bytes as INT (#97). Skip ANY/UNKNOWN/SQLNULL
+    // during the join so column-refs that bind as ANY don't poison the
+    // inference.
     LogicalType result_type = LogicalType::ANY;
     auto promote = [&](const LogicalType& candidate) {
         auto cid = candidate.id();

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -2143,11 +2143,10 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanProjectionBody(
                 inner->SetAlias(tmp_alias);
                 agg_projs.push_back(inner);
                 // Resolve the new variable's LogicalType. The binder may
-                // leave the aggregate's data_type as ANY (e.g. max(x)
-                // where x is itself an alias of a previous-WITH agg);
-                // downstream scalar binders like BindDecimalRoundPrecision
-                // crash on a malformed DECIMAL/ANY input. Convert the agg
-                // through ORCA to recover the real type (#69).
+                // leave an aggregate's data_type as ANY when it derives
+                // from a previous-WITH agg; downstream scalar binders that
+                // expect a concrete DECIMAL would crash on the malformed
+                // input. Convert through ORCA to recover the real type (#69).
                 LogicalType resolved_lt = e->GetDataType();
                 if (resolved_lt.id() == LogicalTypeId::ANY ||
                     resolved_lt.id() == LogicalTypeId::UNKNOWN ||
@@ -2501,13 +2500,11 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanGroupBy(
             pre_arr->Append(GPOS_NEW(mp_) CExpression(
                 mp_, GPOS_NEW(mp_) CScalarProjectElement(mp_, new_colref), c_expr));
             prev_plan->getSchema()->appendColumn(cname, new_colref);
-            // Replace the aggregate's child with a variable pointing to the
-            // pre-projected column. Derive the new variable's type from the
-            // ORCA-resolved scalar (LogicalTypeFromCExpr) rather than the
-            // binder's data_type — for arithmetic like `a * (1 - b)` the
-            // binder leaves the result as ANY, which would later cause
-            // downstream agg binders (e.g. BindDecimalSum) to crash on
-            // missing TypeInfo (#69).
+            // Replace the agg's child with a variable for the pre-projected
+            // column. Type comes from the ORCA-resolved scalar, not the
+            // binder's data_type — the binder leaves compound arithmetic
+            // as ANY, which would crash downstream aggregate binders that
+            // need a resolved TypeInfo (#69).
             auto resolved_lt = LogicalTypeFromCExpr(c_expr);
             auto new_child = make_shared<BoundVariableExpression>(cname, resolved_lt, cname);
             // Reconstruct the aggregate with the new child

--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -569,37 +569,21 @@ CExpression *Cypher2OrcaConverter::ConvertComparison(const CypherBoundComparison
     CExpression *lhs = ConvertExpression(*l_expr, plan);
     CExpression *rhs = ConvertExpression(*r_expr, plan);
 
-    // Literal-side type promotion within the numeric category. Cypher's
-    // "numerical order" rule means `5 < 5.5` and `id <= 5` must compare
-    // correctly across INTEGER and FLOAT / DuckDB's UBIGINT / DECIMAL.
-    // The literal is parsed with its narrowest fitting type (e.g. INT
-    // for `5`); when paired with a wider column type, downstream
-    // consumers — notably planner_physical's range-filter pushdown via
-    // `Value::MinimumValue(literal_type)` — observe the literal's OID
-    // and produce a degenerate range (e.g. INT_MIN reinterpreted as a
-    // huge unsigned on a UBIGINT :ID column wipes out `<` / `<=`).
+    // Promote a narrow integer literal to the wider column type before
+    // handing the comparison to ORCA. Without this, the physical
+    // range-filter pushdown derives the open-ended bound from the literal
+    // type's MinimumValue — e.g. INT_MIN on a UBIGINT :ID column
+    // reinterprets as a huge unsigned and wipes out `<` / `<=` (#118).
     //
-    // We restrict promotion to (1) only the literal side, and (2) only
-    // when the column type is the wider numeric (LCT == column_type),
-    // so the cast is always lossless. Column-side and same-LogicalTypeId
-    // (e.g. DECIMAL(12,2) vs DECIMAL(10,2)) cases are deferred to ORCA's
-    // own `GetScCmpMdIdConsiderCasts`, which knows how to find an
-    // appropriate cmp function across types without relying on the
-    // catalog's `Pmdcast` table (which is sparsely populated for some
-    // pairs like DECIMAL → DOUBLE).
-    //
-    // Non-numeric category mismatches (STRING vs INT, DATE vs INT) are
-    // left alone; Cypher's graceful NULL/FALSE behavior there is closer
-    // to the current path and is a separate concern.
-    // Scope limited to the integer family for this pass. DECIMAL /
-    // FLOAT / DOUBLE participate in numeric comparisons too, but
-    // promoting them here would activate latent bugs in the storage
-    // pruning path (extent_iterator.cpp's DECIMAL filter helpers read
-    // the *semantic* value via `GetValue<int64_t>` instead of the
-    // unscaled internal integer). Those paths are tracked separately;
-    // for the float/decimal family the previous behavior — ORCA's own
-    // `CMDAccessorUtils::GetScCmpMdIdConsiderCasts` inserting an
-    // implicit cast — is preserved untouched.
+    // Scope is intentionally narrow:
+    //   - Literal side only. Column-side / same-LogicalTypeId cases stay
+    //     with ORCA's own cmp-cast resolver (it handles those via implicit
+    //     cast without consulting the catalog cast table).
+    //   - Column type must equal the LCT — guarantees a lossless cast.
+    //   - Integer family only. Extending to FLOAT/DECIMAL would expose a
+    //     latent bug in the storage-pruning helpers, which read DECIMAL
+    //     filter values via the semantic int64 accessor instead of the
+    //     unscaled internal representation.
     auto is_integer = [](LogicalTypeId id) {
         switch (id) {
         case LogicalTypeId::TINYINT:   case LogicalTypeId::SMALLINT:

--- a/src/function/scalar/nested_functions.cpp
+++ b/src/function/scalar/nested_functions.cpp
@@ -218,11 +218,10 @@ static uint64_t ResolveCurrentEntityPidForMetaInput(
     GraphMetaBindData &bind, uint64_t input_id, GraphMetaEntityKind kind,
     const InsertBuffer **buf = nullptr, idx_t *row_idx = nullptr) {
 	auto pid = ResolveCurrentEntityPid(bind, input_id, buf, row_idx);
-	// PLAN.md Bug A: pid == 0 is the legitimate (extent 0, row 0) disk slot
-	// the first checkpointed row of the first vertex partition lands on, and
-	// input_id == 0 is the matching lid. Gate on deletion only so both keep
-	// driving the partition_id extraction. NULL inputs are filtered upstream
-	// at the function entry via Value::IsNull().
+	// pid == 0 / input_id == 0 are legitimate values — the first row of
+	// the first vertex partition lands on (extent 0, row 0). Gate on
+	// liveness (deletion) only; NULL inputs are filtered at the function
+	// entry via Value::IsNull() (#73).
 	bool lid_alive = bind.context && bind.context->db &&
 	                 !bind.context->db->delta_store.IsLogicalIdDeleted(input_id);
 	if (lid_alive) {
@@ -256,10 +255,9 @@ static PartitionCatalogEntry *ResolveCurrentPartition(GraphMetaBindData &bind,
                                                       uint64_t logical_id,
                                                       GraphMetaEntityKind kind) {
 	auto current_pid = ResolveCurrentEntityPidForMetaInput(bind, logical_id, kind);
-	// PLAN.md Bug A: pid == 0 is the legitimate (extent 0, row 0) disk slot
-	// and logical_id == 0 is the matching lid. Treat the lookup as failed
-	// only when the lid is dead, otherwise extract partition_id from the
-	// (possibly zero) pid.
+	// pid == 0 is a legitimate slot; fail the lookup only when the lid
+	// itself is dead, otherwise extract partition_id from the (possibly
+	// zero) pid.
 	bool lid_alive = bind.context && bind.context->db &&
 	                 !bind.context->db->delta_store.IsLogicalIdDeleted(logical_id);
 	if (!lid_alive) {

--- a/src/include/binder/bind_context.hpp
+++ b/src/include/binder/bind_context.hpp
@@ -113,10 +113,10 @@ public:
 
     // ---- Property-origin tracking for alias chains ----
     // Marks aliases whose ultimate source is a node/rel property reference
-    // (e.g. `WITH p.speaks AS xs`). Used by BindUnwindClause to reject
-    // `UNWIND xs` for the same reason it rejects `UNWIND p.speaks`: the
-    // alias would carry a non-LIST property's value (or a SQLNULL fallback
-    // for unknown keys), which would silently produce zero rows.
+    // (e.g. `WITH p.speaks AS xs`). Lets the UNWIND binder reject aliased
+    // property refs the same way it rejects direct ones — the alias would
+    // carry the property's value (or a SQLNULL fallback for unknown keys)
+    // and silently produce zero rows (#80 follow-up).
     void MarkAliasAsPropertyRef(const string& name) {
         property_aliased_names_.insert(name);
     }

--- a/test/common/test_validity_mask.cpp
+++ b/test/common/test_validity_mask.cpp
@@ -1,16 +1,7 @@
-// =============================================================================
-// [validity-mask] CheckAllValid / CheckAllInValid trailing-bit handling
-// =============================================================================
-// Tag: [common][validity-mask]
-//
-// SetAllValid(count) / SetAllInvalid(count) only touch active bits inside
-// the last validity entry — unused trailing bits are left in the opposite
-// state (zero after SetAllValid, one after SetAllInvalid). The whole-entry
-// fast-path checks used to compare the entire entry, so a buffer whose
-// active rows were uniformly valid or invalid could fail the "all valid"
-// or "all invalid" check whenever `count` was not a multiple of 64.
-// Regression coverage for issue #44.
-// =============================================================================
+// Regression for issue #44: SetAllValid/SetAllInvalid only touch the
+// active bits of the last validity entry, but the whole-entry fast paths
+// in CheckAllValid/CheckAllInValid used to compare the full word. Counts
+// not aligned to 64 spuriously failed.
 
 #include "catch.hpp"
 #include "common/types/validity_mask.hpp"


### PR DESCRIPTION
## Summary

- Reduce multi-paragraph block comments added in PRs #118–#123 to short why-lines + scope/invariant notes.
- Drop verbatim query examples (TPC-H Q8, `BindDecimalSum`, file paths like `extent_iterator.cpp`) that would rot under rename/refactor. Keep issue-number breadcrumbs.
- Drop `PLAN.md Bug A:` references in `nested_functions.cpp` — `PLAN.md` no longer exists in the repo.
- Net: -44 lines across 6 files; no logic changes.

Style going forward (also captured in memory):
- One short comment that names the non-obvious *why*.
- Keep invariants and scope restrictions (they prevent future regressions).
- Avoid concrete internal identifiers — prefer roles ("downstream aggregate binders" vs `BindDecimalSum`).
- Long-form details belong in commit messages / PR descriptions.

## Test plan
- [x] `ninja -C build-portable` — clean rebuild green.
- [x] `./test/unittest` — 204/204, 814 assertions.
- [x] TPC-H mini — 54/54, 895 assertions.
- [x] LDBC mini — 358 passed, 126 failed (baseline unchanged; failures are deferred issues #79/#77/#90).