### PR TITLE
capi: add turbolynx_value_is_null + tighten getter NULL handling (closes #159)

### DIFF
--- a/src/include/main/capi/turbolynx.h
+++ b/src/include/main/capi/turbolynx.h
@@ -461,6 +461,12 @@ turbolynx_decimal turbolynx_get_decimal(turbolynx_resultset_wrapper* result_set_
 
 uint64_t turbolynx_get_id(turbolynx_resultset_wrapper* result_set_wrp, idx_t col_idx);
 
+// Returns true when the cursored row's column is SQL NULL. Numeric getters
+// have no validity bit in their return type and silently return 0 on NULL,
+// so callers that need to distinguish NULL from a real zero must consult
+// this first. Mirrors DuckDB's `duckdb_value_is_null`.
+bool turbolynx_value_is_null(turbolynx_resultset_wrapper* result_set_wrp, idx_t col_idx);
+
 turbolynx_string turbolynx_decimal_to_string(turbolynx_decimal val);
 
 #ifdef __cplusplus

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -4006,9 +4006,10 @@ int16_t turbolynx_get_value<int16_t, duckdb::LogicalTypeId::DECIMAL>(turbolynx_r
         last_error_code = TURBOLYNX_ERROR_INVALID_COLUMN_TYPE;
         return 0;
     }
-    else {
-		return SmallIntValue::Get(((int16_t*)vec->GetData())[local_cursor]);
+    if (vec->GetValue(local_cursor).IsNull()) {
+        return 0;
     }
+	return SmallIntValue::Get(((int16_t*)vec->GetData())[local_cursor]);
 }
 
 template <>
@@ -4030,9 +4031,10 @@ int32_t turbolynx_get_value<int32_t, duckdb::LogicalTypeId::DECIMAL>(turbolynx_r
         last_error_code = TURBOLYNX_ERROR_INVALID_COLUMN_TYPE;
         return 0;
     }
-    else {
-		return IntegerValue::Get(((int32_t*)vec->GetData())[local_cursor]);
+    if (vec->GetValue(local_cursor).IsNull()) {
+        return 0;
     }
+	return IntegerValue::Get(((int32_t*)vec->GetData())[local_cursor]);
 }
 
 template <>
@@ -4054,9 +4056,10 @@ int64_t turbolynx_get_value<int64_t, duckdb::LogicalTypeId::DECIMAL>(turbolynx_r
         last_error_code = TURBOLYNX_ERROR_INVALID_COLUMN_TYPE;
         return 0;
     }
-    else {
-		return BigIntValue::Get(((int64_t*)vec->GetData())[local_cursor]);
+    if (vec->GetValue(local_cursor).IsNull()) {
+        return 0;
     }
+	return BigIntValue::Get(((int64_t*)vec->GetData())[local_cursor]);
 }
 
 template <>
@@ -4078,9 +4081,10 @@ hugeint_t turbolynx_get_value<hugeint_t, duckdb::LogicalTypeId::DECIMAL>(turboly
         last_error_code = TURBOLYNX_ERROR_INVALID_COLUMN_TYPE;
         return 0;
     }
-    else {
-		return HugeIntValue::Get(Value::HUGEINT(((hugeint_t*)vec->GetData())[local_cursor]));
+    if (vec->GetValue(local_cursor).IsNull()) {
+        return hugeint_t();
     }
+	return HugeIntValue::Get(Value::HUGEINT(((hugeint_t*)vec->GetData())[local_cursor]));
 }
 
 bool turbolynx_get_bool(turbolynx_resultset_wrapper* result_set_wrp, idx_t col_idx) {
@@ -4242,6 +4246,19 @@ turbolynx_decimal turbolynx_get_decimal(turbolynx_resultset_wrapper* result_set_
 
 uint64_t turbolynx_get_id(turbolynx_resultset_wrapper* result_set_wrp, idx_t col_idx) {
 	return turbolynx_get_value<uint64_t, duckdb::LogicalTypeId::ID>(result_set_wrp, col_idx);
+}
+
+bool turbolynx_value_is_null(turbolynx_resultset_wrapper* result_set_wrp, idx_t col_idx) {
+	if (result_set_wrp == NULL) {
+		last_error_message = INVALID_RESULT_SET_MSG;
+		last_error_code = TURBOLYNX_ERROR_INVALID_RESULT_SET;
+		return true;
+	}
+	size_t local_cursor;
+	auto result = turbolynx_move_to_cursored_result(result_set_wrp, col_idx, local_cursor);
+	if (result == NULL) { return true; }
+	duckdb::Vector* vec = reinterpret_cast<duckdb::Vector*>(result->__internal_data);
+	return vec->GetValue(local_cursor).IsNull();
 }
 
 turbolynx_string turbolynx_decimal_to_string(turbolynx_decimal val) {

--- a/test/query/helpers/query_runner.hpp
+++ b/test/query/helpers/query_runner.hpp
@@ -139,14 +139,16 @@ public:
                     }
 
                     Value v;
-                    if (ct == ColType::BOOL || dtype == TURBOLYNX_TYPE_BOOLEAN) {
+                    if (turbolynx_value_is_null(rw, (idx_t)c)) {
+                        // NULL goes first so numeric branches don't have to
+                        // distinguish a real zero from a NULL slot (the C API
+                        // numeric getters return 0 for both).
+                        v = Null{};
+                    } else if (ct == ColType::BOOL || dtype == TURBOLYNX_TYPE_BOOLEAN) {
                         v = (bool)turbolynx_get_bool(rw, (idx_t)c);
                     } else if (ct == ColType::STRING || dtype == TURBOLYNX_TYPE_VARCHAR) {
                         turbolynx_string sv = turbolynx_get_varchar(rw, (idx_t)c);
-                        if (sv.data == nullptr)
-                            v = Null{};
-                        else
-                            v = std::string(sv.data, sv.size);
+                        v = std::string(sv.data, sv.size);
                     } else if (ct == ColType::UINT64 || dtype == TURBOLYNX_TYPE_UBIGINT) {
                         v = (int64_t)turbolynx_get_uint64(rw, (idx_t)c);
                     } else if (dtype == TURBOLYNX_TYPE_HUGEINT) {

--- a/test/query/helpers/tpch_expected_counts.hpp
+++ b/test/query/helpers/tpch_expected_counts.hpp
@@ -404,7 +404,6 @@ inline constexpr Q15Row Q15_ROW =
 // Q19 — revenue across three brand×container×size×shipmode buckets.
 // All three are empty on the mini fixture (no PARTs match the brand /
 // container / size predicates), so the SUM is NULL.
-inline constexpr bool Q19_REVENUE_IS_NULL = true;
 
 #else
 // SF1 (full benchmark) — DuckDB-reference verified.

--- a/test/query/test_ldbc_crud.cpp
+++ b/test/query/test_ldbc_crud.cpp
@@ -1028,8 +1028,7 @@ TEST_CASE("REMOVE property", "[ldbc][crud][remove]") {
         auto r2 = qr->run("MATCH (n:Person {id: " SAMPLE_ID_S "}) RETURN n.firstName",
                            {qtest::ColType::STRING});
         REQUIRE(r2.size() == 1);
-        // After REMOVE, property should be NULL or different from the SET value
-        CHECK(r2[0].str_at(0) != "TempName");
+        CHECK(r2[0].is_null_at(0));
     } catch (const std::exception& e) {
         FAIL("REMOVE property: " << e.what());
     }
@@ -3475,10 +3474,9 @@ TEST_CASE("Multi-variable SET on fresh-bootstrap workspace",
         CHECK(post[1].str_at(0) == "Keanu Reeves");
         CHECK(post[1].int64_at(1) == 1965);
         // The SET targeted only Carrie's email; Keanu's email must not have
-        // been cross-applied. (The exact representation of "no value" for a
-        // schema column the row predates is missing-key-emits-empty-string,
-        // which is a separate concern from SET dispatch correctness.)
-        CHECK(post[1].str_at(2) != "cam@matrix.com");
+        // been cross-applied. Missing key for the schema column resolves to
+        // NULL via the validity bit (see #159 + the C API is-null check).
+        CHECK(post[1].is_null_at(2));
     } catch (const std::exception &e) {
         FAIL("Bug D multi-variable SET: " << e.what());
     }
@@ -3579,7 +3577,7 @@ TEST_CASE("CREATE on existing partition registers + emits new property",
         CHECK(rows[0].str_at(0) == "Carrie-Anne Moss");
         CHECK(rows[0].str_at(1) == "cam@matrix.com");
         CHECK(rows[1].str_at(0) == "Keanu Reeves");
-        CHECK(rows[1].str_at(1) != "cam@matrix.com");
+        CHECK(rows[1].is_null_at(1));
 
         // (c): WHERE on `email` while RETURN-ing only `name` must not let
         // email values leak into the name column of the result chunk.

--- a/test/query/test_ldbc_traversal.cpp
+++ b/test/query/test_ldbc_traversal.cpp
@@ -557,6 +557,25 @@ TEST_CASE("OPTIONAL MATCH: property access on missing node returns NULL",
     CHECK(r[0].bool_at(1));
 }
 
+// Pre-#159 the C API surfaced raw memory for unmatched numeric props on
+// LOJ right sides — the binder-level IS NULL above wouldn't catch that
+// because it short-circuits at planning time. is_null_at goes through
+// the actual getter, which is the path real C API consumers take.
+TEST_CASE("OPTIONAL MATCH: numeric props on missing node are NULL via getter",
+          "[ldbc][traversal][optional][issue159]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (p:Person {id: " + std::to_string(ldbc::SAMPLE_PERSON_ID) +
+             "}) "
+             "OPTIONAL MATCH (p)-[:KNOWS]->(f:Person {id: 9999999999999}) "
+             "RETURN p.id, f.id, f.creationDate";
+    auto r = qr->run(q.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::AUTO, qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
+    CHECK(r[0].is_null_at(1));
+    CHECK(r[0].is_null_at(2));
+}
+
 // count(var) does not count NULL; count(*) counts rows. With matches the
 // two agree; on a miss they disagree.
 TEST_CASE("OPTIONAL MATCH: count(var) == count(*) when matches exist",

--- a/test/query/test_tpch_correctness.cpp
+++ b/test/query/test_tpch_correctness.cpp
@@ -1110,21 +1110,13 @@ TEST_CASE("TPC-H Q15 (rows)", "[tpch][q15]") {
 
 // Q19 — none of the three brand × container × size × shipmode buckets
 // contain a matching PART on the mini fixture, so SUM(...) is NULL.
-// The DECIMAL C API getter has no validity check (it returns the raw
-// underlying int, which is 0 for the NULL slot), and QueryRunner's
-// DECIMAL branch formats that to "0.0000". So a strict `is_null` check
-// isn't supportable today; pin the formatted-zero output and document
-// the gap.
 TEST_CASE("TPC-H Q19 (rows)", "[tpch][q19]") {
     SKIP_IF_NO_DB();
     std::string query = readFile(QUERY_DIR + "q19.cql");
     REQUIRE(!query.empty());
     auto r = qr->run(query.c_str(), {qtest::ColType::AUTO});
     REQUIRE(r.size() == 1);
-    CHECK(tpch::Q19_REVENUE_IS_NULL);
-    // No matching parts → NULL aggregate → "0.0000" via DECIMAL formatter.
-    INFO("Q19 revenue str = '" << r[0].str_at(0) << "'");
-    CHECK(r[0].str_at(0) == "0.0000");
+    CHECK(r[0].is_null_at(0));
 }
 
 // Q14 — value test: 100*SUM(CASE...) / SUM(...) PROMO revenue.
@@ -1217,6 +1209,43 @@ TEST_CASE("CASE-in-SUM-over-SUM ratio — DECIMAL Q14-shape (sanity)",
         {qtest::ColType::AUTO});
     REQUIRE(r.size() == 1);
     CHECK(r[0].str_at(0) == "24.839263");
+}
+
+// Aggregate-over-empty NULL semantics, pinned per type. Pre-#159 the
+// C API DECIMAL getter would surface uninitialised memory here on
+// platforms that don't zero-init the result buffer (root cause of
+// Q19's macOS↔Ubuntu divergence). is_null_at must now be reliable
+// for every aggregate family that PRs #158 / #162 patched.
+TEST_CASE("aggregates over empty input are NULL — INTEGER",
+          "[tpch][issue159][i159-int]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) WHERE l.L_QUANTITY < -1 "
+        "RETURN sum(l.L_LINENUMBER), min(l.L_LINENUMBER), "
+        "max(l.L_LINENUMBER), avg(l.L_LINENUMBER)",
+        {qtest::ColType::AUTO, qtest::ColType::AUTO,
+         qtest::ColType::AUTO, qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].is_null_at(0));
+    CHECK(r[0].is_null_at(1));
+    CHECK(r[0].is_null_at(2));
+    CHECK(r[0].is_null_at(3));
+}
+
+TEST_CASE("aggregates over empty input are NULL — DECIMAL",
+          "[tpch][issue159][i159-dec]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (l:LINEITEM) WHERE l.L_QUANTITY < -1 "
+        "RETURN sum(l.L_EXTENDEDPRICE), min(l.L_EXTENDEDPRICE), "
+        "max(l.L_EXTENDEDPRICE), avg(l.L_EXTENDEDPRICE)",
+        {qtest::ColType::AUTO, qtest::ColType::AUTO,
+         qtest::ColType::AUTO, qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].is_null_at(0));
+    CHECK(r[0].is_null_at(1));
+    CHECK(r[0].is_null_at(2));
+    CHECK(r[0].is_null_at(3));
 }
 #else
 // SF1 (full benchmark): all 22 queries exercised.


### PR DESCRIPTION
## Summary
Numeric C API getters surface raw vector data without consulting the column validity bit, so SQL NULL slots return whatever happens to be in memory. PR #158 papered over the macOS↔Ubuntu divergence for the SUM Finalize path on TPC-H Q19, but every other aggregate / OPTIONAL MATCH right side / COALESCE-of-NULLs path was still platform-dependent.

## Changes
- **C API:** Add `bool turbolynx_value_is_null(rs, col_idx)` — consults the Vector's validity mask via the same `GetValue().IsNull()` path the generic getter already uses. Mirrors DuckDB's `duckdb_value_is_null`.
- **DECIMAL getters:** Add a validity check to the four specialisations that bypass `GetValue` and read the raw buffer directly. They now return 0 (or `hugeint_t{}`) on NULL deterministically, matching the generic numeric getter's sentinel behaviour.
- **QueryRunner:** Prepend `turbolynx_value_is_null` check so `is_null_at(i)` works for every column type. Drops the dead VARCHAR `data == nullptr` branch (`turbolynx_get_varchar` always returns a malloc'd empty string for NULL, never nullptr).

## Test-side cleanups (formerly relying on validity-blind behaviour)
- Q19 caveat — converted from `str_at(0) == "0.0000"` workaround to strict `is_null_at(0)`. `Q19_REVENUE_IS_NULL` flag removed.
- REMOVE-property test — `str_at(0) != "TempName"` → `is_null_at(0)`.
- Bug D multi-variable SET (CRUD) — two sites changed from `str_at != "cam@matrix.com"` to `is_null_at`.

## New tests
- `[tpch][issue159]` — SUM/MIN/MAX/AVG over empty input pin NULL per type (INTEGER and DECIMAL).
- `[ldbc][traversal][issue159]` — OPTIONAL MATCH unmatched right side: numeric props (`f.id` ID, `f.creationDate` DATE_EPOCHMS) via the C API getter. (Binder-level `IS NULL` short-circuits at plan time and doesn't exercise the same code path.)

## Test plan
- [x] `ninja` in `build-portable`
- [x] `query_test [tpch]~[stress]` — 55 cases / 1047 assertions
- [x] `query_test [ldbc]~[!mayfail]~[stress]` — 524 cases / 1919 assertions
- [x] `query_test [crud]~[!mayfail]~[stress]` — 140 cases / 446 assertions
- [ ] CI on macOS + Linux