### PR TITLE
aggregate Finalize: drop defensive zero-writes redundant after #159

### DIFF
--- a/src/function/aggregate/algebraic/avg.cpp
+++ b/src/function/aggregate/algebraic/avg.cpp
@@ -84,17 +84,12 @@ static T GetAverageDivident(uint64_t count, FunctionData *bind_data) {
 	return divident;
 }
 
-// Empty-input AVG → NULL slot. Mirror the SUM fix in #158: write a
-// typed zero to target[idx] alongside SetInvalid so downstream
-// validity-blind readers (the C API numeric getters, see #159) see a
-// deterministic value rather than uninitialised memory.
 struct IntegerAverageOperation : public BaseSumOperation<AverageSetOperation, RegularAdd> {
 	template <class T, class STATE>
 	static void Finalize(Vector &result, FunctionData *bind_data, STATE *state, T *target, ValidityMask &mask,
 	                     idx_t idx) {
 		if (state->count == 0) {
 			mask.SetInvalid(idx);
-			target[idx] = T{};
 		} else {
 			double divident = GetAverageDivident<double>(state->count, bind_data);
 			target[idx] = double(state->value) / divident;
@@ -108,7 +103,6 @@ struct IntegerAverageOperationHugeint : public BaseSumOperation<AverageSetOperat
 	                     idx_t idx) {
 		if (state->count == 0) {
 			mask.SetInvalid(idx);
-			target[idx] = T{};
 		} else {
 			long double divident = GetAverageDivident<long double>(state->count, bind_data);
 			target[idx] = Hugeint::Cast<long double>(state->value) / divident;
@@ -122,7 +116,6 @@ struct HugeintAverageOperation : public BaseSumOperation<AverageSetOperation, Re
 	                     idx_t idx) {
 		if (state->count == 0) {
 			mask.SetInvalid(idx);
-			target[idx] = T{};
 		} else {
 			long double divident = GetAverageDivident<long double>(state->count, bind_data);
 			target[idx] = Hugeint::Cast<long double>(state->value) / divident;
@@ -135,7 +128,6 @@ struct NumericAverageOperation : public BaseSumOperation<AverageSetOperation, Re
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (state->count == 0) {
 			mask.SetInvalid(idx);
-			target[idx] = T{};
 		} else {
 			if (!Value::DoubleIsFinite(state->value)) {
 				throw OutOfRangeException("AVG is out of range!");
@@ -150,7 +142,6 @@ struct KahanAverageOperation : public BaseSumOperation<AverageSetOperation, Kaha
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (state->count == 0) {
 			mask.SetInvalid(idx);
-			target[idx] = T{};
 		} else {
 			if (!Value::DoubleIsFinite(state->value)) {
 				throw OutOfRangeException("AVG is out of range!");

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -106,19 +106,11 @@ struct NumericMinMaxBase : public MinMaxBase {
 
 	template <class T, class STATE>
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		// state->value is only assigned when isset=true (see Operation /
-		// ConstantOperation). When the aggregate sees no input rows we
-		// must still produce a deterministic value for downstream readers
-		// that ignore the validity bit (notably the C API numeric
-		// getters; see #159). Mirror the SUM fix: write a typed zero
-		// alongside SetInvalid so the slot doesn't leak uninitialised
-		// memory.
 		if (state->isset) {
 			mask.SetValid(idx);
 			target[idx] = state->value;
 		} else {
 			mask.SetInvalid(idx);
-			target[idx] = T{};
 		}
 	}
 };
@@ -196,7 +188,6 @@ struct StringMinMaxBase : public MinMaxBase {
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (!state->isset) {
 			mask.SetInvalid(idx);
-			target[idx] = T{};  // see NumericMinMaxBase::Finalize / #159
 		} else {
 			target[idx] = StringVector::AddStringOrBlob(result, state->value);
 		}

--- a/src/function/aggregate/distributive/sum.cpp
+++ b/src/function/aggregate/distributive/sum.cpp
@@ -31,18 +31,11 @@ struct SumSetOperation {
 	}
 };
 
-// Empty SUM → result slot must be NULL. Some downstream readers
-// (e.g. the C API DECIMAL getter, which has no validity bit) read the
-// raw value regardless of the mask, so the slot also has to be
-// deterministically zero — otherwise the reader sees uninitialized
-// memory. macOS happened to zero the buffer; Ubuntu didn't and was
-// returning garbage values for empty SUM aggregates.
 struct IntegerSumOperation : public BaseSumOperation<SumSetOperation, RegularAdd> {
 	template <class T, class STATE>
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (!state->isset) {
 			mask.SetInvalid(idx);
-			target[idx] = T{};
 		} else {
 			target[idx] = Hugeint::Convert(state->value);
 		}
@@ -54,7 +47,6 @@ struct SumToHugeintOperation : public BaseSumOperation<SumSetOperation, HugeintA
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (!state->isset) {
 			mask.SetInvalid(idx);
-			target[idx] = T{};
 		} else {
 			target[idx] = state->value;
 		}
@@ -67,7 +59,6 @@ struct DoubleSumOperation : public BaseSumOperation<SumSetOperation, ADD_OPERATO
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (!state->isset) {
 			mask.SetInvalid(idx);
-			target[idx] = T{};
 		} else {
 			if (!Value::DoubleIsFinite(state->value)) {
 				throw OutOfRangeException("SUM is out of range!");
@@ -85,7 +76,6 @@ struct HugeintSumOperation : public BaseSumOperation<SumSetOperation, RegularAdd
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (!state->isset) {
 			mask.SetInvalid(idx);
-			target[idx] = T{};
 		} else {
 			target[idx] = state->value;
 		}


### PR DESCRIPTION
## Summary
#158 and #162 had the SUM/MIN/MAX/AVG Finalize functions write `target[idx] = T{}` alongside SetInvalid so a validity-blind reader on the C API path (the DECIMAL getter at that time) would see a deterministic zero instead of platform-dependent uninitialised memory. That was the right fix when filed — Q19 was actively diverging between macOS and Ubuntu CI runs.

#159 then made the DECIMAL getter consult the validity bit and added `turbolynx_value_is_null`. With that, **the validity bit IS the contract** and every C API consumer goes through it. The earlier defensive writes:
- Have no current reader (1 store / NULL Finalize for no observable effect).
- Hide future validity-bit-bypass bugs by handing the buggy caller a deterministic 0 that looks legitimate. A genuinely broken bypass would silently "work" with 0 NULL values and break on non-zero ones — the worst-shaped regression.

## Changes
- Drop the 11 `target[idx] = T{}` (or `hugeint_t()`) writes across:
  - `sum.cpp` — 4 sites (IntegerSumOperation, SumToHugeintOperation, DoubleSumOperation, HugeintSumOperation)
  - `minmax.cpp` — 2 sites (NumericMinMaxBase, StringMinMaxBase)
  - `avg.cpp` — 5 sites (Integer/IntegerHugeint/Hugeint/Numeric/Kahan AverageOperation)
- Drop the comment blocks referencing the old DECIMAL-getter behaviour (now misleading).

Net: 28 deletions, 0 additions.

## Related issue
Closes #160 too — that issue asked to extend the same defensive write to all other aggregates (skew/kurtosis/bool/product/first/arg_min_max/string_agg/bitagg/regr_*). With #159 making validity the source of truth, the right answer is the opposite: no aggregate should write a "look legitimate" value on the NULL path. Everything stays on `SetInvalid` alone, matching the contract.

## Test plan
- [x] `ninja` — build clean
- [x] `query_test [tpch]~[stress]` — 55 cases / 1047 assertions
- [x] `query_test [ldbc]~[!mayfail]~[stress]` — 524 cases / 1919 assertions
- [x] `query_test [crud]~[!mayfail]~[stress]` — 140 cases / 446 assertions
- [x] `query_test [issue159]` — 3 cases / 14 assertions (these pin NULL via `is_null_at`, so they pass *because* the validity bit is sufficient — exactly what we're claiming)
- [ ] CI on macOS + Linux