### PR TITLE
test(tpch): promote Q1/3/5/6/7/9/10/11/15/19 to per-row value checks

### DIFF
--- a/test/query/helpers/tpch_expected_counts.hpp
+++ b/test/query/helpers/tpch_expected_counts.hpp
@@ -258,6 +258,154 @@ inline constexpr Q20Row Q20_ROWS[] = {
     {"Supplier#000000021", "TZoQwNFFO i,baXpbpin02,hvuhE,GRVIKm "},
     {"Supplier#000000092", "EWS4tXaiXFFFS7Y,T G"},
 };
+
+// Q1 — full lineitem aggregation by (returnflag, linestatus). Mix of
+// DECIMAL sums (exact "%.Nf" strings) and DOUBLE averages (formatted
+// "%f" → 6 fractional digits). DuckDB SF0.01 reference values.
+struct Q1Row {
+    const char* ret_flag;
+    const char* line_stat;
+    const char* sum_qty;           // DECIMAL(38,2)
+    const char* sum_base_price;    // DECIMAL(38,2)
+    const char* sum_disc_price;    // DECIMAL(38,4)
+    const char* sum_charge;        // DECIMAL(38,6)
+    const char* avg_qty;           // DOUBLE
+    const char* avg_price;         // DOUBLE
+    const char* avg_disc;          // DOUBLE
+    int64_t     count_order;
+};
+inline constexpr Q1Row Q1_ROWS[] = {
+    {"A","F", "380456.00",  "532348211.65",  "505822441.4861",  "526165934.000839",  "25.575155", "35785.709307", "0.050081", 14876},
+    {"N","F",   "8971.00",   "12384801.37",   "11798257.2080",   "12282485.056933",  "25.778736", "35588.509684", "0.047759",   348},
+    {"N","O", "738774.00", "1035875694.71",  "984393404.8664", "1023859818.407892",  "25.451270", "35686.626062", "0.049922", 29027},
+    {"R","F", "381449.00",  "534594445.35",  "507996454.4067",  "528524219.358903",  "25.597168", "35874.006533", "0.049828", 14902},
+};
+
+// Q3 — top-10 in-flight orders for FURNITURE customers (revenue DESC,
+// O_ORDERDATE ASC). REVENUE is DECIMAL(38,4); O_ORDERDATE is rendered
+// as the C-API DATE-epoch-ms int64.
+struct Q3Row {
+    int64_t     o_orderkey;
+    const char* revenue;        // DECIMAL(38,4) → "%.4f"
+    int64_t     o_orderdate_ms;
+    int64_t     o_shippriority;
+};
+inline constexpr Q3Row Q3_ROWS[] = {
+    {47525, "243081.6966", 794275200000LL, 0},  // 1995-03-04
+    {12868, "221241.4305", 794102400000LL, 0},  // 1995-03-02
+    {22849, "215389.6280", 792806400000LL, 0},  // 1995-02-15
+    { 9221, "207109.5308", 789177600000LL, 0},  // 1995-01-04
+    {37734, "204279.4455", 788486400000LL, 0},  // 1994-12-27
+    {14503, "190618.5163", 792028800000LL, 0},  // 1995-02-06
+    {21219, "190266.7609", 790300800000LL, 0},  // 1995-01-17
+    {28773, "183596.8430", 792460800000LL, 0},  // 1995-02-11
+    { 9537, "180368.6940", 792720000000LL, 0},  // 1995-02-14
+    {49312, "175723.1224", 793411200000LL, 0},  // 1995-02-22
+};
+
+// Q5 — EUROPE-region 1994 revenue by nation. 5 rows DESC.
+struct Q5Row {
+    const char* n_name;
+    const char* revenue;        // DECIMAL(38,4)
+};
+inline constexpr Q5Row Q5_ROWS[] = {
+    {"ROMANIA",        "738458.3390"},
+    {"RUSSIA",         "642220.3110"},
+    {"GERMANY",        "540272.0412"},
+    {"UNITED KINGDOM", "512853.7625"},
+    {"FRANCE",         "132804.8366"},
+};
+
+// Q6 — single-row revenue scalar from a calendar-1994 LINEITEM
+// scan with discount/quantity bounds.
+inline constexpr const char* Q6_REVENUE_STR = "996212.3469";
+
+// Q7 — shipping volume between IRAN and ETHIOPIA, by (supp_nation,
+// cust_nation, year). 4 rows.
+struct Q7Row {
+    const char* supp_nation;
+    const char* cust_nation;
+    int64_t     l_year;
+    const char* revenue;        // DECIMAL(38,4)
+};
+inline constexpr Q7Row Q7_ROWS[] = {
+    {"ETHIOPIA", "IRAN",     1995, "347608.1349"},
+    {"ETHIOPIA", "IRAN",     1996, "703045.9414"},
+    {"IRAN",     "ETHIOPIA", 1995, "270996.1957"},
+    {"IRAN",     "ETHIOPIA", 1996, "322515.0610"},
+};
+
+// Q9 — profit by supplier-nation × order-year for parts whose name
+// contains "salmon". 175 rows. Pin the first 7 (ALGERIA) and the
+// total count rather than the full set.
+inline constexpr int64_t Q9_NUM_ROWS = 175;
+struct Q9Row {
+    const char* nation;
+    int64_t     year;
+    const char* amount;         // DECIMAL(38,4)
+};
+inline constexpr Q9Row Q9_FIRST_7_ROWS[] = {
+    {"ALGERIA", 1998, "231358.5658"},
+    {"ALGERIA", 1997, "203944.6086"},
+    {"ALGERIA", 1996, "138857.8791"},
+    {"ALGERIA", 1995,  "13736.3900"},
+    {"ALGERIA", 1994,  "96759.1130"},
+    {"ALGERIA", 1993,  "86062.2353"},
+    {"ALGERIA", 1992, "253781.0598"},
+};
+
+// Q10 — top-20 customers by returned-order revenue in 1993 Q3.
+struct Q10Row {
+    int64_t     c_custkey;
+    const char* c_name;
+    const char* revenue;       // DECIMAL(38,4)
+    const char* c_acctbal;     // DECIMAL(12,2)
+    const char* n_name;
+    const char* c_address;
+    const char* c_phone;
+    const char* c_comment_prefix;   // startswith match (long varchar)
+};
+inline constexpr Q10Row Q10_ROWS[] = {
+    {1355, "Customer#000001355", "456831.6010", "2351.10", "SAUDI ARABIA",   "PZ UkSSIusgaGw66YgBJ lvJ2xBnCZTC7Ckq", "30-918-883-1662", "arefully even deposits"},
+    { 109, "Customer#000000109", "392384.5988", "-716.10", "MOZAMBIQUE",     "dccG2qKoesLea36FGCOCgPVU M N4BZdmYO",  "26-992-422-8153", "osits; blithely special braids"},
+    { 481, "Customer#000000481", "325194.7804", "7157.21", "VIETNAM",        "DWuQTiY,dAkeSm,uGj0dhMZKbt,WcAjD",     "31-363-392-6461", "accounts above the theodolites"},
+    {1249, "Customer#000001249", "324966.3197",  "448.49", "GERMANY",        "vRxG1EdI6eWBpb3umXMBRKMv5bpb1svk2nU ej","17-866-269-1165", " accounts. special platelets"},
+    { 967, "Customer#000000967", "320041.7205", "5710.41", "UNITED KINGDOM", "vgNqFVj84wrEByskKaj3YOeEu2nJLtAeAu",   "33-687-917-3598", "quickly even asymptotes"},
+};
+
+// Q11 — partkeys whose ROMANIA supplier-cost share exceeds 0.01% of
+// the total ROMANIA cost. 357 rows DESC by value. Pin the top 5 and
+// the total count.
+inline constexpr int64_t Q11_NUM_ROWS = 357;
+struct Q11Row {
+    int64_t     partkey;
+    const char* value;          // DECIMAL(38,2)
+};
+inline constexpr Q11Row Q11_TOP5_ROWS[] = {
+    { 917, "12344895.22"},
+    { 685, "11950940.60"},
+    {1081, "10580686.59"},
+    {1011,  "9608892.80"},
+    { 623,  "9343081.80"},
+};
+
+// Q15 — supplier with the maximum 4-decimal-rounded revenue in a
+// 3-month window. Single row.
+struct Q15Row {
+    int64_t     s_suppkey;
+    const char* s_name;
+    const char* s_address;
+    const char* s_phone;
+    const char* total_revenue;  // DECIMAL(38,4)
+};
+inline constexpr Q15Row Q15_ROW =
+    {82, "Supplier#000000082", "5t7gqU1BlZWyZQoeF7X", "28-177-572-9691", "1488143.1723"};
+
+// Q19 — revenue across three brand×container×size×shipmode buckets.
+// All three are empty on the mini fixture (no PARTs match the brand /
+// container / size predicates), so the SUM is NULL.
+inline constexpr bool Q19_REVENUE_IS_NULL = true;
+
 #else
 // SF1 (full benchmark) — DuckDB-reference verified.
 inline constexpr int64_t Q1  = 4;

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -955,20 +955,201 @@ TEST_CASE("TPC-H Q22 (rows)", "[tpch][q22]") {
     }
 }
 // Previously SIGSEGV'd on the SF0.01 fixture (#69) — all 11 unblocked
