### PR TITLE
capi: reject plain DELETE on node with incident edges (closes #49)

### DIFF
--- a/docs/documentation/internals/cud-design.md
+++ b/docs/documentation/internals/cud-design.md
@@ -57,8 +57,8 @@ Node writes affect only `Graphlet Delta`. Edge writes may also affect `CSR Delta
 | `CREATE edge` | `GraphletInserts`, `CsrInserts`, `LidPidTable` | Append the edge record and add forward/backward adjacency entries. |
 | `UPDATE node` | `GraphletDeletes`, `GraphletInserts`, `LidPidTable` | Invalidate the old version and append a new one. |
 | `UPDATE edge property` | `GraphletDeletes`, `GraphletInserts`, `LidPidTable` | Replace the edge record; adjacency stays unchanged if endpoints do not change. |
-| `DELETE node` | `GraphletDeletes`, `CSR Delta`, `LidPidTable` | Invalidate the node and remove incident edge visibility. |
-| `DETACH DELETE node` | same as `DELETE node` | Current query surface uses cascade semantics. |
+| `DELETE node` | `GraphletDeletes`, `LidPidTable` | Invalidate the node. Rejected with an error when the node still has any incident edge — callers must use `DETACH DELETE` for cascade. |
+| `DETACH DELETE node` | `GraphletDeletes`, `CSR Delta`, `LidPidTable` | Remove incident edge visibility (bidirectional adjacency tombstones), then invalidate the node. |
 | `DELETE edge` | `CSR Delta`, `LidPidTable` | Mark the edge invisible through adjacency tombstones; invalidate the logical record. |
 | `READ` | Base + Delta | Merge Base data with Delta inserts/deletes to expose the latest state. |
 

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -1395,6 +1395,34 @@ static bool ApplyPendingDeleteMutations(
             auto current_pid = delta_store.ResolvePid(logical_id);
             uint32_t extent_id = (uint32_t)(current_pid >> 32);
             uint32_t row_offset = (uint32_t)(current_pid & 0xFFFFFFFFull);
+
+            // Cypher standard: plain `DELETE` is rejected when the node
+            // still has incident relationships; only `DETACH DELETE`
+            // cascades. Prior to this guard both forms silently
+            // cascaded — the `pending_detach_delete` flag existed only
+            // as a logging tag (issue #49).
+            if (!detach_delete) {
+                bool has_incident_edge = false;
+                ForEachIncidentBaseEdge(
+                    h, logical_id,
+                    [&](uint16_t, uint64_t, uint64_t) {
+                        has_incident_edge = true;
+                    });
+                if (!has_incident_edge) {
+                    ForEachLiveIncidentDeltaEdge(
+                        h, logical_id,
+                        [&](uint16_t, uint64_t, uint64_t) {
+                            has_incident_edge = true;
+                        });
+                }
+                if (has_incident_edge) {
+                    throw std::runtime_error(
+                        "Cannot delete node id=" + std::to_string(logical_id) +
+                        " because it still has relationships. "
+                        "Use DETACH DELETE instead.");
+                }
+            }
+
             std::unordered_set<uint64_t> deleted_edge_ids;
             auto cascade_delete_edge =
                 [&](uint16_t edge_partition_id, uint64_t neighbor_vid,

--- a/test/query/test_ldbc_crud.cpp
+++ b/test/query/test_ldbc_crud.cpp
@@ -582,20 +582,20 @@ TEST_CASE("SET on second pattern variable targets only that variable",
 // Phase 4: DELETE tests
 // ============================================================
 
-TEST_CASE("DELETE base node decrements count", "[ldbc][crud][delete]") {
+TEST_CASE("DETACH DELETE base node decrements count", "[ldbc][crud][delete]") {
     SKIP_IF_NO_DB();
     try {
         auto before = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
                                {qtest::ColType::INT64});
         int64_t cnt_before = before[0].int64_at(0);
 
-        qr->run("MATCH (n:Person {id: " FOURTH_ID_S "}) DELETE n", {});
+        qr->run("MATCH (n:Person {id: " FOURTH_ID_S "}) DETACH DELETE n", {});
 
         auto after = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
                               {qtest::ColType::INT64});
         CHECK(after[0].int64_at(0) == cnt_before - 1);
     } catch (const std::exception& e) {
-        FAIL("DELETE base node: " << e.what());
+        FAIL("DETACH DELETE base node: " << e.what());
     }
 }
 
@@ -616,7 +616,7 @@ TEST_CASE("DELETE non-existent node is no-op", "[ldbc][crud][delete]") {
     }
 }
 
-TEST_CASE("DELETE node with edges cascades incident relationships", "[ldbc][crud][delete]") {
+TEST_CASE("DETACH DELETE node with edges cascades incident relationships", "[ldbc][crud][delete]") {
     SKIP_IF_NO_DB();
     try {
         auto neighbor = qr->run(
@@ -633,7 +633,7 @@ TEST_CASE("DELETE node with edges cascades incident relationships", "[ldbc][crud
         REQUIRE(edge_before.size() == 1);
         REQUIRE(edge_before[0].int64_at(0) > 0);
 
-        qr->run("MATCH (n:Person {id: " SAMPLE_ID_S "}) DELETE n", {});
+        qr->run("MATCH (n:Person {id: " SAMPLE_ID_S "}) DETACH DELETE n", {});
 
         auto node_after = qr->run(
             "MATCH (n:Person {id: " SAMPLE_ID_S "}) RETURN count(n) AS cnt",
@@ -648,11 +648,11 @@ TEST_CASE("DELETE node with edges cascades incident relationships", "[ldbc][crud
         CHECK(node_after[0].int64_at(0) == 0);
         CHECK(edge_after[0].int64_at(0) == 0);
     } catch (const std::exception& e) {
-        FAIL("DELETE node with edges cascade: " << e.what());
+        FAIL("DETACH DELETE node with edges cascade: " << e.what());
     }
 }
 
-TEST_CASE("DELETE does not affect other nodes", "[ldbc][crud][delete]") {
+TEST_CASE("DETACH DELETE does not affect other nodes", "[ldbc][crud][delete]") {
     SKIP_IF_NO_DB();
     try {
         // Delete one base node and verify another is unaffected
@@ -660,7 +660,7 @@ TEST_CASE("DELETE does not affect other nodes", "[ldbc][crud][delete]") {
                                {qtest::ColType::INT64});
         int64_t cnt_before = before[0].int64_at(0);
 
-        qr->run("MATCH (n:Person {id: " FOURTH_ID_S "}) DELETE n", {});
+        qr->run("MATCH (n:Person {id: " FOURTH_ID_S "}) DETACH DELETE n", {});
 
         auto after = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
                               {qtest::ColType::INT64});
@@ -672,45 +672,75 @@ TEST_CASE("DELETE does not affect other nodes", "[ldbc][crud][delete]") {
         REQUIRE(r.size() == 1);
         CHECK(r[0].str_at(0).length() > 0);
     } catch (const std::exception& e) {
-        FAIL("DELETE isolation: " << e.what());
+        FAIL("DETACH DELETE isolation: " << e.what());
     }
 }
 
-TEST_CASE("multiple DELETEs decrement count", "[ldbc][crud][delete]") {
+TEST_CASE("multiple DETACH DELETEs decrement count", "[ldbc][crud][delete]") {
     SKIP_IF_NO_DB();
     try {
         auto before = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
                                {qtest::ColType::INT64});
         int64_t cnt_before = before[0].int64_at(0);
 
-        qr->run("MATCH (n:Person {id: " FIFTH_ID_S "}) DELETE n", {});
-        qr->run("MATCH (n:Person {id: " FOURTH_ID_S "}) DELETE n", {});
+        qr->run("MATCH (n:Person {id: " FIFTH_ID_S "}) DETACH DELETE n", {});
+        qr->run("MATCH (n:Person {id: " FOURTH_ID_S "}) DETACH DELETE n", {});
 
         auto r = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
                           {qtest::ColType::INT64});
         REQUIRE(r.size() == 1);
         CHECK(r[0].int64_at(0) == cnt_before - 2);
     } catch (const std::exception& e) {
-        FAIL("DELETE multiple: " << e.what());
+        FAIL("DETACH DELETE multiple: " << e.what());
     }
 }
 
-TEST_CASE("DELETE node with edges decrements count", "[ldbc][crud][delete]") {
+TEST_CASE("DETACH DELETE node with edges decrements count", "[ldbc][crud][delete]") {
     SKIP_IF_NO_DB();
     try {
         auto before = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
                                {qtest::ColType::INT64});
         REQUIRE(before.size() == 1);
 
-        qr->run("MATCH (n:Person {id: " SAMPLE_ID_S "}) DELETE n", {});
+        qr->run("MATCH (n:Person {id: " SAMPLE_ID_S "}) DETACH DELETE n", {});
 
         auto after = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
                               {qtest::ColType::INT64});
         REQUIRE(after.size() == 1);
         CHECK(after[0].int64_at(0) == before[0].int64_at(0) - 1);
     } catch (const std::exception& e) {
-        FAIL("DELETE node with edges decrements count: " << e.what());
+        FAIL("DETACH DELETE node with edges decrements count: " << e.what());
     }
+}
+
+// Cypher standard: plain DELETE must reject a node that still has
+// incident relationships. Pre-issue #49 the C API silently cascaded
+// regardless of the DETACH keyword.
+TEST_CASE("plain DELETE on node with edges fails (Cypher standard)",
+          "[ldbc][crud][delete][issue49]") {
+    SKIP_IF_NO_DB();
+    auto before = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                           {qtest::ColType::INT64});
+    int64_t cnt_before = before[0].int64_at(0);
+
+    bool threw = false;
+    try {
+        qr->run("MATCH (n:Person {id: " SAMPLE_ID_S "}) DELETE n", {});
+    } catch (const std::exception& e) {
+        threw = true;
+        const std::string msg = e.what();
+        CHECK(msg.find("DETACH DELETE") != std::string::npos);
+    }
+    CHECK(threw);
+
+    // Node must still be there; count unchanged.
+    auto after = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                          {qtest::ColType::INT64});
+    CHECK(after[0].int64_at(0) == cnt_before);
+    auto still = qr->run(
+        "MATCH (n:Person {id: " SAMPLE_ID_S "}) RETURN count(n)",
+        {qtest::ColType::INT64});
+    CHECK(still[0].int64_at(0) == 1);
 }
 
 TEST_CASE("DELETE node without edges succeeds", "[ldbc][crud][delete]") {
@@ -732,7 +762,7 @@ TEST_CASE("DELETE node without edges succeeds", "[ldbc][crud][delete]") {
     }
 }
 
-TEST_CASE("DELETE cascades edges on fresh connected nodes", "[ldbc][crud][delete]") {
+TEST_CASE("DETACH DELETE cascades edges on fresh connected nodes", "[ldbc][crud][delete]") {
     SKIP_IF_NO_DB();
     try {
         // Create two nodes with an edge
@@ -740,8 +770,8 @@ TEST_CASE("DELETE cascades edges on fresh connected nodes", "[ldbc][crud][delete
         qr->run("CREATE (b:Person {id: 999771, firstName: 'B'})", {});
         qr->run("MATCH (a:Person {id: 999770}), (b:Person {id: 999771}) CREATE (a)-[:KNOWS]->(b)", {});
 
-        // Plain DELETE should cascade the relationship
-        qr->run("MATCH (n:Person {id: 999770}) DELETE n", {});
+        // DETACH DELETE cascades the relationship.
+        qr->run("MATCH (n:Person {id: 999770}) DETACH DELETE n", {});
 
         auto edge_after = qr->run(
             "MATCH (a:Person {id: 999770})-[:KNOWS]->(b:Person {id: 999771}) RETURN count(b) AS cnt",
@@ -749,14 +779,14 @@ TEST_CASE("DELETE cascades edges on fresh connected nodes", "[ldbc][crud][delete
         REQUIRE(edge_after.size() == 1);
         CHECK(edge_after[0].int64_at(0) == 0);
 
-        // The neighbor should now be independently deletable
+        // The neighbor is now edge-free and plain DELETE works.
         qr->run("MATCH (n:Person {id: 999771}) DELETE n", {});
 
         auto r = qr->run("MATCH (n:Person {id: 999771}) RETURN n.firstName",
                           {qtest::ColType::STRING});
         CHECK(r.empty());
     } catch (const std::exception& e) {
-        FAIL("DELETE cascades fresh edge: " << e.what());
+        FAIL("DETACH DELETE cascades fresh edge: " << e.what());
     }
 }
 


### PR DESCRIPTION
## Summary
The Cypher standard rejects \`DELETE n\` when \`n\` still has incident relationships; only \`DETACH DELETE\` cascades. \`turbolynx-c.cpp\`'s \`ApplyPendingDeleteMutations\` was running both forms through the same cascade path — the \`pending_detach_delete\` flag only fed the spdlog tag at line 1429. So the engine silently cascaded plain \`DELETE\`, the docs noted \"same as DELETE node — cascade semantics,\" and the standard-mandated rejection was nowhere.

Probe before the fix:
\`\`\`cypher
CREATE (a:N {id: 1});
CREATE (b:N {id: 2});
MATCH (a:N {id: 1}), (b:N {id: 2}) CREATE (a)-[:R]->(b);
MATCH (a:N {id: 1}) DELETE a;     -- succeeded; relationship cascaded
\`\`\`

## Changes
- \`src/main/capi/turbolynx-c.cpp\`: in the per-row delete loop, when \`detach_delete\` is false, scan \`ForEachIncidentBaseEdge\` + \`ForEachLiveIncidentDeltaEdge\` for any incident edge and throw \`runtime_error(\"Cannot delete node id=… because it still has relationships. Use DETACH DELETE instead.\")\`. The outer execute catch turns it into \`TURBOLYNX_ERROR_INVALID_PLAN\` so callers see the message. \`detach_delete=true\` keeps cascading as before.
- \`test/query/test_ldbc_crud.cpp\`: six TEST_CASEs that exercised cascade-via-plain-DELETE were renamed and rewritten to use \`DETACH DELETE\` — their intent was always cascade. Added a new \`plain DELETE on node with edges fails (Cypher standard)\` case under \`[crud][delete][issue49]\` that asserts (a) the throw, (b) the error message mentions \`DETACH DELETE\`, (c) the target node and total count are unchanged after rejection.
- \`docs/documentation/internals/cud-design.md\` lines 60-61: split the two forms — plain \`DELETE\` is now described as rejecting on incident edges, \`DETACH DELETE\` as cascading.

The smoke-CLI test (\`test_smoke_cli.cpp:197\`) already used plain DELETE on an isolated node so it keeps that form.

## Test plan
- [x] \`ninja\` — build clean
- [x] \`query_test [crud]~[!mayfail]~[stress]\` — 141 cases / 450 assertions (issue49 case included)
- [x] \`query_test [ldbc]~[!mayfail]~[stress]\` — 525 cases / 1923 assertions
- [x] \`query_test [tpch]~[stress]\` — 55 cases / 1047 assertions
- [x] \`bulkload_test [smoke]\` — 5 cases / 61 assertions
- [ ] CI on macOS + Linux