### PR TITLE
vector: stop propagating source's vector-wide invalid to append targets (#90)

### DIFF
--- a/src/common/vector_operations/vector_copy.cpp
+++ b/src/common/vector_operations/vector_copy.cpp
@@ -74,8 +74,16 @@ void VectorOperations::Copy(const Vector &source, Vector &target, const Selectio
 	         (src_pt == PhysicalType::INT64 && tgt_pt == PhysicalType::UINT64));
 	idx_t copy_count = source_count - source_offset;
 
-	if (!source.GetIsValid() && source_offset == 0) {
-		target.SetIsValid(false);
+	if (!source.GetIsValid()) {
+		// Source is wholly invalid. Mark only the affected range of
+		// target as per-row invalid — the previous fast path flipped
+		// target's vector-wide validity flag, which destroyed valid
+		// prefix rows when called from append-style consumers (e.g.
+		// list_aggregate's per-row ListVector::Append) (#90).
+		auto &tmask = FlatVector::Validity(target);
+		for (idx_t i = 0; i < copy_count; i++) {
+			tmask.SetInvalid(target_offset + i);
+		}
 		return;
 	}
 

--- a/test/common/test_vector_copy.cpp
+++ b/test/common/test_vector_copy.cpp
@@ -1,0 +1,59 @@
+// Regression for issue #90: VectorOperations::Copy used to propagate the
+// source's vector-wide invalid flag to the target by calling
+// target.SetIsValid(false). For append-style targets (e.g. list aggregate
+// state accumulating per-row inputs) this destroyed valid rows that had
+// already been appended.
+
+#include "catch.hpp"
+#include "common/types/vector.hpp"
+#include "common/vector_operations/vector_operations.hpp"
+
+using duckdb::FlatVector;
+using duckdb::idx_t;
+using duckdb::LogicalType;
+using duckdb::Value;
+using duckdb::Vector;
+using duckdb::VectorOperations;
+
+TEST_CASE("VectorOperations::Copy: wholly-invalid source preserves target's valid prefix",
+          "[common][vector-copy]") {
+    Vector source(LogicalType::VARCHAR);
+    source.SetIsValid(false);  // wholly invalid source
+
+    Vector target(LogicalType::VARCHAR);
+    target.SetValue(0, Value("first"));
+    target.SetValue(1, Value("second"));
+    REQUIRE(target.GetIsValid());
+
+    // Simulate an append: copy 1 row from source into target[2..3).
+    // Before the fix, this would call target.SetIsValid(false) and wipe
+    // out rows 0 and 1.
+    VectorOperations::Copy(source, target, /*source_count=*/1,
+                           /*source_offset=*/0, /*target_offset=*/2);
+
+    CHECK(target.GetIsValid());
+    CHECK(target.GetValue(0).ToString() == "first");
+    CHECK(target.GetValue(1).ToString() == "second");
+    CHECK(target.GetValue(2).IsNull());
+}
+
+TEST_CASE("VectorOperations::Copy: wholly-invalid source followed by valid source",
+          "[common][vector-copy]") {
+    // Mirrors list_aggregate's per-row append pattern: first input is a
+    // single NULL row, second input is a single valid row. The resulting
+    // list child must read [NULL, valid] — not [NULL, NULL].
+    Vector target(LogicalType::VARCHAR);
+
+    Vector src_null(LogicalType::VARCHAR);
+    src_null.SetIsValid(false);
+    VectorOperations::Copy(src_null, target, 1, 0, 0);
+
+    Vector src_val(LogicalType::VARCHAR);
+    src_val.SetValue(0, Value("photo.jpg"));
+    VectorOperations::Copy(src_val, target, 1, 0, 1);
+
+    CHECK(target.GetIsValid());
+    CHECK(target.GetValue(0).IsNull());
+    CHECK_FALSE(target.GetValue(1).IsNull());
+    CHECK(target.GetValue(1).ToString() == "photo.jpg");
+}


### PR DESCRIPTION
## Summary

`VectorOperations::Copy` had a fast path that, when the source vector was flagged wholly invalid (`!source.GetIsValid()` with `source_offset == 0`), copied that flag onto the target and returned. For append-style consumers — concretely `list_aggregate::ListUpdateFunction`'s per-row append into the list's child vector — this destroyed valid rows that had already been appended. A single NULL input on the first call made every subsequent value invisible, so `collect(...)` over an MPV scan with a sibling-only property collapsed to `[NULL, NULL, ...]` even though count/max on the same column saw real values.

Fix: mark only the affected slice of target as per-row invalid; never flip the target's vector-wide flag from inside `Copy`. The old fast path was O(1); the new code is O(copy_count) which is microseconds at typical batch sizes and never on the value-copy hot path.

## Scope

- Resolves the collect-over-MPV-property symptom of #90.
- The full IC7 query also depends on multi-hop join correctly preserving sibling-only properties; that is a separate bug in the id_seek / MPV pipeline and will be filed as a follow-up.

## Test plan

- [x] `test/common/test_vector_copy.cpp` — wholly-invalid source against a target with valid prefix; per-row append pattern.
- [x] `unittest` — 206/206 (823 assertions).
- [x] TPC-H mini — 54/54 (895 assertions).
- [x] LDBC mini — 358/488 passed, 126 baseline fails unchanged.
- [x] Manual: `MATCH (m:Message) WHERE m.id IN [Post_id, Comment_id] WITH collect({n: m.imageFile, c: m.content}) AS xs UNWIND xs AS w RETURN w.n, w.c;` returns correct per-row values (previously empty for Posts).

Stacked on #126 (chore-comment-cleanup). Retarget to `main` after #126 merges.