### PR TITLE
chore: drop dead [!mayfail] tag on CRUD compaction tests

### DIFF
--- a/test/query/test_ldbc_crud.cpp
+++ b/test/query/test_ldbc_crud.cpp
@@ -1911,7 +1911,7 @@ TEST_CASE("parallel checkpointed fresh KNOWS traversal preserves rowset",
     }
 }
 
-TEST_CASE("CREATE node findable by id after compaction", "[ldbc][crud][compaction][!mayfail]") {
+TEST_CASE("CREATE node findable by id after compaction", "[ldbc][crud][compaction]") {
     COMPACTION_SETUP();
     try {
         qr->run("CREATE (n:Person {id: 11111111111110, firstName: 'FindAfterCP'})", {});
@@ -1952,7 +1952,7 @@ TEST_CASE("multiple CREATEs survive compaction", "[ldbc][crud][compaction]") {
     }
 }
 
-TEST_CASE("SET survives compaction + reconnect", "[ldbc][crud][compaction][!mayfail]") {
+TEST_CASE("SET survives compaction + reconnect", "[ldbc][crud][compaction]") {
     COMPACTION_SETUP();
     try {
         qr->run("MATCH (n:Person {id: " SAMPLE_ID_S "}) SET n.firstName = 'Compacted933'", {});
@@ -1969,7 +1969,7 @@ TEST_CASE("SET survives compaction + reconnect", "[ldbc][crud][compaction][!mayf
     }
 }
 
-TEST_CASE("DELETE survives compaction + reconnect", "[ldbc][crud][compaction][!mayfail]") {
+TEST_CASE("DELETE survives compaction + reconnect", "[ldbc][crud][compaction]") {
     COMPACTION_SETUP();
     try {
         auto before = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
@@ -1989,7 +1989,7 @@ TEST_CASE("DELETE survives compaction + reconnect", "[ldbc][crud][compaction][!m
     }
 }
 
-TEST_CASE("CREATE with full schema survives compaction", "[ldbc][crud][compaction][!mayfail]") {
+TEST_CASE("CREATE with full schema survives compaction", "[ldbc][crud][compaction]") {
     COMPACTION_SETUP();
     try {
         // Full Person schema — should match existing PropertySchema exactly


### PR DESCRIPTION
## Summary
Four CRUD compaction \`TEST_CASE\`s carried \`[!mayfail]\` from when checkpoint round-trips were known-flaky. Locally on mini all four pass without the failure-isolation tag, so the tag is dead — strip it so a future regression that breaks any of these surfaces as an outright CI failure rather than being silently downgraded.

Tests affected:
- \`CREATE node findable by id after compaction\`
- \`SET survives compaction + reconnect\`
- \`DELETE survives compaction + reconnect\`
- \`CREATE with full schema survives compaction\`

## Stacked on
- #154 (\`chore-stress-cleanup\`). Stack: #150 → #151 → #152 → #153 → #154 → this.

## Test plan
- [x] \`query_test [ldbc][crud]\` on mini — 130/130 cases / 372 assertions (unchanged from previous run)
- [ ] CI on macOS + Linux