### PR TITLE
sum: zero target slot on empty input so NULL is deterministic

### DIFF
--- a/src/function/aggregate/distributive/sum.cpp
+++ b/src/function/aggregate/distributive/sum.cpp
@@ -31,11 +31,18 @@ struct SumSetOperation {
 	}
 };
 
+// Empty SUM → result slot must be NULL. Some downstream readers
+// (e.g. the C API DECIMAL getter, which has no validity bit) read the
+// raw value regardless of the mask, so the slot also has to be
+// deterministically zero — otherwise the reader sees uninitialized
+// memory. macOS happened to zero the buffer; Ubuntu didn't and was
+// returning garbage values for empty SUM aggregates.
 struct IntegerSumOperation : public BaseSumOperation<SumSetOperation, RegularAdd> {
 	template <class T, class STATE>
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (!state->isset) {
 			mask.SetInvalid(idx);
+			target[idx] = T{};
 		} else {
 			target[idx] = Hugeint::Convert(state->value);
 		}
@@ -47,6 +54,7 @@ struct SumToHugeintOperation : public BaseSumOperation<SumSetOperation, HugeintA
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (!state->isset) {
 			mask.SetInvalid(idx);
+			target[idx] = T{};
 		} else {
 			target[idx] = state->value;
 		}
@@ -59,6 +67,7 @@ struct DoubleSumOperation : public BaseSumOperation<SumSetOperation, ADD_OPERATO
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (!state->isset) {
 			mask.SetInvalid(idx);
+			target[idx] = T{};
 		} else {
 			if (!Value::DoubleIsFinite(state->value)) {
 				throw OutOfRangeException("SUM is out of range!");
@@ -76,6 +85,7 @@ struct HugeintSumOperation : public BaseSumOperation<SumSetOperation, RegularAdd
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (!state->isset) {
 			mask.SetInvalid(idx);
+			target[idx] = T{};
 		} else {
 			target[idx] = state->value;
 		}


### PR DESCRIPTION
## Summary
SUM's \`Finalize\` set the validity mask to invalid on an empty input set but never wrote the result slot. The mask flagged NULL, but every downstream reader that bypasses the validity bit (the C API's numeric getters, QueryRunner's DECIMAL/integer formatters) reads the raw buffer and sees whatever bytes happened to be there. macOS allocators reliably zero the slot so empty SUM looked like \`"0.0000"\`; GCC-built Ubuntu binaries on CI returned different garbage values per run (e.g. \`"9450617508.2672"\`, \`"14031869550.6512"\`), surfacing as platform-divergent TPC-H Q19 results.

Set \`target[idx] = T{}\` alongside \`SetInvalid\` in every SUM \`Finalize\` variant (Integer/SumToHugeint/Double/Hugeint) so the slot is deterministic.

## Wider issue (follow-up)
- C API numeric getters (\`turbolynx_get_int*\`, \`get_decimal\`, \`get_double\`, etc.) don't expose validity at all — they always return raw bytes. Only \`get_varchar\` checks null via pointer indirection.
- Other aggregates (min/max/avg/...) use the same \`isset / target\` pattern in \`Finalize\` and likely have the same latent uninit-result bug.

Both need a broader design change (probably \`turbolynx_value_is_null()\` C API + QueryRunner / DECIMAL/int formatter NULL handling). Not in scope here.

## Test plan
- [x] \`query_test [tpch]~[stress]\` on macOS: 52/52 cases, 841 assertions
- [x] Q19 on Ubuntu docker (gcc 13.3, Release): NULL (empty CLI cell). My docker's allocator also zeroes the slot, so the divergence isn't reproducible locally — CI Ubuntu is the actual verification.
- [ ] CI on macOS + Linux

Once this lands, PRs #151 → #156 stacked on \`tpch-mini-value-tests\` need to be rebased onto a new base that includes this commit, since #151 added the Q19 value check that exposed the bug.