### PR TITLE
bufferpool: gate dirty_count_ on clean↔dirty transitions (closes #2)

### DIFF
--- a/src/include/storage/cache/buffer_pool.h
+++ b/src/include/storage/cache/buffer_pool.h
@@ -57,9 +57,12 @@ public:
     // Decrement pin_count (makes page evictable when count reaches 0).
     void Release(ChunkID cid);
 
-    // Dirty-bit management.
-    void SetDirty(ChunkID cid);
-    void ClearDirty(ChunkID cid);
+    // Dirty-bit management. SetDirty / ClearDirty return true when the
+    // entry's dirty bit actually changed, so callers can keep their
+    // aggregate dirty counter consistent (only count clean→dirty and
+    // dirty→clean transitions, not no-op writes — issue #2).
+    bool SetDirty(ChunkID cid);
+    bool ClearDirty(ChunkID cid);
     bool GetDirty(ChunkID cid) const;
 
     // Remove a page immediately (caller must already have flushed if dirty).

--- a/src/storage/cache/buffer_pool.cc
+++ b/src/storage/cache/buffer_pool.cc
@@ -118,16 +118,22 @@ void BufferPool::Release(ChunkID cid) {
 // Dirty-bit helpers
 // ---------------------------------------------------------------------------
 
-void BufferPool::SetDirty(ChunkID cid) {
+bool BufferPool::SetDirty(ChunkID cid) {
     std::lock_guard<std::mutex> lk(mu_);
     auto it = entries_.find(cid);
-    if (it != entries_.end()) it->second.dirty = true;
+    if (it == entries_.end()) return false;
+    if (it->second.dirty) return false;
+    it->second.dirty = true;
+    return true;
 }
 
-void BufferPool::ClearDirty(ChunkID cid) {
+bool BufferPool::ClearDirty(ChunkID cid) {
     std::lock_guard<std::mutex> lk(mu_);
     auto it = entries_.find(cid);
-    if (it != entries_.end()) it->second.dirty = false;
+    if (it == entries_.end()) return false;
+    if (!it->second.dirty) return false;
+    it->second.dirty = false;
+    return true;
 }
 
 bool BufferPool::GetDirty(ChunkID cid) const {

--- a/src/storage/cache/chunk_cache_manager.cc
+++ b/src/storage/cache/chunk_cache_manager.cc
@@ -332,8 +332,9 @@ ReturnStatus ChunkCacheManager::PinSegment(ChunkID cid, std::string file_path, u
     if (pool_->GetDirty(victim)) {
       // Flush victim to disk before evicting (calls PinSegment → cache hit).
       UnswizzleFlushSwizzle(victim, file_handlers[victim], false);
-      pool_->ClearDirty(victim);
-      dirty_count_.fetch_sub(1, std::memory_order_relaxed);
+      if (pool_->ClearDirty(victim)) {
+        dirty_count_.fetch_sub(1, std::memory_order_relaxed);
+      }
     }
     pool_->Remove(victim);
   }
@@ -374,8 +375,12 @@ ReturnStatus ChunkCacheManager::UnPinSegment(ChunkID cid) {
 
 ReturnStatus ChunkCacheManager::SetDirty(ChunkID cid) {
   UpgradeToWriteLock();
-  pool_->SetDirty(cid);
-  dirty_count_.fetch_add(1, std::memory_order_relaxed);
+  // Only count clean→dirty transitions: repeated writes to a segment
+  // already marked dirty should not inflate dirty_count_ and falsely
+  // trigger watermark throttling (issue #2).
+  if (pool_->SetDirty(cid)) {
+    dirty_count_.fetch_add(1, std::memory_order_relaxed);
+  }
   return NOERROR;
 }
 
@@ -428,8 +433,9 @@ ReturnStatus ChunkCacheManager::FlushDirtySegmentsAndDeleteFromcache(bool destro
     spdlog::trace("[FlushDirtySegmentsAndDeleteFromcache] Flush file: {} with size {}", file_handler.second->GetFilePath(), file_handler.second->file_size());
 
     UnswizzleFlushSwizzle(file_handler.first, file_handler.second, false);
-    pool_->ClearDirty(file_handler.first);
-    dirty_count_.fetch_sub(1, std::memory_order_relaxed);
+    if (pool_->ClearDirty(file_handler.first)) {
+      dirty_count_.fetch_sub(1, std::memory_order_relaxed);
+    }
     if (destroy_segment) {
       DestroySegment(file_handler.first);
     }

--- a/test/storage/test_buffer_pool.cpp
+++ b/test/storage/test_buffer_pool.cpp
@@ -102,6 +102,39 @@ TEST_CASE("BufferPool: SetDirty / ClearDirty round-trip", "[storage][bufferpool]
     REQUIRE_FALSE(pool.GetDirty(2));
 }
 
+// Regression for issue #2: SetDirty / ClearDirty must report whether
+// the entry's dirty bit actually flipped, so an aggregate dirty
+// counter only counts clean→dirty and dirty→clean transitions.
+TEST_CASE("BufferPool: SetDirty returns true only on clean→dirty transition",
+          "[storage][bufferpool][issue-2]") {
+    BufferPool pool(LIMIT);
+    uint8_t* ptr = nullptr;
+    REQUIRE(pool.Alloc(3, 512, &ptr));
+
+    REQUIRE(pool.SetDirty(3));         // clean→dirty
+    REQUIRE_FALSE(pool.SetDirty(3));   // already dirty: no transition
+    REQUIRE_FALSE(pool.SetDirty(3));
+    REQUIRE(pool.GetDirty(3));
+
+    // Unknown cid: no entry → no transition.
+    REQUIRE_FALSE(pool.SetDirty(999));
+}
+
+TEST_CASE("BufferPool: ClearDirty returns true only on dirty→clean transition",
+          "[storage][bufferpool][issue-2]") {
+    BufferPool pool(LIMIT);
+    uint8_t* ptr = nullptr;
+    REQUIRE(pool.Alloc(4, 512, &ptr));
+
+    REQUIRE_FALSE(pool.ClearDirty(4)); // already clean
+    pool.SetDirty(4);
+    REQUIRE(pool.ClearDirty(4));       // dirty→clean
+    REQUIRE_FALSE(pool.ClearDirty(4)); // back to clean
+    REQUIRE_FALSE(pool.GetDirty(4));
+
+    REQUIRE_FALSE(pool.ClearDirty(999));
+}
+
 // ---------------------------------------------------------------------------
 // Remove
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- \`ChunkCacheManager::SetDirty\` unconditionally bumped \`dirty_count_\`. Re-marking an already-dirty segment kept inflating the counter, eventually crossing \`CRITICAL_WATERMARK\` and throttling the write pipeline on workloads where no new segment had become dirty.
- \`BufferPool::SetDirty\` / \`ClearDirty\` now return \`bool\` — true only when the entry's dirty bit actually flipped. Unknown cid returns false.
- The three callers in \`ChunkCacheManager\` (SetDirty, eviction flush, drain flush) gate \`dirty_count_\` updates on that return.

## Stacked on
- #143 (\`fix-issue43-list-value-constant\`).

## Test plan
- [x] \`ninja\` in \`build-portable\`
- [x] \`unittest [issue-2]\` — 2 cases, 12 assertions
- [x] \`unittest\` — 208 cases pass
- [x] \`query_test [ldbc]~[crud]\` — 403 cases pass
- [ ] CI on macOS + Linux