-// by the converter type-resolution fix; now exercised as count-only
-// smoke tests. Future PRs can promote individual queries to row-by-row
-// value tests against the DuckDB oracle (already done for Q8 / Q12 /
-// Q13 / Q16-Q22).
-TPCH_TEST(1,  tpch::Q1)
-TPCH_TEST(3,  tpch::Q3)
-TPCH_TEST(5,  tpch::Q5)
-TPCH_TEST(6,  tpch::Q6)
-TPCH_TEST(7,  tpch::Q7)
-TPCH_TEST(9,  tpch::Q9)
-TPCH_TEST(10, tpch::Q10)
-TPCH_TEST(11, tpch::Q11)
-TPCH_TEST(15, tpch::Q15)
-TPCH_TEST(19, tpch::Q19)
+// by the converter type-resolution fix. Originally registered as
+// count-only smoke tests; promoted to row-by-row value comparisons
+// here against the DuckDB oracle so a regression that returns the
+// right count but wrong values doesn't slip through.
+
+TEST_CASE("TPC-H Q1 (rows)", "[tpch][q1]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q1.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::STRING, qtest::ColType::STRING,
+         qtest::ColType::AUTO,   qtest::ColType::AUTO,
+         qtest::ColType::AUTO,   qtest::ColType::AUTO,
+         qtest::ColType::AUTO,   qtest::ColType::AUTO,
+         qtest::ColType::AUTO,   qtest::ColType::INT64});
+    constexpr size_t N = sizeof(tpch::Q1_ROWS) / sizeof(tpch::Q1_ROWS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("Q1 row " << i);
+        const auto& e = tpch::Q1_ROWS[i];
+        CHECK(r[i].str_at(0) == e.ret_flag);
+        CHECK(r[i].str_at(1) == e.line_stat);
+        CHECK(r[i].str_at(2) == e.sum_qty);
+        CHECK(r[i].str_at(3) == e.sum_base_price);
+        CHECK(r[i].str_at(4) == e.sum_disc_price);
+        CHECK(r[i].str_at(5) == e.sum_charge);
+        CHECK(r[i].str_at(6) == e.avg_qty);
+        CHECK(r[i].str_at(7) == e.avg_price);
+        CHECK(r[i].str_at(8) == e.avg_disc);
+        CHECK(r[i].int64_at(9) == e.count_order);
+    }
+}
+
+TEST_CASE("TPC-H Q3 (rows)", "[tpch][q3]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q3.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::AUTO,
+         qtest::ColType::INT64, qtest::ColType::INT64});
+    constexpr size_t N = sizeof(tpch::Q3_ROWS) / sizeof(tpch::Q3_ROWS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("Q3 row " << i);
+        const auto& e = tpch::Q3_ROWS[i];
+        CHECK(r[i].int64_at(0) == e.o_orderkey);
+        CHECK(r[i].str_at(1)   == e.revenue);
+        CHECK(r[i].int64_at(2) == e.o_orderdate_ms);
+        CHECK(r[i].int64_at(3) == e.o_shippriority);
+    }
+}
+
+TEST_CASE("TPC-H Q5 (rows)", "[tpch][q5]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q5.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::STRING, qtest::ColType::AUTO});
+    constexpr size_t N = sizeof(tpch::Q5_ROWS) / sizeof(tpch::Q5_ROWS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("Q5 row " << i);
+        CHECK(r[i].str_at(0) == tpch::Q5_ROWS[i].n_name);
+        CHECK(r[i].str_at(1) == tpch::Q5_ROWS[i].revenue);
+    }
+}
+
+TEST_CASE("TPC-H Q6 (rows)", "[tpch][q6]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q6.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(), {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == tpch::Q6_REVENUE_STR);
+}
+
+TEST_CASE("TPC-H Q7 (rows)", "[tpch][q7]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q7.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::STRING, qtest::ColType::STRING,
+         qtest::ColType::INT64,  qtest::ColType::AUTO});
+    constexpr size_t N = sizeof(tpch::Q7_ROWS) / sizeof(tpch::Q7_ROWS[0]);
+    REQUIRE(r.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+        INFO("Q7 row " << i);
+        const auto& e = tpch::Q7_ROWS[i];
+        CHECK(r[i].str_at(0)   == e.supp_nation);
+        CHECK(r[i].str_at(1)   == e.cust_nation);
+        CHECK(r[i].int64_at(2) == e.l_year);
+        CHECK(r[i].str_at(3)   == e.revenue);
+    }
+}
+
+// Q9 — 175 rows. Pin the first 7 (ALGERIA, sorted by year DESC) and
+// the total row count rather than the full set.
+TEST_CASE("TPC-H Q9 (rows)", "[tpch][q9]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q9.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::STRING, qtest::ColType::INT64, qtest::ColType::AUTO});
+    REQUIRE(r.size() == (size_t)tpch::Q9_NUM_ROWS);
+    constexpr size_t HEAD =
+        sizeof(tpch::Q9_FIRST_7_ROWS) / sizeof(tpch::Q9_FIRST_7_ROWS[0]);
+    for (size_t i = 0; i < HEAD; ++i) {
+        INFO("Q9 row " << i);
+        const auto& e = tpch::Q9_FIRST_7_ROWS[i];
+        CHECK(r[i].str_at(0)   == e.nation);
+        CHECK(r[i].int64_at(1) == e.year);
+        CHECK(r[i].str_at(2)   == e.amount);
+    }
+}
+
+// Q10 — 20 rows. Pin first 5 (the highest-revenue customers). The
+// C_COMMENT column is the lengthy narrative TPC-H comment, so the
+// oracle stores a startswith prefix and we substring-match it.
+TEST_CASE("TPC-H Q10 (rows)", "[tpch][q10]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q10.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::INT64,  qtest::ColType::STRING,
+         qtest::ColType::AUTO,   qtest::ColType::AUTO,
+         qtest::ColType::STRING, qtest::ColType::STRING,
+         qtest::ColType::STRING, qtest::ColType::STRING});
+    REQUIRE(r.size() == 20);
+    constexpr size_t HEAD = sizeof(tpch::Q10_ROWS) / sizeof(tpch::Q10_ROWS[0]);
+    for (size_t i = 0; i < HEAD; ++i) {
+        INFO("Q10 row " << i);
+        const auto& e = tpch::Q10_ROWS[i];
+        CHECK(r[i].int64_at(0) == e.c_custkey);
+        CHECK(r[i].str_at(1)   == e.c_name);
+        CHECK(r[i].str_at(2)   == e.revenue);
+        CHECK(r[i].str_at(3)   == e.c_acctbal);
+        CHECK(r[i].str_at(4)   == e.n_name);
+        CHECK(r[i].str_at(5)   == e.c_address);
+        CHECK(r[i].str_at(6)   == e.c_phone);
+        CHECK(r[i].str_at(7).find(e.c_comment_prefix) == 0);
+    }
+}
+
+// Q11 — 357 rows. Pin the top 5 by value DESC and the total count.
+TEST_CASE("TPC-H Q11 (rows)", "[tpch][q11]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q11.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::AUTO});
+    REQUIRE(r.size() == (size_t)tpch::Q11_NUM_ROWS);
+    constexpr size_t HEAD =
+        sizeof(tpch::Q11_TOP5_ROWS) / sizeof(tpch::Q11_TOP5_ROWS[0]);
+    for (size_t i = 0; i < HEAD; ++i) {
+        INFO("Q11 row " << i);
+        CHECK(r[i].int64_at(0) == tpch::Q11_TOP5_ROWS[i].partkey);
+        CHECK(r[i].str_at(1)   == tpch::Q11_TOP5_ROWS[i].value);
+    }
+}
+
+TEST_CASE("TPC-H Q15 (rows)", "[tpch][q15]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q15.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::STRING,
+         qtest::ColType::STRING, qtest::ColType::STRING,
+         qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    const auto& e = tpch::Q15_ROW;
+    CHECK(r[0].int64_at(0) == e.s_suppkey);
+    CHECK(r[0].str_at(1)   == e.s_name);
+    CHECK(r[0].str_at(2)   == e.s_address);
+    CHECK(r[0].str_at(3)   == e.s_phone);
+    CHECK(r[0].str_at(4)   == e.total_revenue);
+}
+
+// Q19 — none of the three brand × container × size × shipmode buckets
+// contain a matching PART on the mini fixture, so SUM(...) is NULL.
+// The DECIMAL C API getter has no validity check (it returns the raw
+// underlying int, which is 0 for the NULL slot), and QueryRunner's
+// DECIMAL branch formats that to "0.0000". So a strict `is_null` check
+// isn't supportable today; pin the formatted-zero output and document
+// the gap.
+TEST_CASE("TPC-H Q19 (rows)", "[tpch][q19]") {
+    SKIP_IF_NO_DB();
+    std::string query = readFile(QUERY_DIR + "q19.cql");
+    REQUIRE(!query.empty());
+    auto r = qr->run(query.c_str(), {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(tpch::Q19_REVENUE_IS_NULL);
+    // No matching parts → NULL aggregate → "0.0000" via DECIMAL formatter.
+    INFO("Q19 revenue str = '" << r[0].str_at(0) << "'");
+    CHECK(r[0].str_at(0) == "0.0000");
+}
 
 // Q14 — value test: 100*SUM(CASE...) / SUM(...) PROMO revenue.
 // Pre-fix this returned 1734.31 (100x) because CScalarIf had no


### PR DESCRIPTION
## Summary
The ten TPC-H queries previously registered via the count-only `TPCH_TEST` macro had no defense against a regression that returns the right row count but wrong values. This PR adds DuckDB-sourced oracles in `helpers/tpch_expected_counts.hpp` (mini block only) and replaces each `TPCH_TEST` invocation with a per-row `TEST_CASE` that compares every projected column.

## Oracle generation
Cross-checked against `duckdb v1.5.2` reading the committed `test/data/tpch-mini/*.tbl` files directly. DECIMAL columns pin the exact `"%.<scale>f"` format; DOUBLE averages pin six fractional digits (matching QueryRunner's `%f`); DATE columns pin epoch-ms via `EPOCH_MS(DATE ...)`.

For large result sets the existing head + total-count pattern is reused:
- Q9 (175 rows): pin the 7-row ALGERIA block + total.
- Q11 (357 rows): pin the top 5 by value + total.
- Q10 (20 rows): pin the top 5 customers.

## Q19 caveat
Mini's three brand × container × size × shipmode buckets have zero matching PARTs, so SUM(...) is NULL. The C API's DECIMAL getter has no validity bit and QueryRunner's formatter renders that slot as `"0.0000"`. With #158 merged, SUM Finalize writes T{} on the NULL path so this is now deterministic across platforms (Ubuntu used to leak uninitialised garbage here). Follow-up: tracked under #159 / #160.

## Test plan
- [x] `ninja` in `build-portable`
- [x] `query_test [tpch]` — 56 cases / 1100 assertions on mini fixture
- [x] Full `[ldbc],[tpch],[crud]~[!mayfail]~[broken-mini]~[stress]` sweep — 616 cases / 3046 assertions
- [ ] CI on macOS + Linux