### PR TITLE
ci: run LDBC [crud] suite on the mini fixture

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -196,6 +196,18 @@ jobs:
         # track issue #73 (empty-string return on the mini fixture).
         run: ./build-portable/test/query/query_test "[ldbc][func]" --ldbc-path /tmp/ldbc-mini-ws
 
+      - name: Run LDBC [crud] tests on mini fixture
+        # `[ldbc][crud]` exercises CREATE / SET / DELETE / DETACH DELETE /
+        # MERGE / REMOVE / WAL / compaction round-trips against an
+        # isolated copy of the mini fixture made per-test (so mutations
+        # never bleed). 148 cases on SF0.003, all fixture-pinned via
+        # the `ldbc::SAMPLE_PERSON_ID` family in helpers/. The macOS-
+        # incompatible `cp --reflink=auto` was switched to a portable
+        # dispatcher in #146; reduces local-only developer divergence.
+        # `[!mayfail]` covers seven CRUD compaction cases (separate
+        # issue) and stays out of the failure count.
+        run: ./build-portable/test/query/query_test "[ldbc][crud]" --ldbc-path /tmp/ldbc-mini-ws
+
       - name: Build Python wheel
         run: bash tools/pythonpkg/scripts/build_wheel.sh build-portable
 


### PR DESCRIPTION
## Summary
The CRUD test suite (CREATE / SET / DELETE / DETACH DELETE / MERGE / REMOVE / WAL / compaction round-trips) had no CI step on either platform. PR #146 made the per-test workspace copy macOS-portable and migrated the test bodies to the SF0.003 mini fixture, so the suite now runs cleanly end-to-end on the same fixture CI already loads for the other \`[ldbc][...]\` steps.

Adds a \`[ldbc][crud]\` step right after the existing \`[ldbc][func]\` step. Locally on macOS the step covers 130 cases / 372 assertions (seven \`[!mayfail]\` compaction cases stay out of the failure count and are tracked as a separate fixture-content follow-up).

No other workflow changes — same job matrix (macos-latest, ubuntu-latest) and same per-step timeout.

## Stacked on
- #151 (\`tpch-mini-value-tests\`). Stack: #150 → #151 → this.

## Test plan
- [x] \`query_test [ldbc][crud] --ldbc-path /tmp/ldbc-mini-ws\` — 130/130 cases, 372 assertions on macOS.
- [ ] CI on macOS + Linux (this PR's own check is the actual validation).