### PR TITLE
ci: include LDBC [robustness][stress] in mini sweep

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -171,13 +171,16 @@ jobs:
         run: ./build-portable/test/query/query_test "[ldbc][ic]" --ldbc-path /tmp/ldbc-mini-ws
 
       - name: Run LDBC [robustness] tests on mini fixture
-        # `[ldbc][robustness]~[stress]` exercises invalid/malformed
-        # query handling against fixture-pinned anchors. `~[stress]`
-        # excludes the four stress cases that depend on legacy SF1
-        # paths. SIGSEGV-prone cases (issue #79) are gated SF1-only
-        # via #ifndef TURBOLYNX_LDBC_FIXTURE_MINI; the SF1 binder
-        # guard probe (#80) is similarly gated.
-        run: ./build-portable/test/query/query_test "[ldbc][robustness]~[stress]" --ldbc-path /tmp/ldbc-mini-ws
+        # `[ldbc][robustness]` exercises invalid/malformed query
+        # handling against fixture-pinned anchors. The four `[stress]`
+        # cases (deep-OR/function-call chains, large IN list, long
+        # string literal) are fixture-independent stress probes that
+        # run cleanly on mini and complete in well under a second
+        # each, so the historical `~[stress]` exclusion has been
+        # dropped. SIGSEGV-prone cases (issue #79) remain gated
+        # SF1-only via `#ifndef TURBOLYNX_LDBC_FIXTURE_MINI`; the SF1
+        # binder guard probe (#80) is similarly gated.
+        run: ./build-portable/test/query/query_test "[ldbc][robustness]" --ldbc-path /tmp/ldbc-mini-ws
 
       - name: Run LDBC [filter] tests on mini fixture
         # `[ldbc][filter]` exercises property filters, UNWIND, scalar


### PR DESCRIPTION
## Summary
Drop the \`~[stress]\` carve-out from the \`[ldbc][robustness]\` CI step. The four affected cases (deep-OR / deep-function chains, large IN list, very long string literal) are fixture-independent malformed-query probes that run cleanly on the mini fixture in well under a second each.

The other historically-stress carve-outs are intentional and stay:
- \`[ldbc][crud][stress]\` (8 cases) is already in CI via \`[ldbc][crud]\` (no \`~[stress]\` filter there).
- \`[tpch][stress]\` (3 cases: Q21/Q12 multi-thread loops + the parallel-scan benchmark) remains excluded — they're long-running perf probes, not correctness checks.

## Stacked on
- #153 (\`chore-cleanup-broken-mini\`). Stack: #150 → #151 → #152 → #153 → this.

## Test plan
- [x] \`query_test [ldbc][robustness]\` on mini — 240/240 cases (was 236; +4 stress cases) / 256 assertions
- [ ] CI on macOS + Linux