### PR TITLE
min/max/avg: zero target slot on NULL path (extends #158)

### DIFF
--- a/src/function/aggregate/algebraic/avg.cpp
+++ b/src/function/aggregate/algebraic/avg.cpp
@@ -84,12 +84,17 @@ static T GetAverageDivident(uint64_t count, FunctionData *bind_data) {
 	return divident;
 }
 
+// Empty-input AVG → NULL slot. Mirror the SUM fix in #158: write a
+// typed zero to target[idx] alongside SetInvalid so downstream
+// validity-blind readers (the C API numeric getters, see #159) see a
+// deterministic value rather than uninitialised memory.
 struct IntegerAverageOperation : public BaseSumOperation<AverageSetOperation, RegularAdd> {
 	template <class T, class STATE>
 	static void Finalize(Vector &result, FunctionData *bind_data, STATE *state, T *target, ValidityMask &mask,
 	                     idx_t idx) {
 		if (state->count == 0) {
 			mask.SetInvalid(idx);
+			target[idx] = T{};
 		} else {
 			double divident = GetAverageDivident<double>(state->count, bind_data);
 			target[idx] = double(state->value) / divident;
@@ -103,6 +108,7 @@ struct IntegerAverageOperationHugeint : public BaseSumOperation<AverageSetOperat
 	                     idx_t idx) {
 		if (state->count == 0) {
 			mask.SetInvalid(idx);
+			target[idx] = T{};
 		} else {
 			long double divident = GetAverageDivident<long double>(state->count, bind_data);
 			target[idx] = Hugeint::Cast<long double>(state->value) / divident;
@@ -116,6 +122,7 @@ struct HugeintAverageOperation : public BaseSumOperation<AverageSetOperation, Re
 	                     idx_t idx) {
 		if (state->count == 0) {
 			mask.SetInvalid(idx);
+			target[idx] = T{};
 		} else {
 			long double divident = GetAverageDivident<long double>(state->count, bind_data);
 			target[idx] = Hugeint::Cast<long double>(state->value) / divident;
@@ -128,6 +135,7 @@ struct NumericAverageOperation : public BaseSumOperation<AverageSetOperation, Re
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (state->count == 0) {
 			mask.SetInvalid(idx);
+			target[idx] = T{};
 		} else {
 			if (!Value::DoubleIsFinite(state->value)) {
 				throw OutOfRangeException("AVG is out of range!");
@@ -142,6 +150,7 @@ struct KahanAverageOperation : public BaseSumOperation<AverageSetOperation, Kaha
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (state->count == 0) {
 			mask.SetInvalid(idx);
+			target[idx] = T{};
 		} else {
 			if (!Value::DoubleIsFinite(state->value)) {
 				throw OutOfRangeException("AVG is out of range!");

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -106,8 +106,20 @@ struct NumericMinMaxBase : public MinMaxBase {
 
 	template <class T, class STATE>
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		mask.Set(idx, state->isset);
-		target[idx] = state->value;
+		// state->value is only assigned when isset=true (see Operation /
+		// ConstantOperation). When the aggregate sees no input rows we
+		// must still produce a deterministic value for downstream readers
+		// that ignore the validity bit (notably the C API numeric
+		// getters; see #159). Mirror the SUM fix: write a typed zero
+		// alongside SetInvalid so the slot doesn't leak uninitialised
+		// memory.
+		if (state->isset) {
+			mask.SetValid(idx);
+			target[idx] = state->value;
+		} else {
+			mask.SetInvalid(idx);
+			target[idx] = T{};
+		}
 	}
 };
 
@@ -184,6 +196,7 @@ struct StringMinMaxBase : public MinMaxBase {
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (!state->isset) {
 			mask.SetInvalid(idx);
+			target[idx] = T{};  // see NumericMinMaxBase::Finalize / #159
 		} else {
 			target[idx] = StringVector::AddStringOrBlob(result, state->value);
 		}


### PR DESCRIPTION
## Summary
Extends the SUM uninit-result fix from #158 to \`min\` / \`max\` / \`avg\` — the next most commonly-used aggregates. Each shares the same Finalize pattern that leaves \`target[idx]\` uninitialised on the NULL path, where validity-blind downstream readers (the C API numeric getters, tracked in #159) would then leak whatever bytes happen to be in the result buffer.

\`NumericMinMaxBase\` is actually *worse* than SUM: it wrote \`target[idx] = state->value\` unconditionally — and \`state->value\` is only assigned when \`isset = true\`. Empty MIN/MAX therefore wrote uninitialised \`state->value\` into the result buffer every time on this code path, not just \"sometimes\" depending on the allocator.

## Out of scope
- \`product\` / \`bool\` / \`bitagg\` / \`first\` / \`arg_min_max\` / \`string_agg\` / \`entropy\` / \`skew\` / \`kurtosis\` / etc. — same Finalize pattern, tracked in audit issue #160.
- The C API numeric getters' lack of validity-bit support — tracked in #159.

## Stacked on
- #158 (\`fix-sum-uninit-result\`). Stack: #158 → this.

## Test plan
- [x] \`ninja\` in build-portable
- [x] \`query_test [ldbc],[tpch],[crud]~[!mayfail]~[broken-mini]~[stress]\` on macOS — 615/615 cases, 2849 assertions
- [ ] CI on macOS + Linux