### PR TITLE
extent: read DECIMAL filter literals as unscaled int (closes #117)

### DIFF
--- a/src/storage/extent/extent_iterator.cpp
+++ b/src/storage/extent/extent_iterator.cpp
@@ -87,19 +87,26 @@ struct BigintRange {
 };
 } // namespace common
 
+// Read the raw unscaled internal integer instead of going through
+// Value::GetValue<T>, which for DECIMAL Values casts via DOUBLE and
+// returns the *semantic* value (24.00 → 24). Columns store the
+// unscaled int (24.00 → 2400), so the zone-map min/max must be
+// compared against the unscaled literal (issue #117). For non-DECIMAL
+// integers GetValueUnsafe<T> is a direct union read and matches
+// GetValue<T>'s identity path.
 static bool TryGetSignedPruningScalar(const Value &value, int64_t &result) {
     switch (value.type().InternalType()) {
     case PhysicalType::INT8:
-        result = value.GetValue<int8_t>();
+        result = value.GetValueUnsafe<int8_t>();
         return true;
     case PhysicalType::INT16:
-        result = value.GetValue<int16_t>();
+        result = value.GetValueUnsafe<int16_t>();
         return true;
     case PhysicalType::INT32:
-        result = value.GetValue<int32_t>();
+        result = value.GetValueUnsafe<int32_t>();
         return true;
     case PhysicalType::INT64:
-        result = value.GetValue<int64_t>();
+        result = value.GetValueUnsafe<int64_t>();
         return true;
     default:
         return false;
@@ -109,16 +116,16 @@ static bool TryGetSignedPruningScalar(const Value &value, int64_t &result) {
 static bool TryGetUnsignedPruningScalar(const Value &value, uint64_t &result) {
     switch (value.type().InternalType()) {
     case PhysicalType::UINT8:
-        result = value.GetValue<uint8_t>();
+        result = value.GetValueUnsafe<uint8_t>();
         return true;
     case PhysicalType::UINT16:
-        result = value.GetValue<uint16_t>();
+        result = value.GetValueUnsafe<uint16_t>();
         return true;
     case PhysicalType::UINT32:
-        result = value.GetValue<uint32_t>();
+        result = value.GetValueUnsafe<uint32_t>();
         return true;
     case PhysicalType::UINT64:
-        result = value.GetValue<uint64_t>();
+        result = value.GetValueUnsafe<uint64_t>();
         return true;
     default:
         return false;
@@ -1498,9 +1505,11 @@ void ExtentIterator::findMatchedRowsEQFilter(
     }
     else if (column_type.id() == LogicalTypeId::DECIMAL &&
              value_type.id() == LogicalTypeId::DECIMAL) {
+        // Read the literal's unscaled internal integer to match the
+        // column's on-disk encoding (issue #117).
         switch (column_type.InternalType()) {
             case PhysicalType::INT16: {
-                auto int16_value = filterValue.GetValue<int16_t>();
+                auto int16_value = filterValue.GetValueUnsafe<int16_t>();
                 auto filter = std::make_unique<common::BigintRange>(
                     static_cast<int64_t>(int16_value),
                     static_cast<int64_t>(int16_value), false);
@@ -1510,7 +1519,7 @@ void ExtentIterator::findMatchedRowsEQFilter(
                 break;
             }
             case PhysicalType::INT32: {
-                auto int32_value = filterValue.GetValue<int32_t>();
+                auto int32_value = filterValue.GetValueUnsafe<int32_t>();
                 auto filter = std::make_unique<common::BigintRange>(
                     static_cast<int64_t>(int32_value),
                     static_cast<int64_t>(int32_value), false);
@@ -1520,7 +1529,7 @@ void ExtentIterator::findMatchedRowsEQFilter(
                 break;
             }
             case PhysicalType::INT64: {
-                auto int64_value = filterValue.GetValue<int64_t>();
+                auto int64_value = filterValue.GetValueUnsafe<int64_t>();
                 auto filter = std::make_unique<common::BigintRange>(
                     static_cast<int64_t>(int64_value),
                     static_cast<int64_t>(int64_value), false);
@@ -1620,10 +1629,12 @@ void ExtentIterator::findMatchedRowsRangeFilter(
     }
     else if (column_type.id() == LogicalTypeId::DECIMAL &&
              value_type.id() == LogicalTypeId::DECIMAL) {
+        // DECIMAL literal: read the unscaled int to match the column's
+        // on-disk encoding (issue #117).
         switch (column_type.InternalType()) {
             case PhysicalType::INT16: {
-                auto l_int16_value = l_filterValue.GetValue<int16_t>();
-                auto r_int16_value = r_filterValue.GetValue<int16_t>();
+                auto l_int16_value = l_filterValue.GetValueUnsafe<int16_t>();
+                auto r_int16_value = r_filterValue.GetValueUnsafe<int16_t>();
                 if (!l_inclusive)
                     l_int16_value = l_int16_value + 1;
                 if (!r_inclusive)
@@ -1637,8 +1648,8 @@ void ExtentIterator::findMatchedRowsRangeFilter(
                 break;
             }
             case PhysicalType::INT32: {
-                auto l_int32_value = l_filterValue.GetValue<int32_t>();
-                auto r_int32_value = r_filterValue.GetValue<int32_t>();
+                auto l_int32_value = l_filterValue.GetValueUnsafe<int32_t>();
+                auto r_int32_value = r_filterValue.GetValueUnsafe<int32_t>();
                 if (!l_inclusive)
                     l_int32_value = l_int32_value + 1;
                 if (!r_inclusive)
@@ -1652,8 +1663,8 @@ void ExtentIterator::findMatchedRowsRangeFilter(
                 break;
             }
             case PhysicalType::INT64: {
-                auto l_int64_value = l_filterValue.GetValue<int64_t>();
-                auto r_int64_value = r_filterValue.GetValue<int64_t>();
+                auto l_int64_value = l_filterValue.GetValueUnsafe<int64_t>();
+                auto r_int64_value = r_filterValue.GetValueUnsafe<int64_t>();
                 if (!l_inclusive)
                     l_int64_value = l_int64_value + 1;
                 if (!r_inclusive)

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -607,6 +607,45 @@ TEST_CASE("Range cmp on UBIGINT :ID column",
     CHECK(r[0].int64_at(0) == 17);
 }
 
+// Regression for issue #117. The storage pruning / SIMD-filter helpers
+// extracted DECIMAL filter values through `Value::GetValue<int64_t>`,
+// which routes DECIMAL through a CastAs(DOUBLE) and yields the
+// *semantic* value (24.00 → 24). Columns are stored in unscaled
+// internal-int form (24.00 → 2400), so `<` returned 0 rows and `>`
+// returned every row. The bug is latent today because most DECIMAL
+// literals get re-cast by ORCA before reaching the simple-filter
+// path, but a DECIMAL-DECIMAL cmp written directly with a DECIMAL
+// literal (24.0) does hit it.
+TEST_CASE("DECIMAL filter on L_QUANTITY (issue #117)",
+          "[tpch][cmp][cmp-decimal][issue-117]") {
+    SKIP_IF_NO_DB();
+    // Oracle counts cross-checked against DuckDB SF0.01:
+    // total LINEITEM rows = 60175 = 27627 (<24) + 1240 (=24) + 31308 (>24).
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) WHERE l.L_QUANTITY < 24.0 RETURN count(l) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 27627);
+
+    r = qr->run(
+        "MATCH (l:LINEITEM) WHERE l.L_QUANTITY > 24.0 RETURN count(l) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 31308);
+
+    r = qr->run(
+        "MATCH (l:LINEITEM) WHERE l.L_QUANTITY = 24.0 RETURN count(l) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 1240);
+
+    // The three branches partition the full LINEITEM relation.
+    r = qr->run("MATCH (l:LINEITEM) RETURN count(l) AS c",
+                {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 60175);
+}
+
 // Q8 — ETHIOPIA market-share within AFRICA, by ship year. Two rows
 // (1995 / 1996). Values verified against DuckDB SF0.01.
 TEST_CASE("TPC-H Q8 (rows)", "[tpch][q8]") {


### PR DESCRIPTION
## Summary
- Storage pruning helpers and SIMD-filter DECIMAL branches read filter values via \`Value::GetValue<int64_t>\`, which routes DECIMAL through \`CastAs(DOUBLE)\` and yields the semantic value (\`24.00 → 24\`). Columns are stored as unscaled internal ints (\`24.00 → 2400\`); comparing semantic literal vs unscaled column makes every row look \`> literal\`, so \`<\` / \`<=\` returned 0 rows and \`>\` / \`>=\` returned everything.
- Switched to \`GetValueUnsafe<T>\` at all affected sites — for DECIMAL it reads the union slot directly (unscaled int); for non-DECIMAL it's identity.
- Sites changed:
  - \`TryGetSignedPruningScalar\` / \`TryGetUnsignedPruningScalar\` (4 cases each — zone-map pruning).
  - SIMD equality DECIMAL branches (INT16 / INT32 / INT64).
  - SIMD range DECIMAL branches (lower + upper, three widths each).
- Latent on \`main\` because \`l.L_QUANTITY < 24\` (INT literal) gets ORCA-cast into the expression-executor path, bypassing these helpers; a DECIMAL literal (\`24.0\`) hits the simple-filter path and surfaces the bug.

## Stacked on
- #144 (\`fix-issue2-dirty-count-transitions\`).

## Test plan
- [x] \`ninja\` in \`build-portable\`
- [x] New \`[issue-117]\` test: \`L_QUANTITY < / = / > 24.0\` and total → 27627 / 1240 / 31308 / 60175 (DuckDB cross-checked on the same \`tpch-mini\` CSV).
- [x] \`query_test [tpch],[ldbc]~[crud]\` — 458 cases pass.
- [ ] CI on macOS + Linux.

## Follow-up
Once these helpers are unscaled-safe, the converter's int-literal promotion can extend its \`is_integer\` predicate to DECIMAL/FLOAT/DOUBLE without flipping \`<\` / \`>\` results.