### PR TITLE
OPTIONAL MATCH: BOTH-phase snapshot + self-ref both-bound LOJ (closes #83)

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -790,6 +790,10 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
         uint64_t loj_anchor_edge_key = 0; // edge key to join with anchor
         string loj_anchor_edge_name; // edge name for the LOJ key
         CExpression *loj_additional_pred = nullptr; // extra pred for both-bound case
+        // For BOTH self-ref edges with both endpoints id-bound, the join cond
+        // must accept either orientation — supplying a full OR predicate here
+        // bypasses the anchor-equality combine in ExprLogicalJoin (issue #83).
+        CExpression *loj_full_pred_override = nullptr;
 
         // Edge reordering: if the first edge has no bound endpoint but a
         // later edge does (e.g. OPTIONAL MATCH (a)<-[r1]-(b)<-[r2]-(c)
@@ -836,6 +840,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
             // --- Determine edge direction (same logic as PlanRegularMatch) ---
             bool lhs_is_src = true;
             bool is_both = (qedge->GetDirection() == RelDirection::BOTH);
+            bool is_both_self_ref = false;
             auto &catalog = context_->db->GetCatalog();
             auto expanded_lhs_pids = ExpandRealVertexPartitions(
                 catalog, *context_, lhs_node->GetPartitionIDs());
@@ -859,6 +864,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
 
                 if (is_both && any_self_ref) {
                     lhs_is_src = true;
+                    is_both_self_ref = true;
                     for (auto ep_oid : qedge->GetPartitionIDs()) {
                         both_edge_partitions_.insert((idx_t)ep_oid);
                     }
@@ -945,14 +951,31 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
                     loj_anchor_name = lhs_name;
                     loj_anchor_edge_key = lhs_edge_key;
                     loj_anchor_edge_name = edge_name;
-                    // Build additional predicate for the other bound endpoint
-                    loj_additional_pred = ExprScalarCmpEq(
-                        GPOS_NEW(mp_) CExpression(mp_,
-                            GPOS_NEW(mp_) CScalarIdent(mp_,
-                                edge_plan->getSchema()->getColRefOfKey(edge_name, rhs_edge_key))),
-                        GPOS_NEW(mp_) CExpression(mp_,
-                            GPOS_NEW(mp_) CScalarIdent(mp_,
-                                prev_plan->getSchema()->getColRefOfKey(rhs_name, ID_KEY_ID))));
+                    if (is_both_self_ref) {
+                        // BOTH self-ref + both id-bound: storage may hold the
+                        // edge in either orientation. Build the full
+                        // (a∈{SID,TID}) AND (b∈{SID,TID}) OR predicate so the
+                        // LOJ matches in either direction (issue #83).
+                        auto a_pred = ExprBothSelfRefEndpointPred(
+                            lhs_name, prev_plan, edge_name, edge_plan);
+                        auto b_pred = ExprBothSelfRefEndpointPred(
+                            rhs_name, prev_plan, edge_name, edge_plan);
+                        CExpressionArray *and_children =
+                            GPOS_NEW(mp_) CExpressionArray(mp_);
+                        and_children->Append(a_pred);
+                        and_children->Append(b_pred);
+                        loj_full_pred_override = CUtils::PexprScalarBoolOp(
+                            mp_, CScalarBoolOp::EboolopAnd, and_children);
+                    } else {
+                        // Build additional predicate for the other bound endpoint
+                        loj_additional_pred = ExprScalarCmpEq(
+                            GPOS_NEW(mp_) CExpression(mp_,
+                                GPOS_NEW(mp_) CScalarIdent(mp_,
+                                    edge_plan->getSchema()->getColRefOfKey(edge_name, rhs_edge_key))),
+                            GPOS_NEW(mp_) CExpression(mp_,
+                                GPOS_NEW(mp_) CScalarIdent(mp_,
+                                    prev_plan->getSchema()->getColRefOfKey(rhs_name, ID_KEY_ID))));
+                    }
                 } else {
                     // One endpoint bound in prev_plan
                     D_ASSERT(is_lhs_bound || is_rhs_bound);
@@ -1072,12 +1095,36 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
 
         // Apply a single LOJ: prev_plan LOJ subquery
         D_ASSERT(subquery);
-        absorb_optional_predicates(subquery, loj_additional_pred);
-        CExpression *loj = ExprLogicalJoin(
-            prev_plan->getPlanExpr(), subquery->getPlanExpr(),
-            prev_plan->getSchema()->getColRefOfKey(loj_anchor_name, ID_KEY_ID),
-            subquery->getSchema()->getColRefOfKey(loj_anchor_edge_name, loj_anchor_edge_key),
-            loj_type, loj_additional_pred);
+        CExpression *loj;
+        if (loj_full_pred_override) {
+            // BOTH self-ref + both endpoints id-bound: bypass anchor-eq
+            // combine and use the full OR predicate as the LOJ condition.
+            // Side WHERE predicates still need to be ANDed on top.
+            CExpression *side_pred = nullptr;
+            absorb_optional_predicates(subquery, side_pred);
+            CExpression *final_pred = loj_full_pred_override;
+            if (side_pred) {
+                CExpressionArray *and_children =
+                    GPOS_NEW(mp_) CExpressionArray(mp_);
+                and_children->Append(final_pred);
+                and_children->Append(side_pred);
+                final_pred = CUtils::PexprScalarBoolOp(
+                    mp_, CScalarBoolOp::EboolopAnd, and_children);
+            }
+            prev_plan->getPlanExpr()->AddRef();
+            subquery->getPlanExpr()->AddRef();
+            final_pred->AddRef();
+            loj = CUtils::PexprLogicalJoin<CLogicalLeftOuterJoin>(
+                mp_, prev_plan->getPlanExpr(), subquery->getPlanExpr(),
+                final_pred);
+        } else {
+            absorb_optional_predicates(subquery, loj_additional_pred);
+            loj = ExprLogicalJoin(
+                prev_plan->getPlanExpr(), subquery->getPlanExpr(),
+                prev_plan->getSchema()->getColRefOfKey(loj_anchor_name, ID_KEY_ID),
+                subquery->getSchema()->getColRefOfKey(loj_anchor_edge_name, loj_anchor_edge_key),
+                loj_type, loj_additional_pred);
+        }
         prev_plan->getSchema()->appendSchema(subquery->getSchema());
         prev_plan->addBinaryParentOp(loj, subquery);
     }
@@ -3842,6 +3889,22 @@ CExpression *Cypher2OrcaConverter::ExprScalarProperty(const string &var_name,
     CColRef *colref = plan->getSchema()->getColRefOfKey(var_name, key_id);
     D_ASSERT(colref != nullptr);
     return GPOS_NEW(mp_) CExpression(mp_, GPOS_NEW(mp_) CScalarIdent(mp_, colref));
+}
+
+CExpression *Cypher2OrcaConverter::ExprBothSelfRefEndpointPred(
+    const string &node_var, turbolynx::LogicalPlan *node_plan,
+    const string &edge_var, turbolynx::LogicalPlan *edge_plan)
+{
+    CExpression *eq_sid = ExprScalarCmpEq(
+        ExprScalarProperty(node_var, ID_KEY_ID, node_plan),
+        ExprScalarProperty(edge_var, SID_KEY_ID, edge_plan));
+    CExpression *eq_tid = ExprScalarCmpEq(
+        ExprScalarProperty(node_var, ID_KEY_ID, node_plan),
+        ExprScalarProperty(edge_var, TID_KEY_ID, edge_plan));
+    CExpressionArray *children = GPOS_NEW(mp_) CExpressionArray(mp_);
+    children->Append(eq_sid);
+    children->Append(eq_tid);
+    return CUtils::PexprScalarBoolOp(mp_, CScalarBoolOp::EboolopOr, children);
 }
 
 // ============================================================

--- a/src/execution/execution/physical_operator/physical_adjidxjoin.cpp
+++ b/src/execution/execution/physical_operator/physical_adjidxjoin.cpp
@@ -639,9 +639,12 @@ inline void PhysicalAdjIdxJoin::GetAdjListAndFillRHSOutput(
                      src_vid, dbg_size, first_tgts, last_tgts, pos113);
     }
 
