### PR TITLE
test(ldbc): drop two stale gate comments (IC2 / IC9 mini status)

### DIFF
--- a/test/query/helpers/ldbc_expected_counts.hpp
+++ b/test/query/helpers/ldbc_expected_counts.hpp
@@ -589,10 +589,6 @@ inline constexpr IcFofMessage IC9_RESULTS[] = {
 // Threshold = 2013-01-01T00:00:00Z. Returns 20 rows ordered by date DESC,
 // id ASC. Anchor reuses IC1_ANCHOR_PERSON_ID (Ali, 17 friends → enough
 // upstream messages to fill the LIMIT 20).
-//
-// NOTE: blocked on issue #89 (BIGINT → TIMESTAMP_MS cast); the IC2 mini
-// TEST_CASE is gated SF1-only until that lands. Constants are pinned so
-// re-enabling is a one-line change.
 inline constexpr int64_t IC2_DATE_THRESHOLD_MS = 1356998400000LL;
 struct IcRecentMessage {
     int64_t     person_id;

--- a/test/query/test_ldbc_ic_correctness.cpp
+++ b/test/query/test_ldbc_ic_correctness.cpp
@@ -734,7 +734,7 @@ TEST_CASE("IC11 job referral", "[ldbc][ic][ic11]") {
     }
 }
 
-#endif  // !TURBOLYNX_LDBC_FIXTURE_MINI (IC9-IC11 mini migration deferred)
+#endif  // !TURBOLYNX_LDBC_FIXTURE_MINI (IC10-IC11 mini migration deferred)
 
 // IC12 — trending posts.
 // Tags reachable via HAS_TYPE/IS_SUBCLASS_OF hierarchy, friends' comments


### PR DESCRIPTION
## Summary
Two SF1-only gate comments lied about what they were gating:

- \`ldbc_expected_counts.hpp:593\` claimed IC2's mini TEST_CASE was \"gated SF1-only until #89 lands\". PR #93 unblocked #89, IC2 mini has had its own TEST_CASE for a while (lines 179-208 of \`test_ldbc_ic_correctness.cpp\`).
- \`test_ldbc_ic_correctness.cpp:737\` said \"IC9-IC11 mini migration deferred\" at the #endif of the SF1-only block. IC9 actually sits *outside* that block (line 578) and runs on both fixtures. Only IC10 / IC11 are still gated.

No code change — just comment accuracy.

## Test plan
- [x] \`ninja\` — still compiles
- [x] \`query_test [ldbc][ic]\` — 16 cases / 738 assertions on mini fixture (unchanged)