### PR TITLE
struct_extract: slice through DICTIONARY input; toFloat(INTERVAL) → ms (#90)

### DIFF
--- a/src/function/scalar/string/to_integer.cpp
+++ b/src/function/scalar/string/to_integer.cpp
@@ -29,6 +29,20 @@ struct ToIntegerIdentityOperator {
 	}
 };
 
+// Interval → milliseconds (extension used by LDBC IC7's
+// `toFloat(t1 - t2)` idiom, where the timestamps are stored in ms and
+// the caller expects the diff to behave like long-long subtraction).
+// `months` is intentionally ignored — TIMESTAMP - TIMESTAMP never
+// produces a months component, and months-to-ms is ambiguous anyway.
+struct IntervalToMilliseconds {
+	template <class TA, class TR>
+	static inline TR Operation(const TA &input) {
+		const int64_t kMillisPerDay = 86400000LL;
+		return static_cast<TR>(input.days * kMillisPerDay +
+		                       input.micros / 1000);
+	}
+};
+
 void ToIntegerFun::RegisterFunction(BuiltinFunctions &set) {
 	ScalarFunctionSet to_integer("tointeger");
 	to_integer.AddFunction(ScalarFunction(
@@ -109,6 +123,9 @@ void ToFloatFun::RegisterFunction(BuiltinFunctions &set) {
 	to_float.AddFunction(ScalarFunction(
 		{LogicalType::UBIGINT}, LogicalType::DOUBLE,
 		ScalarFunction::UnaryFunction<uint64_t, double, ToIntegerIdentityOperator>));
+	to_float.AddFunction(ScalarFunction(
+		{LogicalType::INTERVAL}, LogicalType::DOUBLE,
+		ScalarFunction::UnaryFunction<interval_t, double, IntervalToMilliseconds>));
 	set.AddFunction(to_float);
 }
 

--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -26,7 +26,17 @@ static void StructExtractFunction(DataChunk &args, ExpressionState &state, Vecto
 	auto &struct_vec = args.data[0];
 	auto &children = StructVector::GetEntries(struct_vec);
 	D_ASSERT(bind_data.field_index < children.size());
-	result.Reference(*children[bind_data.field_index]);
+	// StructVector::GetEntries drills through DICTIONARY_VECTOR to return the
+	// underlying flat children, so a Reference alone drops the parent's
+	// selection. Propagate the slice so callers that compose this with
+	// SelectionVector-driven evaluators (e.g. CASE/coalesce) read the
+	// per-row value, not row 0 of the unsliced child (#90).
+	if (struct_vec.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		auto &sel = DictionaryVector::SelVector(struct_vec);
+		result.Slice(*children[bind_data.field_index], sel, args.size());
+	} else {
+		result.Reference(*children[bind_data.field_index]);
+	}
 }
 
 static unique_ptr<FunctionData> StructExtractBind(ClientContext &,

--- a/test/query/test_ldbc_ic_correctness.cpp
+++ b/test/query/test_ldbc_ic_correctness.cpp
@@ -478,14 +478,15 @@ TEST_CASE("IC7 recent likers", "[ldbc][ic][ic7]") {
         CHECK(r[i].str_at(2) == exp.last_name);
         CHECK(r[i].int64_at(3) == exp.like_creation_ms);
         CHECK(r[i].int64_at(4) == exp.comment_or_post_id);
-        // column 5 (commentOrPostContent) and column 6 (minutesLatency)
-        // are gated on issue #90: struct-field access of nested-node
-        // properties (latestLike.msg.content / latestLike.msg.creationDate)
-        // returns empty / 0 instead of the underlying property value.
-        // commentOrPostId works because .id is the primary key. Re-enable
-        // these two CHECKs once #90 is fixed.
+        // column 5 (commentOrPostContent) is gated on a separate data
+        // representation issue: image-Post `content` loads as empty
+        // string rather than NULL, so `coalesce(content, imageFile)`
+        // short-circuits on "" instead of falling through to imageFile.
+        // The two struct/interval pieces of #90 are resolved here;
+        // this remaining check needs the loader/storage path to treat
+        // empty CSV string fields as NULL.
         // CHECK(r[i].str_at(5).find(exp.content) == 0);
-        // CHECK(r[i].int64_at(6) == exp.minutes_latency);
+        CHECK(r[i].int64_at(6) == exp.minutes_latency);
         // column 7 (isNew) is engine-side pattern-expression placeholder,
         // also not asserted.
     }

--- a/test/query/test_ldbc_traversal.cpp
+++ b/test/query/test_ldbc_traversal.cpp
@@ -229,6 +229,45 @@ TEST_CASE("Message sibling-only property via HAS_CREATOR join",
     CHECK(r[0].str_at(1).find("photo") == 0);
 }
 
+// Regression for issue #90's struct/CASE path. struct_extract used to
+// drop the parent's selection (Reference instead of Slice through the
+// dictionary), so callers like CASE/coalesce that evaluate a branch on
+// only a subset of rows would read row-0 of the unsliced child. Drive
+// CASE explicitly so the regression is exercised even when the dataset
+// happens to short-circuit coalesce on the first child.
+TEST_CASE("struct_extract preserves row selection through CASE",
+          "[ldbc][traversal][issue-90][struct-extract]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (m:Message) WHERE m.id = 1168231105519 "
+        "WITH head(collect({n: m})) AS w "
+        "RETURN CASE WHEN w.n.imageFile <> '' THEN w.n.imageFile ELSE 'fallback' END AS pick",
+        {qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    // 1168231105519 is an image-Post in the LDBC mini fixture. The CASE
+    // THEN branch must read the actual imageFile value through the
+    // struct chain, not the fallback.
+    CHECK(r[0].str_at(0).find("photo") == 0);
+}
+
+// toFloat(INTERVAL) → total milliseconds, the LDBC IC7 idiom for
+// "ms diff between two ms-timestamps".
+TEST_CASE("toFloat(INTERVAL) returns total milliseconds",
+          "[ldbc][traversal][issue-90][tofloat-interval]") {
+    SKIP_IF_NO_DB();
+    // 1356998400000 - 1356998200000 = 200000 ms.
+    auto r = qr->run(
+        "MATCH (a:Message {id: 1168231108551}) "
+        "MATCH (b:Message {id: 1168231108526}) "
+        "RETURN toInteger(toFloat(a.creationDate - b.creationDate)) AS ms",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    // The exact value isn't pinned (fixture-dependent), but the result
+    // must be a non-zero integer — pre-fix it was 0 because toFloat had
+    // no INTERVAL overload.
+    CHECK(r[0].int64_at(0) != 0);
+}
+
 TEST_CASE("Message IdSeek keeps same-seqno partitions separated", "[ldbc][traversal][mpv][idseek]") {
     SKIP_IF_NO_DB();
 


### PR DESCRIPTION
## Summary

Two scalar-level fixes that close out the IC7-driving pieces of #90:

1. **struct_extract through a DICTIONARY input.** `StructVector::GetEntries` walks through a dictionary view to return the underlying flat children; the function previously `Reference`d them directly, dropping the parent's row selection. Inside CASE / coalesce evaluators (where the THEN branch sees a sliced subset), the consumer would then read row 0 of the unsliced child instead of the per-row value. Slice the result by the parent's selection vector when the input is a dictionary.

2. **toFloat(INTERVAL).** Missing overload. LDBC IC7 uses `toFloat(t1 - t2)` for two TIMESTAMP_MS values and expects total milliseconds; the subtraction returns INTERVAL by SQL standard, and the missing overload made the result silently zero. Add an `INTERVAL → DOUBLE` overload that returns total ms (`days * 86400000 + micros / 1000`). Months ignored — never produced by timestamp subtraction.

## Scope

- IC7 mini column 6 (`minutesLatency`) is now re-enabled.
- IC7 mini column 5 (`commentOrPostContent`) stays gated: the loader stores empty CSV string fields as `""` rather than `NULL`, so `coalesce(content, imageFile)` short-circuits on `""` for image-Posts. That's a loader/storage path issue and will be filed separately.

## Test plan

- [x] `test/query/test_ldbc_traversal.cpp` — two new `[issue-90]` regression tests:
  - struct_extract through CASE on an image-Post.
  - toFloat(INTERVAL) returns non-zero ms for a real timestamp diff.
- [x] `unittest` — 206/206 (823 assertions).
- [x] TPC-H mini — 54/54 (895 assertions).
- [x] LDBC mini — 491 / 361 passed / 126 failed (3 new passes, 0 new fails; 126 baseline fails unchanged).

Stacked on #129. Retarget to \`main\` after the stack merges.