-    // calculate size can be fetched — only snapshot at the start of a NEW LHS row
-    // (adj_idx==0), not when advancing to the next sub-partition within the same LHS row.
-    if (state.rhs_idx == 0 && state.adj_idx == 0) {
+    // Snapshot output_idx at the start of a NEW LHS row only. For BOTH
+    // direction, the backward phase resets rhs_idx to 0 but stays on the
+    // same LHS; resetting the snapshot there would let a successful forward
+    // match be treated as "no match" by the LEFT-OUTER check (issue #83).
+    if (state.rhs_idx == 0 && state.adj_idx == 0 &&
+        state.both_phase == BothPhase::FORWARD) {
         state.output_idx_before_fetch = state.output_idx;
     }
     idx_t adj_size = GetAdjacencyEntryCount(adj_start, adj_end);
@@ -772,8 +775,10 @@ inline void PhysicalAdjIdxJoin::GetAdjListAndFillRHSOutputInto(
     }
     // When skip_this_adj is true, adj_start/adj_end remain nullptr → adj_size = 0
 
-    // calculate size can be fetched — only snapshot at the start of a NEW LHS row
-    if (state.rhs_idx == 0 && state.adj_idx == 0) {
+    // Snapshot output_idx at the start of a NEW LHS row only — see the
+    // matching note in GetAdjListAndFillRHSOutput (issue #83).
+    if (state.rhs_idx == 0 && state.adj_idx == 0 &&
+        state.both_phase == BothPhase::FORWARD) {
         state.output_idx_before_fetch = state.output_idx;
     }
     idx_t adj_size = GetAdjacencyEntryCount(adj_start, adj_end);

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -272,6 +272,14 @@ private:
     CExpression *ExprScalarCmpEq(CExpression *left, CExpression *right);
     CExpression *ExprScalarProperty(const string &var_name, uint64_t key_id,
                                      turbolynx::LogicalPlan *plan);
+    // OR predicate `(node.id = edge.SID) OR (node.id = edge.TID)`. Used by
+    // BOTH-direction self-ref edges with id-bound endpoints — the storage
+    // is directed and may hold the edge in either orientation, so the join
+    // condition must match against both endpoint columns.
+    CExpression *ExprBothSelfRefEndpointPred(const string &node_var,
+                                              turbolynx::LogicalPlan *node_plan,
+                                              const string &edge_var,
+                                              turbolynx::LogicalPlan *edge_plan);
 
     CExpression *ConvertLiteral(const BoundLiteralExpression &expr);
     CExpression *ConvertProperty(const BoundPropertyExpression &expr,

--- a/test/query/helpers/ldbc_expected_counts.hpp
+++ b/test/query/helpers/ldbc_expected_counts.hpp
@@ -144,6 +144,20 @@ inline constexpr int64_t SAMPLE_PERSON_LIKED_COMMENTS  = 4;
 inline constexpr int64_t SAMPLE_PERSON_LIKED_POSTS     = 8;
 inline constexpr int64_t SAMPLE_PERSON_LIKED_MESSAGES  = 12;
 
+// SAMPLE_PERSON's outgoing KNOWS friends, ordered by id ASC, paired
+// with each friend's IS_LOCATED_IN city. Used by OPTIONAL MATCH
+// correctness tests to verify both multi-row LOJ output and multi-hop
+// atomic LOJ traversal. Oracle: Neo4j 5 on test/data/ldbc-mini.
+struct KnowsFriend {
+    int64_t     person_id;
+    const char* city_name;
+};
+inline constexpr KnowsFriend SAMPLE_PERSON_KNOWS_FRIENDS_BY_ID_ASC[] = {
+    {10995116277782LL, "Hamamatsu"},   // Ken Yamada
+    {24189255811081LL, "Baku"},        // Alim Guliyev
+    {26388279066668LL, "Barnaul"},     // Alexei Kahnovich
+};
+
 // SAMPLE_PERSON's first interest tag in alphabetical order.
 // We pin only the first 4 chars because the full tag name varies and
 // the test only needs to verify ordered head() correctness.

--- a/test/query/test_ldbc_is_correctness.cpp
+++ b/test/query/test_ldbc_is_correctness.cpp
@@ -196,12 +196,6 @@ TEST_CASE("IS6 forum of sample comment", "[ldbc][is]") {
 }
 
 // IS7 — Replies to message with OPTIONAL MATCH + CASE (uses Message super-label)
-//
-// Gated SF1-only: the `(m)-[:HAS_CREATOR]->(a)-[r:KNOWS]-(p)` OPTIONAL
-// MATCH clause traverses the undirected `:KNOWS` edge in both directions
-// without deduping on the mini fixture, so each reply row is duplicated
-// (issue #83). SF1 dev runs still exercise the case.
-#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
 TEST_CASE("IS7 replies to sample message", "[ldbc][is]") {
     SKIP_IF_NO_DB();
     auto q = "MATCH (m:Message {id: " + std::to_string(ldbc::IS7_MESSAGE_ID) +
@@ -234,4 +228,3 @@ TEST_CASE("IS7 replies to sample message", "[ldbc][is]") {
         CHECK(r[i].bool_at(6) == exp.reply_author_knows_orig);
     }
 }
-#endif  // !TURBOLYNX_LDBC_FIXTURE_MINI (IS7 gated, see issue #83)

--- a/test/query/test_ldbc_traversal.cpp
+++ b/test/query/test_ldbc_traversal.cpp
@@ -439,3 +439,257 @@ TEST_CASE("Unlabeled target node properties via IdSeek", "[ldbc][traversal][both
         CHECK(r[i].int64_at(3) > 0);
     }
 }
+
+// ====================================================================
+// OPTIONAL MATCH semantics
+//
+// LOJ semantics pinned down here (oracle: Neo4j 5 on the same fixture):
+// - no match preserves the left row with NULL columns
+// - all matches surface as separate rows
+// - chained OPTIONAL propagates NULL into later clauses
+// - WHERE attached to OPTIONAL filters the match, not the left row
+// - count(var) and count(*) differ on miss (NULL is uncounted)
+// - undirected BOTH-direction with both endpoints bound must produce
+//   exactly one row per pair regardless of storage direction
+//   (issue #83 regression — used to emit a real match + spurious NULL)
+// ====================================================================
+
+TEST_CASE("OPTIONAL MATCH: missing edge keeps left row with NULL",
+          "[ldbc][traversal][optional]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (p:Person {id: " + std::to_string(ldbc::SAMPLE_PERSON_ID) +
+             "}) "
+             "OPTIONAL MATCH (p)-[:KNOWS]->(f:Person {id: 9999999999999}) "
+             "RETURN p.id, f IS NULL AS missing";
+    auto r = qr->run(q.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::BOOL});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
+    CHECK(r[0].bool_at(1));
+}
+
+// T2 (all matches surface as rows) and T4 (multi-hop atomic) are
+// fixture-specific because they pin every friend's id (and city).
+// Their definitions sit in the TURBOLYNX_LDBC_FIXTURE_MINI block at
+// the end of this section, alongside the other mini-only OPTIONAL
+// MATCH cases. SF1 needs its own oracle to enable them there.
+
+TEST_CASE("OPTIONAL MATCH: NULL propagates through chained OPTIONAL",
+          "[ldbc][traversal][optional]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (p:Person {id: " + std::to_string(ldbc::SAMPLE_PERSON_ID) +
+             "}) "
+             "OPTIONAL MATCH (p)-[:KNOWS]->(f:Person {id: 9999999999999}) "
+             "OPTIONAL MATCH (f)-[:IS_LOCATED_IN]->(c:Place) "
+             "RETURN p.id, f IS NULL AS f_null, c IS NULL AS c_null";
+    auto r = qr->run(q.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::BOOL, qtest::ColType::BOOL});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
+    CHECK(r[0].bool_at(1));
+    CHECK(r[0].bool_at(2));
+}
+
+// WHERE attached to OPTIONAL is part of the optional clause — when the
+// filter rejects every match, the left row is still preserved with NULL.
+TEST_CASE("OPTIONAL MATCH: WHERE inside OPTIONAL keeps left row on filter miss",
+          "[ldbc][traversal][optional]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (p:Person {id: " + std::to_string(ldbc::SAMPLE_PERSON_ID) +
+             "}) "
+             "OPTIONAL MATCH (p)-[:KNOWS]->(f:Person) "
+             "WHERE f.firstName = '_NoSuchFirstName_' "
+             "RETURN p.id, f IS NULL AS missing";
+    auto r = qr->run(q.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::BOOL});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
+    CHECK(r[0].bool_at(1));
+}
+
+TEST_CASE("OPTIONAL MATCH: property access on missing node returns NULL",
+          "[ldbc][traversal][optional]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (p:Person {id: " + std::to_string(ldbc::SAMPLE_PERSON_ID) +
+             "}) "
+             "OPTIONAL MATCH (p)-[:STUDY_AT]->(u:Organisation {id: 9999999999999}) "
+             "RETURN p.id, u.name IS NULL AS name_null";
+    auto r = qr->run(q.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::BOOL});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
+    CHECK(r[0].bool_at(1));
+}
+
+// count(var) does not count NULL; count(*) counts rows. With matches the
+// two agree; on a miss they disagree.
+TEST_CASE("OPTIONAL MATCH: count(var) == count(*) when matches exist",
+          "[ldbc][traversal][optional][aggregation]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (p:Person {id: " + std::to_string(ldbc::SAMPLE_PERSON_ID) +
+             "}) "
+             "OPTIONAL MATCH (p)-[:KNOWS]->(f:Person) "
+             "RETURN count(f) AS cf, count(*) AS cs";
+    auto r = qr->run(q.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_OUTGOING_KNOWS);
+    CHECK(r[0].int64_at(1) == ldbc::SAMPLE_PERSON_OUTGOING_KNOWS);
+}
+
+TEST_CASE("OPTIONAL MATCH: count(var)=0 vs count(*)=1 on miss",
+          "[ldbc][traversal][optional][aggregation]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (p:Person {id: " + std::to_string(ldbc::SAMPLE_PERSON_ID) +
+             "}) "
+             "OPTIONAL MATCH (p)-[:KNOWS]->(f:Person {id: 9999999999999}) "
+             "RETURN count(f) AS cf, count(*) AS cs";
+    auto r = qr->run(q.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 0);
+    CHECK(r[0].int64_at(1) == 1);
+}
+
+// Relationship-property filter inside OPTIONAL — every fixture KNOWS
+// edge has creationDate > 0, so the filter is a no-op.
+TEST_CASE("OPTIONAL MATCH: relationship property filter",
+          "[ldbc][traversal][optional]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (p:Person {id: " + std::to_string(ldbc::SAMPLE_PERSON_ID) +
+             "}) "
+             "OPTIONAL MATCH (p)-[r:KNOWS]->(f:Person) "
+             "WHERE r.creationDate > 0 "
+             "RETURN count(r) AS rc";
+    REQUIRE(qr->count(q.c_str()) == ldbc::SAMPLE_PERSON_OUTGOING_KNOWS);
+}
+
+// ------------------- Mini-only OPTIONAL MATCH cases ---------------------
+// These pin BOTH-direction LOJ behaviour against the directed KNOWS
+// storage of the SF0.003 mini fixture. SF1 needs its own anchor ids.
+#ifdef TURBOLYNX_LDBC_FIXTURE_MINI
+
+// BOTH-direction, both endpoints bound, edge absent → no match, single
+// LOJ row with count(r)=0.
+TEST_CASE("OPTIONAL MATCH BOTH (mini): unconnected pair → NULL row",
+          "[ldbc][traversal][optional][both]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (a:Person {id: 14}), (b:Person {id: 16}) "
+        "OPTIONAL MATCH (a)-[r:KNOWS]-(b) "
+        "RETURN count(r) AS rc",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 0);
+}
+
+// BOTH-direction, both endpoints bound, edge stored as a→b. Forward
+// phase of the dual-phase scan matches. IS3_FRIENDS[1] pins Ken's
+// friendship_ms so we can confirm the actual edge was returned.
+// Two queries because RETURN count(agg) + r.property in one
+// projection currently mis-prunes the LOJ row (separate issue).
+TEST_CASE("OPTIONAL MATCH BOTH (mini): edge a→b matches with exact edge",
+          "[ldbc][traversal][optional][both]") {
+    SKIP_IF_NO_DB();
+    const char* prefix =
+        "MATCH (a:Person {id: 14}), (b:Person {id: 10995116277782}) "
+        "OPTIONAL MATCH (a)-[r:KNOWS]-(b) ";
+    auto rc_query = std::string(prefix) + "RETURN count(r) AS rc";
+    auto rd_query = std::string(prefix) + "RETURN r.creationDate AS d";
+    auto rc = qr->run(rc_query.c_str(), {qtest::ColType::INT64});
+    REQUIRE(rc.size() == 1);
+    CHECK(rc[0].int64_at(0) == 1);
+    auto rd = qr->run(rd_query.c_str(), {qtest::ColType::INT64});
+    REQUIRE(rd.size() == 1);
+    CHECK(rd[0].int64_at(0) == ldbc::IS3_FRIENDS[1].friendship_ms);
+}
+
+// BOTH-direction, both endpoints bound, edge stored as b→a. Backward
+// phase of the dual-phase scan must surface the same edge even though
+// the storage SID/TID is reversed relative to the query. Two queries
+// for the same projection caveat as above.
+TEST_CASE("OPTIONAL MATCH BOTH (mini): edge b→a matches same edge",
+          "[ldbc][traversal][optional][both]") {
+    SKIP_IF_NO_DB();
+    const char* prefix =
+        "MATCH (a:Person {id: 10995116277782}), (b:Person {id: 14}) "
+        "OPTIONAL MATCH (a)-[r:KNOWS]-(b) ";
+    auto rc_query = std::string(prefix) + "RETURN count(r) AS rc";
+    auto rd_query = std::string(prefix) + "RETURN r.creationDate AS d";
+    auto rc = qr->run(rc_query.c_str(), {qtest::ColType::INT64});
+    REQUIRE(rc.size() == 1);
+    CHECK(rc[0].int64_at(0) == 1);
+    auto rd = qr->run(rd_query.c_str(), {qtest::ColType::INT64});
+    REQUIRE(rd.size() == 1);
+    CHECK(rd[0].int64_at(0) == ldbc::IS3_FRIENDS[1].friendship_ms);
+}
+
+// Mixed match/no-match across multiple anchors: SAMPLE_PERSON has a
+// STUDY_AT relation, Alim (24189255811081) has none. Both rows
+// surface, the latter with NULL.
+TEST_CASE("OPTIONAL MATCH (mini): mixed match/no-match across anchors",
+          "[ldbc][traversal][optional]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "UNWIND [14, 24189255811081] AS pid "
+        "MATCH (p:Person {id: pid}) "
+        "OPTIONAL MATCH (p)-[:STUDY_AT]->(u:Organisation) "
+        "RETURN p.id AS id, u.name AS uni, u IS NULL AS u_null "
+        "ORDER BY id ASC",
+        {qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::BOOL});
+    REQUIRE(r.size() == 2);
+    CHECK(r[0].int64_at(0) == 14);
+    CHECK(r[0].str_at(1) == "Zanjan_University");
+    CHECK(!r[0].bool_at(2));
+    CHECK(r[1].int64_at(0) == 24189255811081LL);
+    CHECK(r[1].bool_at(2));
+}
+
+// T2 (mini-only): every outgoing KNOWS friend of SAMPLE_PERSON is
+// returned with the exact friend id from the oracle.
+TEST_CASE("OPTIONAL MATCH (mini): all matches surface with exact friend ids",
+          "[ldbc][traversal][optional]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (p:Person {id: " + std::to_string(ldbc::SAMPLE_PERSON_ID) +
+             "}) "
+             "OPTIONAL MATCH (p)-[:KNOWS]->(f:Person) "
+             "RETURN p.id, f.id AS fid ORDER BY fid ASC";
+    auto r = qr->run(q.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    constexpr size_t N =
+        sizeof(ldbc::SAMPLE_PERSON_KNOWS_FRIENDS_BY_ID_ASC) /
+        sizeof(ldbc::SAMPLE_PERSON_KNOWS_FRIENDS_BY_ID_ASC[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        CHECK(r[i].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
+        CHECK(r[i].int64_at(1) ==
+              ldbc::SAMPLE_PERSON_KNOWS_FRIENDS_BY_ID_ASC[i].person_id);
+    }
+}
+
+// T4 (mini-only): multi-hop atomic LOJ. For each KNOWS friend, follow
+// IS_LOCATED_IN to a city and compare both friend id and city name
+// against the oracle.
+TEST_CASE("OPTIONAL MATCH (mini): multi-hop atomic — friend and city exact",
+          "[ldbc][traversal][optional][multihop]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (p:Person {id: " + std::to_string(ldbc::SAMPLE_PERSON_ID) +
+             "}) "
+             "OPTIONAL MATCH (p)-[:KNOWS]->(f:Person)-[:IS_LOCATED_IN]->(c:Place) "
+             "RETURN f.id AS fid, c.name AS city ORDER BY fid ASC";
+    auto r = qr->run(q.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::STRING});
+    constexpr size_t N =
+        sizeof(ldbc::SAMPLE_PERSON_KNOWS_FRIENDS_BY_ID_ASC) /
+        sizeof(ldbc::SAMPLE_PERSON_KNOWS_FRIENDS_BY_ID_ASC[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("row " << i);
+        const auto& exp = ldbc::SAMPLE_PERSON_KNOWS_FRIENDS_BY_ID_ASC[i];
+        CHECK(r[i].int64_at(0) == exp.person_id);
+        CHECK(r[i].str_at(1) == exp.city_name);
+    }
+}
+
+#endif  // TURBOLYNX_LDBC_FIXTURE_MINI


### PR DESCRIPTION
## Summary

- adjidxjoin: don't reset \`output_idx_before_fetch\` between BOTH phases, so a forward-phase match doesn't get treated as no-match by the LEFT-outer fallback. IS7 on the mini fixture goes 4 → 2 rows.
- converter: when an OPTIONAL MATCH connects two id-bound endpoints on a BOTH-direction self-ref edge, build a full OR-of-orientations LOJ predicate so storage in either direction matches.
- Add 14 OPTIONAL MATCH correctness cases to \`test_ldbc_traversal.cpp\` and un-gate IS7 in \`test_ldbc_is_correctness.cpp\`. Every multi-row test pins exact id/property values against the Neo4j-verified mini oracle (new \`SAMPLE_PERSON_KNOWS_FRIENDS_BY_ID_ASC\` table in \`ldbc_expected_counts.hpp\`).

## Follow-ups

- #137 — \`RETURN count(agg) + r.property\` mis-prunes the LOJ; the two \"exact edge\" tests in this PR currently use a two-query split to work around it.
- #138 — plain (non-OPTIONAL) \`MATCH\` on a BOTH self-ref edge with both endpoints id-bound still misses the backward-stored orientation. The OPTIONAL counterpart is what this PR fixes.

Stacked on #135 — merge that one first.

## Test plan

- [x] \`build-portable/test/query/query_test \"[optional]\" --ldbc-path /tmp/ldbc-mini-ws\` — 18/18, 66 assertions
- [x] \`build-portable/test/query/query_test \"[ldbc]~[crud]\" --ldbc-path /tmp/ldbc-mini-ws\` — 398/398, 1544 assertions
- [x] \`build-portable/test/query/query_test \"[tpch]\"\` — 54/54
- [x] \`build-portable/test/unittest\` — 206/206
- [ ] CI Ubuntu + macOS green