### PR TITLE
ldbc-hadoop: smoke regression suite (local-only)

### DIFF
--- a/test/query/CMakeLists.txt
+++ b/test/query/CMakeLists.txt
@@ -44,6 +44,9 @@ add_executable(query_test
     # LDBC E2E correctness
     test_ldbc_is_correctness.cpp
     test_ldbc_ic_correctness.cpp
+    # LDBC Hadoop datagen SF=0.1 smoke (local-only, opt-in via
+    # --ldbc-hadoop-path; auto-skip otherwise)
+    test_ldbc_hadoop_sf01.cpp
     # TPC-H
     test_tpch_correctness.cpp
     test_tpch_stress.cpp

--- a/test/query/query_test_main.cpp
+++ b/test/query/query_test_main.cpp
@@ -10,11 +10,13 @@
 #include <cstdlib>
 
 std::string g_ldbc_path;
+std::string g_ldbc_hadoop_path;
 std::string g_tpch_path;
 std::string g_oss_path;
 std::string g_types_path;
 bool g_skip_requested = false;
 bool g_has_ldbc = false;
+bool g_has_ldbc_hadoop = false;
 bool g_has_tpch = false;
 bool g_has_oss = false;
 bool g_has_types = false;
@@ -50,6 +52,10 @@ static qtest::QueryRunner* activate_runner(const std::string& db_path) {
 
 qtest::QueryRunner* get_ldbc_runner() {
     return activate_runner(g_ldbc_path);
+}
+
+qtest::QueryRunner* get_ldbc_hadoop_runner() {
+    return activate_runner(g_ldbc_hadoop_path);
 }
 
 qtest::QueryRunner* get_tpch_runner() {
@@ -120,6 +126,22 @@ static const ExpectedCount TPCH_CHECKS[] = {
     {"REGION",   "MATCH (n:REGION) RETURN count(n)",   tpch::REGION_COUNT},
 };
 
+// LDBC Hadoop datagen SF=0.1 expected vertex counts. Local-only; the
+// dataset isn't committed and is generated via the Hadoop datagen
+// container per scripts/preprocessors/ldbc-preprocessors/README.md.
+// Same Cypher schema as the Spark mini fixture, so re-uses the
+// LDBC_CHECKS query shapes; only the expected values differ.
+static const ExpectedCount LDBC_HADOOP_CHECKS[] = {
+    {"Person",       "MATCH (n:Person) RETURN count(n)",       1528},
+    {"Comment",      "MATCH (n:Comment) RETURN count(n)",      151043},
+    {"Post",         "MATCH (n:Post) RETURN count(n)",         135701},
+    {"Forum",        "MATCH (n:Forum) RETURN count(n)",        13750},
+    {"Tag",          "MATCH (n:Tag) RETURN count(n)",          16080},
+    {"TagClass",     "MATCH (n:TagClass) RETURN count(n)",     71},
+    {"Organisation", "MATCH (n:Organisation) RETURN count(n)", 7955},
+    {"Place",        "MATCH (n:Place) RETURN count(n)",        1460},
+};
+
 // Expected OSS supply-chain fixture vertex counts
 // (applications/oss-supply-chain/tests/fixtures)
 static const ExpectedCount OSS_CHECKS[] = {
@@ -183,6 +205,25 @@ static void probe_and_verify() {
         }
     }
 
+    // Verify LDBC Hadoop SF=0.1 (disconnects LDBC first)
+    if (auto* qr = get_ldbc_hadoop_runner()) {
+        auto status = verify_counts(qr, LDBC_HADOOP_CHECKS,
+                                    sizeof(LDBC_HADOOP_CHECKS) / sizeof(LDBC_HADOOP_CHECKS[0]),
+                                    "LDBC-Hadoop");
+        if (status != DbStatus::MISSING) {
+            g_has_ldbc_hadoop = true;
+            if (status == DbStatus::CONTAMINATED) {
+                std::cerr << "[ERROR] LDBC Hadoop database has wrong scale!\n"
+                          << "        Counts must match SF=0.1 from the Hadoop datagen.\n"
+                          << "        Regenerate per scripts/preprocessors/ldbc-preprocessors/README.md.\n";
+            } else {
+                std::cerr << "[OK] LDBC Hadoop SF=0.1 fixture integrity verified\n";
+            }
+        } else {
+            std::cerr << "[WARN] --ldbc-hadoop-path given but DB has no LDBC schema\n";
+        }
+    }
+
     // Verify TPC-H (disconnects LDBC first)
     if (auto* qr = get_tpch_runner()) {
         auto status = verify_counts(qr, TPCH_CHECKS,
@@ -241,6 +282,8 @@ static void parse_args(int argc, char* argv[]) {
         std::string a = argv[i];
         if (a == "--ldbc-path" && i + 1 < argc)
             g_ldbc_path = argv[++i];
+        else if (a == "--ldbc-hadoop-path" && i + 1 < argc)
+            g_ldbc_hadoop_path = argv[++i];
         else if (a == "--tpch-path" && i + 1 < argc)
             g_tpch_path = argv[++i];
         else if (a == "--oss-path" && i + 1 < argc)
@@ -261,9 +304,9 @@ static std::vector<char*> strip_custom_args(int argc, char* argv[], int& out_arg
     out.push_back(argv[0]);
     for (int i = 1; i < argc; ++i) {
         std::string a = argv[i];
-        if (a == "--ldbc-path" || a == "--tpch-path" ||
-            a == "--oss-path" || a == "--types-path" ||
-            a == "--db-path") { ++i; continue; }
+        if (a == "--ldbc-path" || a == "--ldbc-hadoop-path" ||
+            a == "--tpch-path" || a == "--oss-path" ||
+            a == "--types-path" || a == "--db-path") { ++i; continue; }
         out.push_back(argv[i]);
     }
     out_argc = (int)out.size();
@@ -273,8 +316,9 @@ static std::vector<char*> strip_custom_args(int argc, char* argv[], int& out_arg
 int main(int argc, char* argv[]) {
     parse_args(argc, argv);
 
-    if (g_ldbc_path.empty() && g_tpch_path.empty() && g_oss_path.empty() && g_types_path.empty()) {
-        std::cerr << "[WARN] No --ldbc-path, --tpch-path, --oss-path, or --types-path given; all query tests will be skipped.\n";
+    if (g_ldbc_path.empty() && g_ldbc_hadoop_path.empty() &&
+        g_tpch_path.empty() && g_oss_path.empty() && g_types_path.empty()) {
+        std::cerr << "[WARN] No --ldbc-path, --ldbc-hadoop-path, --tpch-path, --oss-path, or --types-path given; all query tests will be skipped.\n";
         std::cerr << "[HINT] Usage: query_test --ldbc-path /data/ldbc/sf1 --tpch-path /data/tpch/sf1 --oss-path /data/oss/small --types-path /data/types-mini\n";
     } else {
         probe_and_verify();

--- a/test/query/test_ldbc_hadoop_sf01.cpp
+++ b/test/query/test_ldbc_hadoop_sf01.cpp
@@ -1,0 +1,147 @@
+// LDBC Hadoop datagen SF=0.1 smoke regression.
+//
+// Cross-checks the engine against a fixture produced by the *Hadoop*
+// variant of the LDBC SNB datagen (vs the Spark mini fixture used by
+// the rest of the [ldbc] suite). The two datagens diverge in entity
+// column layout, multi-valued field encoding, and datetime format —
+// so the same query stack should be exercised on both to catch
+// datagen-shaped regressions.
+//
+// This suite is intentionally narrow: a handful of CSV-verifiable
+// counts (scale 1528 Persons, 286k Messages) and one regression query
+// per recently fixed path (#90, #128). No external reference like
+// Neo4j is required — every expected value is either a row count we
+// derived directly from the generated CSVs or a property whose value
+// is known from the schema (e.g. imageFile must start with `photo`
+// for any Post that has one).
+//
+// Local-only. Skip if `--ldbc-hadoop-path` isn't provided. Generation
+// recipe is in scripts/preprocessors/ldbc-preprocessors/README.md.
+
+#include "catch.hpp"
+#include "helpers/query_runner.hpp"
+#include <cstdint>
+#include <string>
+
+extern std::string g_ldbc_hadoop_path;
+extern bool g_skip_requested;
+extern bool g_has_ldbc_hadoop;
+
+extern qtest::QueryRunner* get_ldbc_hadoop_runner();
+
+#define SKIP_IF_NO_DB() \
+    if (g_ldbc_hadoop_path.empty()) { \
+        WARN("--ldbc-hadoop-path not set, skipping"); \
+        g_skip_requested = true; return; \
+    } \
+    if (!g_has_ldbc_hadoop) { \
+        WARN("--ldbc-hadoop-path given but DB has no LDBC schema, skipping"); \
+        return; \
+    } \
+    auto* qr = get_ldbc_hadoop_runner(); \
+    if (!qr) { FAIL("Cannot open DB: " << g_ldbc_hadoop_path); return; }
+
+
+// ---------------------------------------------------------------------------
+// Count sanity — values match the row counts of the generated CSVs and
+// are also checked by the integrity probe in query_test_main.cpp. They
+// re-appear here so a [ldbc-hadoop]-only run still asserts them.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Hadoop SF=0.1: Person count", "[ldbc-hadoop][count]") {
+    SKIP_IF_NO_DB();
+    CHECK(qr->count("MATCH (n:Person) RETURN count(n)") == 1528);
+}
+
+TEST_CASE("Hadoop SF=0.1: Message (Comment+Post) union count",
+          "[ldbc-hadoop][count][mpv]") {
+    SKIP_IF_NO_DB();
+    CHECK(qr->count("MATCH (n:Comment) RETURN count(n)") == 151043);
+    CHECK(qr->count("MATCH (n:Post) RETURN count(n)") == 135701);
+    CHECK(qr->count("MATCH (n:Message) RETURN count(n)") == 286744);
+}
+
+TEST_CASE("Hadoop SF=0.1: KNOWS edge count",
+          "[ldbc-hadoop][count][traversal]") {
+    SKIP_IF_NO_DB();
+    CHECK(qr->count("MATCH (:Person)-[:KNOWS]->(:Person) RETURN count(*)") == 14073);
+}
+
+
+// ---------------------------------------------------------------------------
+// Regression for #128 — IdSeek MPV scan through a multi-hop join used
+// to drop sibling-only properties because the planner clobbered the
+// scan_types for non-primary partitions. Hadoop SF=0.1 has both image
+// Posts (imageFile populated) and text Comments/Posts, so this query
+// exercises the same code path on Hadoop-shaped data.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Hadoop SF=0.1: sibling-only imageFile via HAS_CREATOR join",
+          "[ldbc-hadoop][issue-128][mpv]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (:Person)<-[:HAS_CREATOR]-(m:Message) "
+        "WHERE m.imageFile <> '' "
+        "RETURN m.id, m.imageFile "
+        "ORDER BY m.id ASC LIMIT 3",
+        {qtest::ColType::INT64, qtest::ColType::STRING});
+    REQUIRE(r.size() == 3);
+    for (size_t i = 0; i < r.size(); i++) {
+        INFO("row " << i);
+        // Every imageFile on an LDBC SNB image Post is "photo<post_id>.jpg".
+        CHECK(r[i].str_at(1).find("photo") == 0);
+        CHECK(r[i].int64_at(0) > 0);
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Regression for #90 — struct_extract through a CASE / coalesce path.
+// Hadoop SF=0.1 has 151k Comments with real content, so a single-row
+// collect+head over an arbitrary Comment must surface the underlying
+// string through `coalesce(w.n.content, w.n.imageFile)`.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Hadoop SF=0.1: struct_extract on collect+head over Message union",
+          "[ldbc-hadoop][issue-90][struct-extract]") {
+    SKIP_IF_NO_DB();
+    // Specific image-Post in the SF=0.1 output. collect a struct over
+    // that single row, head() it, then read the imageFile through the
+    // struct chain — this is the per-row path #90's struct_extract
+    // fix addressed.
+    //
+    // (Comment-only WITH→collect+coalesce over a partition that lacks
+    // the imageFile column entirely is a separate code path that
+    // currently SIGSEGVs — tracked under #132.)
+    auto r = qr->run(
+        "MATCH (m:Message) WHERE m.id = 481036337184 "
+        "WITH head(collect({n: m})) AS w "
+        "RETURN w.n.id AS mid, w.n.imageFile AS img",
+        {qtest::ColType::INT64, qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 481036337184LL);
+    CHECK(r[0].str_at(1).find("photo481036337184") == 0);
+}
+
+
+// ---------------------------------------------------------------------------
+// toFloat(INTERVAL) — TIMESTAMP - TIMESTAMP returns INTERVAL by SQL
+// standard; the overload added with #90 makes toFloat over that
+// interval return total milliseconds. Verify on two real messages.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Hadoop SF=0.1: toFloat(INTERVAL) sanity",
+          "[ldbc-hadoop][issue-90][tofloat-interval]") {
+    SKIP_IF_NO_DB();
+    // Two specific messages whose IDs are stable in the SF=0.1 output;
+    // any two messages with different creationDate would do. Drive the
+    // subtraction directly instead of indexing a collected node list —
+    // node-list indexing through `ms[i].prop` is a separate code path
+    // not relevant to the toFloat(INTERVAL) regression.
+    auto r = qr->run(
+        "MATCH (a:Message {id: 148281}) MATCH (b:Message {id: 230037}) "
+        "RETURN toInteger(toFloat(b.creationDate - a.creationDate)) AS ms_diff",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) > 0);
+}


### PR DESCRIPTION
## Summary

Adds a \`[ldbc-hadoop]\`-tagged Catch2 suite that runs against the LDBC Hadoop datagen SF=0.1 workspace produced via the preprocessor in #131. Six tests cover the bug-prone paths recently fixed under #90 / #128.

* Vertex counts (Person/Comment/Post/Message-union, KNOWS edges) match the row counts of the generated CSVs.
* IdSeek through a multi-hop join over a union-label scan (\`MATCH (:Person)<-[:HAS_CREATOR]-(m:Message) WHERE m.imageFile<>''\`) surfaces real \`photo*.jpg\` values — exercises #128's scan_types preservation on Hadoop-shaped data.
* collect+head + per-row struct-field access on a single image-Post — exercises #90's struct_extract dictionary slice propagation.
* \`toFloat(timestamp1 - timestamp2)\` returns non-zero milliseconds — exercises the new INTERVAL → DOUBLE overload from #90.

Local-only. Not added to CI because the Hadoop fixture isn't committed; the suite auto-skips unless \`--ldbc-hadoop-path\` is provided.

## Dependencies

* Functionally depends on the bug fixes in #127 / #129 / #130 — the suite was written to fail on a branch that lacks them. Merging this PR before the fix stack would land a red \`[ldbc-hadoop]\` run locally.
* Adds a new CLI option \`--ldbc-hadoop-path\` to \`query_test\` plus an SF=0.1 integrity probe alongside the existing LDBC/TPC-H/types/OSS probes.

## Follow-up filed

A separate Comment-only struct-field path (\`coalesce(w.n.content, w.n.imageFile)\` where the source partition lacks \`imageFile\`) SIGSEGVs. Tracked under #132 and noted inline in the test comment; this PR skirts that case by querying \`:Message\` (Comment ∪ Post) instead.

## Test plan

\`\`\`bash
rm -rf /tmp/ldbc-hadoop-sf01-data /tmp/ldbc-hadoop-sf01-ws
python3 scripts/preprocessors/ldbc-preprocessors/ldbc-hadoop-preprocess.py \\
    ~/ldbc-hadoop-sf01/out/social_network /tmp/ldbc-hadoop-sf01-data
bash scripts/load-ldbc-hadoop.sh build-portable /tmp/ldbc-hadoop-sf01-data /tmp/ldbc-hadoop-sf01-ws
./build-portable/test/query/query_test "[ldbc-hadoop]" \\
    --ldbc-hadoop-path /tmp/ldbc-hadoop-sf01-ws
\`\`\`

→ All tests passed (17 assertions in 6 test cases) on a tree with #127 + #129 + #130 applied.

Stacked on #131. Retarget to \`main\` after the fix stack and #131 both merge.