### PR TITLE
csv-loader: empty CSV string fields load as NULL (closes #90)

### DIFF
--- a/src/include/common/graph_simdcsv_parser.hpp
+++ b/src/include/common/graph_simdcsv_parser.hpp
@@ -376,7 +376,24 @@ inline void SetValueFromCSV(LogicalType type, DataChunk &output, size_t i, idx_t
 		case LogicalTypeId::DOUBLE:
       duckdb_fast_float::from_chars((const char*)p.data() + start_offset, (const char*)p.data() + end_offset, ((double *)data_ptr)[current_index]); break;
 		case LogicalTypeId::VARCHAR:
-			((string_t *)data_ptr)[current_index] = StringVector::AddStringOrBlob(output.data[i], (const char*)p.data() + start_offset, string_size); break;
+			// Empty CSV string field → NULL. LDBC uses empty fields to mean
+			// "absent" (image-Post has empty `content`, text-Post has empty
+			// `imageFile`); coalesce / IS NULL must treat them as missing
+			// (issue #90).
+			if (string_size == 0) {
+				// FlatVector::SetNull calls ValidityMask::SetInvalid, which
+				// auto-initialises the mask sized for STANDARD_VECTOR_SIZE
+				// (1024) — but the bulk loader fills up to
+				// STORAGE_STANDARD_VECTOR_SIZE rows per chunk. Without
+				// pre-sizing the mask, NULL bits for row index ≥1024 land
+				// past the end of the allocation and get lost on flush.
+				FlatVector::Validity(output.data[i]).EnsureWritable(STORAGE_STANDARD_VECTOR_SIZE);
+				FlatVector::SetNull(output.data[i], current_index, true);
+			} else {
+				FlatVector::SetNull(output.data[i], current_index, false);
+				((string_t *)data_ptr)[current_index] = StringVector::AddStringOrBlob(output.data[i], (const char*)p.data() + start_offset, string_size);
+			}
+			break;
     case LogicalTypeId::DATE:
       ((date_t *)data_ptr)[current_index] = Date::FromCString((const char*)p.data() + start_offset, end_offset - start_offset); break;
     case LogicalTypeId::TIMESTAMP_MS:
@@ -490,10 +507,18 @@ inline void SetValueFromCSV_DOUBLE(LogicalType type, DataChunk &output, size_t i
   duckdb_fast_float::from_chars((const char*)p.data() + start_offset, (const char*)p.data() + end_offset, ((double *)data_ptr)[current_index]);
 }
 
-inline void SetValueFromCSV_VARCHAR(LogicalType type, DataChunk &output, size_t i, idx_t current_index, 
+inline void SetValueFromCSV_VARCHAR(LogicalType type, DataChunk &output, size_t i, idx_t current_index,
                             std::basic_string_view<uint8_t> &p, idx_t start_offset, idx_t end_offset, uint8_t width, uint8_t scale) {
-	auto data_ptr = output.data[i].GetData();
   size_t string_size = end_offset - start_offset;
+  if (string_size == 0) {
+    // Empty CSV string field → NULL. LDBC uses empty fields to mean
+    // "absent" (e.g. image-Post has empty `content`, text-Post has
+    // empty `imageFile`), so coalesce / IS NULL should treat them as
+    // missing rather than as the empty string (issue #90).
+    FlatVector::SetNull(output.data[i], current_index, true);
+    return;
+  }
+  auto data_ptr = output.data[i].GetData();
   ((string_t *)data_ptr)[current_index] = StringVector::AddStringOrBlob(output.data[i], (const char*)p.data() + start_offset, string_size);
 }
 

--- a/test/query/test_ldbc_ic_correctness.cpp
+++ b/test/query/test_ldbc_ic_correctness.cpp
@@ -478,14 +478,7 @@ TEST_CASE("IC7 recent likers", "[ldbc][ic][ic7]") {
         CHECK(r[i].str_at(2) == exp.last_name);
         CHECK(r[i].int64_at(3) == exp.like_creation_ms);
         CHECK(r[i].int64_at(4) == exp.comment_or_post_id);
-        // column 5 (commentOrPostContent) is gated on a separate data
-        // representation issue: image-Post `content` loads as empty
-        // string rather than NULL, so `coalesce(content, imageFile)`
-        // short-circuits on "" instead of falling through to imageFile.
-        // The two struct/interval pieces of #90 are resolved here;
-        // this remaining check needs the loader/storage path to treat
-        // empty CSV string fields as NULL.
-        // CHECK(r[i].str_at(5).find(exp.content) == 0);
+        CHECK(r[i].str_at(5).find(exp.content) == 0);
         CHECK(r[i].int64_at(6) == exp.minutes_latency);
         // column 7 (isNew) is engine-side pattern-expression placeholder,
         // also not asserted.


### PR DESCRIPTION
## Summary

- Treat empty CSV string fields as NULL during bulk load. LDBC uses empty fields to mean \"absent\" (image-Post has empty \`content\`, text-Post has empty \`imageFile\`); loading them as \`\"\"\` short-circuits \`coalesce(content, imageFile)\` to the empty string in IC7 / IC2 instead of falling through to \`imageFile\`.
- Subtle pitfall: \`FlatVector::SetNull\` auto-initialises the validity mask sized for \`STANDARD_VECTOR_SIZE\` (1024), but the bulk loader fills up to \`STORAGE_STANDARD_VECTOR_SIZE\` (~1M) rows per chunk. NULL bits at indices ≥1024 silently fell off the end and never made it to disk — \`coalesce\` would still see \"\". Pre-allocate via \`EnsureWritable(STORAGE_STANDARD_VECTOR_SIZE)\` on first SetNull.
- Un-gate IC7 column 5 (\`commentOrPostContent\`); now passes against the Neo4j-verified mini oracle.

## Test plan

- [x] \`build-portable/test/query/query_test \"IC7 recent likers\" --ldbc-path /tmp/ldbc-mini-ws\` — 136 assertions
- [x] \`build-portable/test/query/query_test \"[ldbc]~[crud]\" --ldbc-path /tmp/ldbc-mini-ws\` — 1567 passed (3 skipped via #138 mayfail)
- [x] \`build-portable/test/query/query_test \"[tpch]\"\` — 54/54
- [x] \`build-portable/test/unittest\` — 206/206
- [ ] CI Ubuntu + macOS green

Stacked on #140 — merge that one first.