### PR TITLE
struct_extract: missing field → NULL, non-STRUCT → error (closes #48, #132)

### DIFF
--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -16,13 +16,28 @@ namespace duckdb {
 
 struct StructExtractBindData : public FunctionData {
 	idx_t field_index;
-	explicit StructExtractBindData(idx_t idx) : field_index(idx) {}
-	unique_ptr<FunctionData> Copy() const { return make_unique<StructExtractBindData>(field_index); }
-	bool Equals(const FunctionData &o) const { return field_index == ((const StructExtractBindData &)o).field_index; }
+	bool missing_field;
+	StructExtractBindData(idx_t idx, bool missing = false)
+	    : field_index(idx), missing_field(missing) {}
+	unique_ptr<FunctionData> Copy() const {
+		return make_unique<StructExtractBindData>(field_index, missing_field);
+	}
+	bool Equals(const FunctionData &o) const {
+		auto &other = (const StructExtractBindData &)o;
+		return field_index == other.field_index &&
+		       missing_field == other.missing_field;
+	}
 };
 
 static void StructExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &bind_data = (StructExtractBindData &)*((BoundFunctionExpression &)state.expr).bind_info;
+	if (bind_data.missing_field) {
+		// Field name not present on the bound struct type — Cypher
+		// treats a missing property access as NULL (issue #132).
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		return;
+	}
 	auto &struct_vec = args.data[0];
 	auto &children = StructVector::GetEntries(struct_vec);
 	D_ASSERT(bind_data.field_index < children.size());
@@ -43,8 +58,11 @@ static unique_ptr<FunctionData> StructExtractBind(ClientContext &,
     ScalarFunction &bound_function, vector<unique_ptr<Expression>> &arguments) {
 	auto &struct_type = arguments[0]->return_type;
 	if (struct_type.id() != LogicalTypeId::STRUCT) {
-		bound_function.return_type = LogicalType::ANY;
-		return make_unique<StructExtractBindData>(0);
+		// Previously fell back to field index 0 silently — that masked
+		// real type errors with arbitrary first-field reads (issue #48).
+		throw BinderException(
+		    "struct_extract: first argument must be STRUCT, got " +
+		    struct_type.ToString());
 	}
 	string field_name;
 	if (arguments[1]->IsFoldable()) {
@@ -58,8 +76,12 @@ static unique_ptr<FunctionData> StructExtractBind(ClientContext &,
 			return make_unique<StructExtractBindData>(i);
 		}
 	}
-	bound_function.return_type = LogicalType::ANY;
-	return make_unique<StructExtractBindData>(0);
+	// Field name not in the bound struct's child list. Cypher property
+	// access on a non-existent key returns NULL — flag the missing field
+	// so the runtime emits a constant NULL instead of dereferencing
+	// children[0] of a different type (issue #132).
+	bound_function.return_type = LogicalType::SQLNULL;
+	return make_unique<StructExtractBindData>(0, /*missing=*/true);
 }
 
 void StructExtractFun::RegisterFunction(BuiltinFunctions &set) {

--- a/test/query/test_ldbc_traversal.cpp
+++ b/test/query/test_ldbc_traversal.cpp
@@ -250,6 +250,42 @@ TEST_CASE("struct_extract preserves row selection through CASE",
     CHECK(r[0].str_at(0).find("photo") == 0);
 }
 
+// Regression for issues #48 + #132: struct_extract used to silently
+// fall back to field index 0 when the requested field name was not
+// present on the bound STRUCT type. With #132's repro (Comment partition
+// has no imageFile column), the runtime dereferenced a wrong-typed
+// child and SIGSEGV'd. The bind path now flags the missing field so
+// the runtime emits a typed-NULL — Cypher property semantics let the
+// coalesce fall through to the next branch.
+TEST_CASE("struct_extract on missing field returns NULL (coalesce path)",
+          "[ldbc][traversal][issue-132][issue-48][struct-extract]") {
+    SKIP_IF_NO_DB();
+    // Comment has `content` but no `imageFile`. coalesce must pick
+    // content (non-NULL) since the imageFile branch is a missing-field
+    // NULL — pre-fix this query SIGSEGV'd at prepare.
+    auto r = qr->run(
+        "MATCH (m:Comment) WHERE m.content <> '' "
+        "WITH m LIMIT 1 "
+        "WITH head(collect({n: m})) AS w "
+        "RETURN coalesce(w.n.content, w.n.imageFile) AS pick",
+        {qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    REQUIRE(!r[0].is_null_at(0));
+    CHECK(r[0].str_at(0).size() > 0);
+}
+
+TEST_CASE("struct_extract on missing field is IS NULL",
+          "[ldbc][traversal][issue-132][issue-48][struct-extract]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (m:Comment) WITH m LIMIT 1 "
+        "WITH head(collect({n: m})) AS w "
+        "RETURN w.n.imageFile IS NULL AS missing",
+        {qtest::ColType::BOOL});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].bool_at(0) == true);
+}
+
 // toFloat(INTERVAL) → total milliseconds, the LDBC IC7 idiom for
 // "ms diff between two ms-timestamps".
 TEST_CASE("toFloat(INTERVAL) returns total milliseconds",


### PR DESCRIPTION
## Summary
- Missing struct field at bind now flags `missing_field` and the runtime emits a constant-NULL vector — Cypher property access on a non-existent key is NULL, not a wrong-typed `children[0]` read (closes #132, the LDBC Comment.imageFile SIGSEGV).
- Non-STRUCT first argument now throws `BinderException` at bind time instead of silently falling back to field index 0 (closes #48).
- Added two regression tests in `test_ldbc_traversal.cpp`:
  - `coalesce(w.n.content, w.n.imageFile)` on a Comment (which has no `imageFile`) returns content — pre-fix this SIGSEGV'd at prepare.
  - `w.n.imageFile IS NULL` on a Comment is true.

## Stacked on
- #141 (`fix-issue90-ic7-nested-struct`).

## Test plan
- [x] `ninja` in `build-portable`
- [x] `query_test [issue-132]` — both new tests pass
- [x] `query_test [ldbc]~[crud]` — 402 cases pass
- [x] `unittest` — 206 cases pass
- [ ] CI on macOS + Linux

## Notes
- The bind-time throw for non-STRUCT first argument is partly defensive: the catalog-side function lookup already rejects `(VARCHAR, VARCHAR)` because `ImplicitCast(VARCHAR, STRUCT({}))` returns -1. But future cast-rule changes that admit a `STRUCT({})` target could route us into bind with the wrong type, so the explicit check stays.
- The pre-existing SIGSEGV path triggered by literal `struct_extract('s', 'k')` (function-lookup failure → exception unwinds through ORCA → ORCA memory pool use-after-free) is the same class of issue as #136 and remains there.