### PR TITLE
planner: preserve user-side types when expanding IdSeek MPV siblings (#128)

### DIFF
--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -3194,6 +3194,13 @@ void Planner::pExpandVirtualPartitionForIdSeek(
         primary_part && !primary_part->sub_partition_oids.empty()
         && !vp_it->second.empty();
 
+    // Snapshot the user-side types before the virtual-partition rewrite below
+    // clobbers scan_types[part_idx] with the first sub-partition's projection.
+    // Without this, the sibling loop downstream would re-read the clobbered
+    // SQLNULL entries and propagate them to every other sub-partition, even
+    // when those siblings do carry the property (#128).
+    auto orig_scan_types = scan_types[part_idx];
+
     if (is_virtual) {
         // Virtual partition: replace part_idx with first real sub.
         oids[part_idx] = vp_it->second[0];
@@ -3208,7 +3215,6 @@ void Planner::pExpandVirtualPartitionForIdSeek(
         for (duckdb::idx_t k = 0; k < first_key_names.size(); k++)
             first_name_pos[first_key_names[k]] = k;
 
-        auto orig_scan_types = scan_types[part_idx];
         auto orig_inner_col_map = inner_col_maps[part_idx];
         scan_projection_mapping[part_idx].clear();
         scan_types[part_idx].clear();
@@ -3267,7 +3273,13 @@ void Planner::pExpandVirtualPartitionForIdSeek(
                 auto nit = sib_name_pos.find(prop_name);
                 if (nit != sib_name_pos.end()) {
                     sib_scan_proj.push_back(nit->second + 1);
-                    sib_scan_types.push_back(scan_types[part_idx][ci]);
+                    // Use the pre-clobber type so sibling sub-partitions that
+                    // carry the property don't inherit the first sub's SQLNULL
+                    // placeholder (#128).
+                    sib_scan_types.push_back(
+                        ci < orig_scan_types.size()
+                            ? orig_scan_types[ci]
+                            : duckdb::LogicalType::SQLNULL);
                 } else {
                     sib_scan_proj.push_back(std::numeric_limits<uint64_t>::max());
                     sib_scan_types.push_back(duckdb::LogicalType::SQLNULL);

--- a/test/query/test_ldbc_traversal.cpp
+++ b/test/query/test_ldbc_traversal.cpp
@@ -210,6 +210,25 @@ TEST_CASE("Message properties via HAS_CREATOR", "[ldbc][traversal][mpv]") {
     CHECK(r[0].int64_at(0) == ldbc::TRAV_MESSAGES_AUTHORED_BY_SAMPLE_PERSON);
 }
 
+// Regression for issue #128: IdSeek through a join into a union-label
+// (`:Message` = Comment ∪ Post) used to drop sibling-only properties
+// because the virtual-partition rewrite clobbered scan_types[part_idx]
+// with the first sub-partition's projection, and later siblings
+// inherited those SQLNULL placeholders.
+TEST_CASE("Message sibling-only property via HAS_CREATOR join",
+          "[ldbc][traversal][mpv][issue-90]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (:Person)<-[:HAS_CREATOR]-(m:Message) "
+        "WHERE m.imageFile <> '' "
+        "RETURN m.id, m.imageFile "
+        "ORDER BY m.id ASC LIMIT 1",
+        {qtest::ColType::INT64, qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) > 0);
+    CHECK(r[0].str_at(1).find("photo") == 0);
+}
+
 TEST_CASE("Message IdSeek keeps same-seqno partitions separated", "[ldbc][traversal][mpv][idseek]") {
     SKIP_IF_NO_DB();
 


### PR DESCRIPTION
## Summary

`pTransformMpvForIdSeek`'s virtual-partition rewrite clobbered `scan_types[part_idx]` with the first sub-partition's projection — any key absent from that sub becomes SQLNULL. The sibling loop then read back the clobbered entry and propagated the same SQLNULL to every other sub-partition, even when those siblings did carry the property. ExtentIterator saw SQLNULL in its property-type table and emitted per-row NULL instead of reading the stored column.

Fix: snapshot the user-side `scan_types` into `orig_scan_types` before the rewrite, and use that pre-clobber view in the sibling loop. Behaviour for non-virtual partitions is unchanged.

## Scope

- Closes #128.
- Resolves the multi-hop join + MPV-union direct property access case (`MATCH (p:Person)<-[:HAS_CREATOR]-(m:Message) RETURN m.imageFile`).
- IC7 mini's column-5 / column-6 checks remain `[!mayfail]` because they depend on a separate empty-string-vs-NULL issue in content/imageFile loading. Will file/fix in a follow-up.

## Test plan

- [x] `test/query/test_ldbc_traversal.cpp` — "Message sibling-only property via HAS_CREATOR join" regression test.
- [x] `unittest` — 206/206 (823 assertions).
- [x] TPC-H mini — 54/54 (895 assertions).
- [x] LDBC mini — 358/488 passed, 126 baseline fails unchanged.
- [x] Manual: previously broken `MATCH (p:Person)<-[:HAS_CREATOR]-(m:Message {id: 137438954446}) RETURN m.imageFile;` returns `photo137438954446.jpg`.

Stacked on #127 (vector_copy fix). Retarget to `main` after the stack merges.