### PR TITLE
test(ldbc): pin plain MATCH BOTH self-ref both-bound regression cases (refs #138)

### DIFF
--- a/test/query/test_ldbc_traversal.cpp
+++ b/test/query/test_ldbc_traversal.cpp
@@ -624,6 +624,67 @@ TEST_CASE("OPTIONAL MATCH BOTH (mini): edge b→a matches same edge",
     CHECK(rd[0].int64_at(0) == ldbc::IS3_FRIENDS[1].friendship_ms);
 }
 
+// Plain (non-OPTIONAL) MATCH counterparts of the OPTIONAL BOTH tests
+// above. The OPTIONAL path is patched by the OR-LOJ-predicate in
+// PlanOptionalMatch; the plain MATCH still relies on a single-direction
+// IJ + SEL chain and misses the backward-stored orientation.
+// Tracked in issue #138.
+TEST_CASE("MATCH BOTH (mini): plain MATCH single-clause edge a→b matches",
+          "[ldbc][traversal][both]") {
+    SKIP_IF_NO_DB();
+    const char* prefix =
+        "MATCH (a:Person {id: 14}), (b:Person {id: 10995116277782}) "
+        "MATCH (a)-[r:KNOWS]-(b) ";
+    auto rc_query = std::string(prefix) + "RETURN count(r) AS rc";
+    auto rd_query = std::string(prefix) + "RETURN r.creationDate AS d";
+    auto rc = qr->run(rc_query.c_str(), {qtest::ColType::INT64});
+    REQUIRE(rc.size() == 1);
+    CHECK(rc[0].int64_at(0) == 1);
+    auto rd = qr->run(rd_query.c_str(), {qtest::ColType::INT64});
+    REQUIRE(rd.size() == 1);
+    CHECK(rd[0].int64_at(0) == ldbc::IS3_FRIENDS[1].friendship_ms);
+}
+
+// [!mayfail] until #138 is fixed — plain MATCH BOTH self-ref both-bound
+// with backward-stored storage misses the edge.
+TEST_CASE("MATCH BOTH (mini): plain MATCH single-clause edge b→a matches",
+          "[ldbc][traversal][both][!mayfail]") {
+    SKIP_IF_NO_DB();
+    const char* prefix =
+        "MATCH (a:Person {id: 10995116277782}), (b:Person {id: 14}) "
+        "MATCH (a)-[r:KNOWS]-(b) ";
+    auto rc_query = std::string(prefix) + "RETURN count(r) AS rc";
+    auto rd_query = std::string(prefix) + "RETURN r.creationDate AS d";
+    auto rc = qr->run(rc_query.c_str(), {qtest::ColType::INT64});
+    REQUIRE(rc.size() == 1);
+    CHECK(rc[0].int64_at(0) == 1);
+    auto rd = qr->run(rd_query.c_str(), {qtest::ColType::INT64});
+    REQUIRE(rd.size() == 1);
+    CHECK(rd[0].int64_at(0) == ldbc::IS3_FRIENDS[1].friendship_ms);
+}
+
+// Single-MATCH form `(a {id})-[r:KNOWS]-(b {id})` — the planner sees
+// neither endpoint bound at the entry of the standard A→R→B branch,
+// so it goes through a different code path than the two-MATCH form.
+// Same backward-stored bug applies in principle.
+TEST_CASE("MATCH BOTH (mini): single-clause inline ids edge a→b matches",
+          "[ldbc][traversal][both]") {
+    SKIP_IF_NO_DB();
+    REQUIRE(qr->count(
+        "MATCH (a:Person {id: 14})-[r:KNOWS]-(b:Person {id: 10995116277782}) "
+        "RETURN count(r)") == 1);
+}
+
+// [!mayfail] until #138 is fixed — single-MATCH inline form takes a
+// different planner path but hits the same forward-only IJ chain.
+TEST_CASE("MATCH BOTH (mini): single-clause inline ids edge b→a matches",
+          "[ldbc][traversal][both][!mayfail]") {
+    SKIP_IF_NO_DB();
+    REQUIRE(qr->count(
+        "MATCH (a:Person {id: 10995116277782})-[r:KNOWS]-(b:Person {id: 14}) "
+        "RETURN count(r)") == 1);
+}
+
 // Mixed match/no-match across multiple anchors: SAMPLE_PERSON has a
 // STUDY_AT relation, Alim (24189255811081) has none. Both rows
 // surface, the latter with NULL.


### PR DESCRIPTION
## Summary

- Pin the four plain (non-OPTIONAL) \`MATCH\` BOTH self-ref both-bound cases that issue #138 covers — two-clause form (\`MATCH (a {id}), (b {id}) MATCH (a)-[r]-(b)\`) and single-clause form (\`MATCH (a {id})-[r]-(b {id})\`), each forward and backward storage orientation.
- Forward orientations pass on current main and stay un-gated.
- Backward orientations miss the edge today; tagged \`[!mayfail]\` so the suite stays green while #138 is open. Each case pins exact \`count(r)\` and \`r.creationDate\` against the Neo4j oracle, so when #138 is fixed flipping the mayfail tag verifies both orientations land the same edge.

## Why \`[!mayfail]\` instead of fixing now

PR #139 patched the OPTIONAL counterpart via an OR-LOJ predicate in \`PlanOptionalMatch\`. The same trick on a plain-MATCH IJ tripped ORCA's \`pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin\` (OR-predicate can't be resolved through that transform → SIGSEGV). The proper plain-MATCH fix is UNION ALL of two directed branches (so each branch stays in regular equi-join shape) — implementing it requires \`PexprCopyWithRemappedColumns\` of \`prev_plan\` plus ORCA-compatible UnionAll wiring, which on this codebase still trips a downstream \`CExpressionPreprocessor::PexprPruneUnusedComputedCols\` crash inside \`CLogicalGet\`. That's a deeper ORCA-internals fix; tracking under #138 instead of taking a slower CartProd / NL fallback workaround.

Stacked on #139 — merge that one first.

## Test plan

- [x] \`build-portable/test/query/query_test \"[ldbc][traversal][both]\" --ldbc-path /tmp/ldbc-mini-ws\` — 13 cases (50 passed, 3 skipped via mayfail)
- [x] \`build-portable/test/query/query_test \"[ldbc]~[crud]\" --ldbc-path /tmp/ldbc-mini-ws\` — 1550 passed, 3 skipped
- [ ] CI Ubuntu + macOS green