### PR TITLE
list_value: materialise constant case once (closes #43)

### DIFF
--- a/src/function/scalar/list/list_value.cpp
+++ b/src/function/scalar/list/list_value.cpp
@@ -21,21 +21,38 @@ static void ListValueFunction(DataChunk &args, ExpressionState &state, Vector &r
 	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
 	auto &child_type = ListType::GetChildType(result.GetType());
 
-	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	bool all_constant = true;
 	for (idx_t i = 0; i < args.ColumnCount(); i++) {
 		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
-			result.SetVectorType(VectorType::FLAT_VECTOR);
+			all_constant = false;
+			break;
 		}
 	}
 
-	auto result_data = FlatVector::GetData<list_entry_t>(result);
-	for (idx_t i = 0; i < args.size(); i++) {
-		result_data[i].offset = ListVector::GetListSize(result);
+	if (all_constant) {
+		// All-constant input → produce a single list value. Writing per
+		// row into a CONSTANT_VECTOR ran off the single-slot buffer for
+		// multi-row chunks (issue #43); a constant list is the same
+		// value repeated, so materialise once.
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		auto result_data = ConstantVector::GetData<list_entry_t>(result);
+		result_data[0].offset = ListVector::GetListSize(result);
 		for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
-			auto val = args.GetValue(col_idx, i).CastAs(child_type);
+			auto val = args.GetValue(col_idx, 0).CastAs(child_type);
 			ListVector::PushBack(result, val);
 		}
-		result_data[i].length = args.ColumnCount();
+		result_data[0].length = args.ColumnCount();
+	} else {
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		auto result_data = FlatVector::GetData<list_entry_t>(result);
+		for (idx_t i = 0; i < args.size(); i++) {
+			result_data[i].offset = ListVector::GetListSize(result);
+			for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
+				auto val = args.GetValue(col_idx, i).CastAs(child_type);
+				ListVector::PushBack(result, val);
+			}
+			result_data[i].length = args.ColumnCount();
+		}
 	}
 	result.Verify(args.size());
 }

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -334,6 +334,25 @@ TEST_CASE("nested map property access", "[ldbc][filter][map]") {
     CHECK(r[0].str_at(0) == ldbc::SAMPLE_PERSON_FIRST_NAME);
 }
 
+// Regression for issue #43: list_value with all-constant arguments set
+// the result to CONSTANT_VECTOR but still wrote one list_entry_t per
+// input row, running past the constant slot. For a multi-row chunk
+// (e.g. MATCH returning N rows + RETURN [c1, c2]) this corrupted
+// adjacent memory or produced wrong-length lists. After the fix the
+// constant case materialises a single list value.
+TEST_CASE("constant list literal across multi-row input",
+          "[ldbc][filter][issue-43][list-value]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (p:Person) WITH p LIMIT 5 "
+        "RETURN size([1, 2, 3, 4]) AS sz",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 5);
+    for (size_t i = 0; i < r.size(); ++i) {
+        CHECK(r[i].int64_at(0) == 4);
+    }
+}
+
 TEST_CASE("head function on list", "[ldbc][filter][func][map]") {
     SKIP_IF_NO_DB();
     auto q = "MATCH (p:Person {id: " + sample_person_id_str() +


### PR DESCRIPTION
## Summary
- When all arguments are CONSTANT_VECTOR, list_value used to switch the result to CONSTANT_VECTOR and then write one \`list_entry_t\` per input row — but constant-vector storage holds a single payload, so multi-row chunks ran off the slot.
- Split the function: all-constant materialises a single list value (offset[0], length[0]); otherwise FLAT_VECTOR per-row as before.
- Regression test in \`test_ldbc_filter.cpp\` exercises a 5-row \`MATCH (p:Person)\` projecting \`size([1,2,3,4])\`. Every row must report size 4.

## Stacked on
- #142 (\`fix-issue48-132-struct-extract\`).

## Test plan
- [x] \`ninja\` in \`build-portable\`
- [x] \`query_test [issue-43]\` passes
- [x] \`query_test [ldbc]~[crud]\` — 403 cases pass
- [x] \`unittest\` — 206 cases pass
- [ ] CI on macOS + Linux