### PR TITLE
chore: drop dead [!mayfail] tag on REPLY_OF / Message-MPV counts

### DIFF
--- a/test/query/test_ldbc_count.cpp
+++ b/test/query/test_ldbc_count.cpp
@@ -116,12 +116,12 @@ TEST_CASE("CONTAINER_OF count", "[ldbc][count]") {
     REQUIRE(qr->count("MATCH (a:Forum)-[r:CONTAINER_OF]->(b:Post) RETURN count(r)") == ldbc::CONTAINER_OF_COUNT);
 }
 
-TEST_CASE("REPLY_OF (Comment->Post) count", "[ldbc][count][!mayfail]") {
+TEST_CASE("REPLY_OF (Comment->Post) count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
     REQUIRE(qr->count("MATCH (a:Comment)-[r:REPLY_OF]->(b:Post) RETURN count(r)") == ldbc::REPLY_OF_POST_COUNT);
 }
 
-TEST_CASE("REPLY_OF (Comment->Comment) count", "[ldbc][count][!mayfail]") {
+TEST_CASE("REPLY_OF (Comment->Comment) count", "[ldbc][count]") {
     SKIP_IF_NO_DB();
     REQUIRE(qr->count("MATCH (a:Comment)-[r:REPLY_OF]->(b:Comment) RETURN count(r)") == ldbc::REPLY_OF_COMMENT_COUNT);
 }
@@ -155,7 +155,7 @@ TEST_CASE("IS_PART_OF count", "[ldbc][count]") {
 // Multi-partition vertex (MPV) — :Message = Comment + Post
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Message count", "[ldbc][count][mpv][!mayfail]") {
+TEST_CASE("Message count", "[ldbc][count][mpv]") {
     SKIP_IF_NO_DB();
     REQUIRE(qr->count("MATCH (m:Message) RETURN count(m)") == ldbc::MESSAGE_COUNT);
 }

--- a/test/query/test_ldbc_traversal.cpp
+++ b/test/query/test_ldbc_traversal.cpp
@@ -179,8 +179,8 @@ TEST_CASE("Message via HAS_CREATOR count", "[ldbc][traversal][mpv]") {
 
 // MPV-02: Count all Messages via REPLY_OF (multi-partition edge + multi-partition vertex)
 // Verified relative to (REPLY_OF→Post + REPLY_OF→Comment) so it stays
-// fixture-independent. Tagged [!mayfail] for pre-existing flakiness.
-TEST_CASE("REPLY_OF to Message count", "[ldbc][traversal][mpv][!mayfail]") {
+// fixture-independent. Previously tagged [!mayfail]; counts match the fixture cleanly now.
+TEST_CASE("REPLY_OF to Message count", "[ldbc][traversal][mpv]") {
     SKIP_IF_NO_DB();
     auto r = qr->run(
         "MATCH (c:Comment)-[:REPLY_OF]->(m:Message) "


### PR DESCRIPTION
## Summary
Three REPLY_OF / Message multi-partition-vertex count tests carried \`[!mayfail]\` from a window when the MPV path was being stabilised. All four pass cleanly on the SF0.003 mini fixture today and produce oracle-matching counts. Strip the tag so any future MPV regression here surfaces as a hard CI failure.

Tests affected:
- REPLY_OF (Comment→Post) count
- REPLY_OF (Comment→Comment) count
- Message count (MPV)
- REPLY_OF to Message count (MPV traversal)

## Stacked on
- #155 (\`chore-cleanup-mayfail-compaction\`). Stack: #150 → #151 → #152 → #153 → #154 → #155 → this.

## Test plan
- [x] \`query_test [ldbc][count],[ldbc][traversal]\` — 69/69 cases / 243 assertions
- [ ] CI on macOS + Linux