### PR TITLE
chore: drop dead TPCH_TEST_BROKEN_MINI macro + CI filter

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -122,12 +122,11 @@ jobs:
         run: ./build-portable/test/query/query_test "[types]" --types-path /tmp/types-mini-ws
 
       - name: Run TPC-H [tpch] query tests on mini fixture
-        # `[broken-mini]`: 11 queries currently SIGSEGV inside the engine on
-        # the SF0.01 fixture (issue #69 — tracked separately). Excluded so
-        # one query's signal doesn't tear down the rest of the run.
         # `[stress]`: stress tests reference legacy hardcoded paths and need
-        # a follow-up cleanup before they can run in CI.
-        run: ./build-portable/test/query/query_test "[tpch]~[broken-mini]~[stress]" --tpch-path /tmp/tpch-mini-ws
+        # a follow-up cleanup before they can run in CI. The historical
+        # `[broken-mini]` exclusion (issue #69, 11 SIGSEGV'ing queries)
+        # is gone — all 22 queries are now exercised end-to-end.
+        run: ./build-portable/test/query/query_test "[tpch]~[stress]" --tpch-path /tmp/tpch-mini-ws
 
       - name: Load LDBC SF0.003 mini fixture
         run: bash scripts/load-ldbc-mini.sh build-portable /tmp/ldbc-mini-ws

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -11,10 +11,10 @@
 //                counts come from DuckDB-generated reference CSVs.
 //   * SF0.01  — the committed mini fixture under `test/data/tpch-mini/`,
 //                loaded via `scripts/load-tpch-mini.sh`. CI uses this.
-//                Eleven of the 22 queries currently SIGSEGV at this
-//                scale (issue #69) and are wrapped with the
-//                `TPCH_TEST_BROKEN_MINI` macro / `[broken-mini]` tag so
-//                they don't tear down the rest of the run.
+//                All 22 queries are now exercised end-to-end on the
+//                SF0.01 fixture; the historical `[broken-mini]` carve-
+//                out (issue #69) is gone and the corresponding macro
+//                has been removed.
 //
 // The path to the .cql query files is resolved at compile time via
 // the TURBOLYNX_REPO_ROOT define injected by CMakeLists.txt.
@@ -91,23 +91,8 @@ TEST_CASE("TPC-H Q" #qnum, "[tpch][q" #qnum "]") { \
     } \
 }
 
-// SF0.01-only macro for queries that SIGSEGV inside the engine on the
-// mini fixture. Tagged `[broken-mini]` so the CI filter excludes them.
-// When the underlying engine bug is fixed, replace with `TPCH_TEST(qnum, ...)`.
-#define TPCH_TEST_BROKEN_MINI(qnum, issue) \
-TEST_CASE("TPC-H Q" #qnum " (broken on SF0.01, issue " issue ")", \
-          "[tpch][q" #qnum "][broken-mini]") { \
-    SKIP_IF_NO_DB(); \
-    std::string query = readFile(QUERY_DIR + "q" #qnum ".cql"); \
-    REQUIRE(!query.empty()); \
-    auto r = qr->run(query.c_str(), {}); \
-    /* If we got here without SIGSEGV / exception, the underlying bug \
-       is likely fixed — convert the call site to TPCH_TEST. */ \
-    FAIL("Query no longer crashes — replace TPCH_TEST_BROKEN_MINI with TPCH_TEST"); \
-}
-
 #ifdef TURBOLYNX_TPCH_FIXTURE_MINI
-// SF0.01 mini fixture: 11 passing queries + 11 broken-mini.
+// SF0.01 mini fixture: all 22 queries pass end-to-end.
 
 // Issue #106 — broader func-over-agg coverage. Each of these has at
 // least one projection element where containsAgg=true (the aggregate


### PR DESCRIPTION
## Summary
The \`TPCH_TEST_BROKEN_MINI\` macro and the matching \`~[broken-mini]\` CI exclusion are dead code: all 11 queries originally tagged \`[broken-mini]\` (issue #69) were fixed long ago, and the macro has never been re-invoked since. This PR removes the macro, refreshes the file-header docstring, and drops the no-op exclusion from the workflow.

## Stacked on
- #152 (\`ci-crud-step\`). Stack: #150 → #151 → #152 → this.

## Test plan
- [x] \`query_test [tpch]~[stress]\` — 53/53 cases, 1038 assertions on macOS
- [ ] CI on macOS + Linux