### PR TITLE
fix(#12): MERGE multi-property + logical-stage graphlet prune

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -547,6 +547,18 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanMatchClause(
     const BoundQueryGraphCollection *qgc = mc.GetQueryGraphCollection();
     const bound_expression_vector &predicates = mc.GetPredicates();
 
+    // Drop graphlets that lack any predicate-referenced property before
+    // ORCA starts optimising — see lPruneUnnecessaryGraphlets in the
+    // pre-M20 planner_logical.cpp. With multi-PS partitions like the
+    // Bug-E mix (Keanu has only `name`, Carrie has `name`+`email`), a
+    // `WHERE p.email = …` filter expression bound to the union schema
+    // gets folded to `NULL = …` for the PS that lacks the column. Once
+    // those PSs are pruned the surviving NodeScan binds the expression
+    // consistently and the delta path stays correct.
+    if (!predicates.empty()) {
+        PruneGraphletsByFilterPredicates(*qgc, predicates);
+    }
+
     turbolynx::LogicalPlan *plan;
     if (!mc.IsOptional()) {
         plan = PlanRegularMatch(*qgc, prev_plan, predicates);
@@ -557,6 +569,163 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanMatchClause(
         plan = PlanOptionalMatch(*qgc, prev_plan, predicates);
     }
     return plan;
+}
+
+// Walk a top-level conjunctive predicate (one CNF conjunct) and
+// collect every (var_name, key_id) pair that *must* be present for
+// the predicate to evaluate to TRUE. Returns false if the expression
+// contains a sub-tree we can't safely reason about (e.g. OR over
+// different properties, NOT, EXISTS, list comprehension), in which
+// case the caller should leave the graphlet list untouched.
+//
+// Why we can't just recurse blindly into OR: `n.email = X OR n.name =
+// Y` is satisfiable on a PS that only has `name`, so requiring both
+// keys would wrongly prune it. NOT and friends have similar issues.
+static bool CollectFilterPropKeyRefs(
+    const BoundExpression *expr,
+    std::unordered_map<string, std::unordered_set<uint64_t>> &out)
+{
+    if (!expr) {
+        return true;
+    }
+    switch (expr->GetExprType()) {
+    case BoundExpressionType::PROPERTY: {
+        auto *p = static_cast<const BoundPropertyExpression *>(expr);
+        out[p->GetVarName()].insert(p->GetPropertyKeyID());
+        return true;
+    }
+    case BoundExpressionType::LITERAL:
+    case BoundExpressionType::VARIABLE:
+    case BoundExpressionType::PARAMETER:
+        return true;
+    case BoundExpressionType::COMPARISON: {
+        auto *c =
+            static_cast<const CypherBoundComparisonExpression *>(expr);
+        if (!CollectFilterPropKeyRefs(c->GetLeft(), out))  return false;
+        if (!CollectFilterPropKeyRefs(c->GetRight(), out)) return false;
+        return true;
+    }
+    case BoundExpressionType::BOOL_OP: {
+        auto *b = static_cast<const BoundBoolExpression *>(expr);
+        if (b->GetOpType() == BoundBoolOpType::AND) {
+            for (auto &child : b->GetChildren()) {
+                if (!CollectFilterPropKeyRefs(child.get(), out))
+                    return false;
+            }
+            return true;
+        }
+        // OR / NOT: branches don't all need to be satisfied. Abort —
+        // the conservative answer is "no graphlet can be safely
+        // pruned" for this CNF conjunct.
+        return false;
+    }
+    case BoundExpressionType::FUNCTION: {
+        // Property references inside arithmetic / string functions
+        // (e.g. `WHERE toLower(n.firstName) = 'ali'`) still demand the
+        // column exist on the matching PS.
+        auto *f = static_cast<const CypherBoundFunctionExpression *>(expr);
+        for (auto &child : f->GetChildren()) {
+            if (!CollectFilterPropKeyRefs(child.get(), out))
+                return false;
+        }
+        return true;
+    }
+    case BoundExpressionType::NULL_OP: {
+        // `n.col IS NULL` is satisfied by a PS without `col` — pruning
+        // such a PS would wrongly drop the row. Abort.
+        return false;
+    }
+    default:
+        // CASE / AGG_FUNCTION / LIST_COMP / EXISTENTIAL / PATH /
+        // ID_IN_COLL — conservative: bail.
+        return false;
+    }
+}
+
+void Cypher2OrcaConverter::PruneGraphletsByFilterPredicates(
+    const BoundQueryGraphCollection &qgc,
+    const bound_expression_vector &predicates)
+{
+    // Each top-level conjunct in `predicates` is itself a CNF clause —
+    // the binder already AND-split. A predicate where we couldn't walk
+    // it safely (OR, NOT, IS NULL, …) is skipped: it contributes no
+    // required keys rather than letting one unsafe clause spoil the
+    // analysis of its siblings.
+    std::unordered_map<string, std::unordered_set<uint64_t>>
+        filter_keys_by_var;
+    for (auto &pred : predicates) {
+        std::unordered_map<string, std::unordered_set<uint64_t>>
+            local;
+        if (!CollectFilterPropKeyRefs(pred.get(), local)) {
+            continue;
+        }
+        for (auto &kv : local) {
+            auto &dst = filter_keys_by_var[kv.first];
+            dst.insert(kv.second.begin(), kv.second.end());
+        }
+    }
+    if (filter_keys_by_var.empty()) {
+        return;
+    }
+
+    auto &catalog = context_->db->GetCatalog();
+    for (uint32_t qg_idx = 0; qg_idx < qgc.GetNumQueryGraphs(); qg_idx++) {
+        auto *qg = qgc.GetQueryGraph(qg_idx);
+        for (auto &node_sp : qg->GetQueryNodes()) {
+            auto it = filter_keys_by_var.find(node_sp->GetUniqueName());
+            if (it == filter_keys_by_var.end() || it->second.empty()) {
+                continue;
+            }
+            const auto &required_keys = it->second;
+
+            const auto &graphlet_ids = node_sp->GetGraphletIDs();
+            if (graphlet_ids.size() <= 1) {
+                // Single-PS scan — pruning to zero would mask a real
+                // empty-result query, so leave it alone. Multi-PS is
+                // the case the prune was designed for.
+                continue;
+            }
+
+            vector<uint64_t> pruned;
+            pruned.reserve(graphlet_ids.size());
+            for (auto gid : graphlet_ids) {
+                auto *ps = static_cast<PropertySchemaCatalogEntry *>(
+                    catalog.GetEntry(*context_, DEFAULT_SCHEMA,
+                                      (idx_t)gid, true));
+                if (!ps) {
+                    continue;
+                }
+                auto *key_ids = ps->GetKeyIDs();
+                if (!key_ids) {
+                    continue;
+                }
+                std::unordered_set<uint64_t> ps_keys(key_ids->begin(),
+                                                     key_ids->end());
+                bool has_all = true;
+                for (auto kid : required_keys) {
+                    if (kid == 0) {
+                        // `_id` is implicit on every PS; never blocks a
+                        // graphlet from being scanned.
+                        continue;
+                    }
+                    if (ps_keys.find(kid) == ps_keys.end()) {
+                        has_all = false;
+                        break;
+                    }
+                }
+                if (has_all) {
+                    pruned.push_back(gid);
+                }
+            }
+            // If pruning would drop every graphlet the predicate is
+            // unsatisfiable on this partition; keep the original list
+            // so ORCA still produces a valid plan that returns zero
+            // rows rather than crashing on an empty scan target.
+            if (!pruned.empty() && pruned.size() < graphlet_ids.size()) {
+                node_sp->SetGraphletIDs(std::move(pruned));
+            }
+        }
+    }
 }
 
 // ============================================================

--- a/src/execution/execution/physical_operator/physical_node_scan.cpp
+++ b/src/execution/execution/physical_operator/physical_node_scan.cpp
@@ -722,6 +722,28 @@ void PhysicalNodeScan::ScanDeltaPhaseChunk(ExecutionContext &context,
     while (state.delta_cur < state.delta_eids.size()) {
         auto *buf = ds.FindInsertBuffer(state.delta_eids[state.delta_cur]);
         if (!buf || state.delta_row >= buf->Size()) { state.delta_cur++; state.delta_row = 0; continue; }
+        // `delta_eids` is partition-wide. Post-issue-#12 storage
+        // refactor every in-memory extent's key set matches some
+        // PropertySchema's GetKeys() exactly (CREATE/Replay both
+        // NULL-pad to the chosen PS layout). So an extent belongs to
+        // a kept oid iff `buf.keys == ps.keys`; if no kept PS matches
+        // the buffer keys this extent is from a PS the converter
+        // pruned (issue #12) and we skip it.
+        bool buf_matches_kept_oid = false;
+        for (auto oid : oids) {
+            auto *cand_ps = (PropertySchemaCatalogEntry *)cat.GetEntry(
+                *context.client, DEFAULT_SCHEMA, oid, true);
+            auto *cand_keys = cand_ps ? cand_ps->GetKeys() : nullptr;
+            if (cand_keys && *cand_keys == buf->GetSchemaKeys()) {
+                buf_matches_kept_oid = true;
+                break;
+            }
+        }
+        if (!buf_matches_kept_oid) {
+            state.delta_cur++;
+            state.delta_row = 0;
+            continue;
+        }
         auto [mapping_idx, scan_ps] = resolve_delta_mapping(*buf);
         auto edge_like =
             buf->FindKeyIndex("_sid") >= 0 && buf->FindKeyIndex("_tid") >= 0;
@@ -951,7 +973,43 @@ void PhysicalNodeScan::ScanDeltaPhaseChunk(ExecutionContext &context,
             out_idx++;
         }
         state.delta_row += n;
-        if (out_idx > 0) { chunk.SetCardinality(out_idx); return; }
+        if (out_idx > 0) {
+            chunk.SetCardinality(out_idx);
+            // FP_EQ / FP_RANGE are evaluated per-row inside the loop above
+            // (lines 769-840). FP_COMPLEX has no per-row branch — the base-
+            // scan path hands the conjunction expression to ExtentIterator,
+            // which doesn't run for the delta phase. Apply it here on the
+            // materialised chunk so multi-property MATCH against in-memory
+            // rows (e.g. `{id: X, firstName: 'Bob'}` after CREATE Alice)
+            // doesn't slip through as true (issue #12).
+            //
+            // Limit to single-schema NodeScans: the expression's column
+            // refs are bound to scan_cols, which only have a single
+            // layout in that case. Multi-schema scans (schemaless filter
+            // pushdown) need per-schema executor binding — out of scope
+            // for the surgical issue #12 fix and tracked separately.
+            // Limit to single-schema NodeScans: the expression's column
+            // refs are bound to scan_cols, which only have a single
+            // layout in that case. Multi-schema scans (schemaless filter
+            // pushdown) are kept correct by the logical-layer graphlet
+            // prune in Cypher2OrcaConverter — partitions that lack the
+            // filter columns are dropped before ORCA optimisation, so
+            // the multi-schema branch only fires when every remaining
+            // PS shares the filtered keys.
+            if (is_filter_pushdowned &&
+                filter_pushdown_type == FilterPushdownType::FP_COMPLEX &&
+                filter_expression && num_schemas == 1) {
+                SelectionVector sel(STANDARD_VECTOR_SIZE);
+                ExpressionExecutor delta_exec(*filter_expression);
+                auto pass = delta_exec.SelectExpression(chunk, sel);
+                if (pass < out_idx) {
+                    chunk.Slice(sel, pass);
+                    chunk.SetCardinality(pass);
+                }
+                if (pass == 0) { continue; }
+            }
+            return;
+        }
     }
     state.iter_finished = true;
 }

--- a/src/include/binder/graph_pattern/bound_node_expression.hpp
+++ b/src/include/binder/graph_pattern/bound_node_expression.hpp
@@ -28,6 +28,12 @@ public:
     const vector<uint64_t>& GetGraphletIDs()  const { return graphlet_ids; }
     bool                  IsMultiLabeled()  const { return graphlet_ids.size() > 1; }
 
+    // Replace the graphlet (PropertySchema) list — used by the converter
+    // to drop graphlets that lack a predicate's columns. Mirrors the
+    // pre-M20 logical-stage `lPruneUnnecessaryGraphlets` and shrinks the
+    // ORCA search space before optimisation (issue #12 sub-symptom).
+    void SetGraphletIDs(vector<uint64_t> ids) { graphlet_ids = std::move(ids); }
+
     // ---- Property access tracking ----
     // Add a property by key ID. The Binder populates these after schema lookup.
     void AddPropertyExpression(uint64_t key_id, shared_ptr<BoundExpression> prop_expr) {

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -209,6 +209,16 @@ private:
     turbolynx::LogicalPlan *PlanShortestPath(
         const BoundQueryGraph &qg, turbolynx::LogicalPlan *prev_plan);
 
+    // Pre-optimisation graphlet pruning: drop PropertySchemas that
+    // lack any column referenced by a WHERE/inline predicate against
+    // that node variable. Mirrors the pre-M20 logical-planner
+    // `lPruneUnnecessaryGraphlets`. Shrinks ORCA's search space and
+    // ensures the surviving multi-schema NodeScan's filter expression
+    // can be bound consistently across every remaining PS (issue #12).
+    void PruneGraphletsByFilterPredicates(
+        const BoundQueryGraphCollection &qgc,
+        const bound_expression_vector &predicates);
+
     // ---- schema helpers ----
     // Build col_idx → column_pos mapping per graphlet.
     // col_idx 0 = _id.  col_idx i = i-th property in node.GetPropertyExpressions().

--- a/src/include/storage/delta_store.hpp
+++ b/src/include/storage/delta_store.hpp
@@ -438,6 +438,26 @@ public:
         return result;
     }
 
+    // Get in-memory ExtentIDs that share a specific schema key set. Used
+    // by scans that have already pruned to a subset of PropertySchemas
+    // (logical-stage graphlet prune, issue #12): the partition-wide
+    // variant would also return extents from PSs the scan deliberately
+    // dropped, leaking unrelated delta rows into the result.
+    std::vector<uint32_t> GetInMemoryExtentIDsForSchema(
+        uint16_t partition_logical_id,
+        const vector<string> &schema_keys) const {
+        std::vector<uint32_t> result;
+        for (auto& [eid, buf] : insert_buffers_) {
+            if (((eid >> 16) & 0xFFFF) != partition_logical_id || buf.Empty()) {
+                continue;
+            }
+            if (buf.GetSchemaKeys() == schema_keys) {
+                result.push_back((uint32_t)eid);
+            }
+        }
+        return result;
+    }
+
     uint32_t GetOrAllocateInMemoryExtentID(uint16_t partition_logical_id,
                                            const vector<string> &schema_keys) {
         for (auto &[eid, buf] : insert_buffers_) {

--- a/src/include/storage/wal.hpp
+++ b/src/include/storage/wal.hpp
@@ -159,10 +159,17 @@ void LogAndApplyInsertEdge(WALWriter* wal, DeltaStore& ds,
 // ============================================================
 // WALReader — replay log on startup
 // ============================================================
+class ClientContext;
+
 class WALReader {
 public:
-    // Replay WAL file into DeltaStore. Returns number of entries replayed.
-    static idx_t Replay(const std::string &db_path, DeltaStore &delta_store);
+    // Replay WAL file into DeltaStore. Returns number of entries
+    // replayed. `client` (when non-null) is used to look up each
+    // INSERT/UPDATE entry's owning PropertySchema so the row can be
+    // NULL-padded to the PS's full key set in memory — matches the
+    // CREATE path's in-memory layout post-issue #12 storage refactor.
+    static idx_t Replay(const std::string &db_path, DeltaStore &delta_store,
+                        ClientContext *client = nullptr);
 
     static uint8_t ReadU8(std::ifstream &f);
     static uint16_t ReadU16(std::ifstream &f);

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -1477,7 +1477,8 @@ int64_t turbolynx_connect(const char *dbname) {
         duckdb::SetClientWrapper(h->client, make_shared<CatalogWrapper>(*h->database->instance));
         duckdb::LoadLogicalMappings(string(dbname), h->database->instance->delta_store);
         // WAL: replay existing log to restore DeltaStore, then open writer for new mutations
-        duckdb::WALReader::Replay(string(dbname), h->database->instance->delta_store);
+        duckdb::WALReader::Replay(string(dbname), h->database->instance->delta_store,
+                                  h->client.get());
         h->database->instance->wal_writer = std::make_unique<duckdb::WALWriter>(string(dbname));
         initialize_planner(*h);
 
@@ -3205,22 +3206,20 @@ static turbolynx_num_rows executeMerge(int64_t conn_id, const string &query,
     string label = m[2].str();
     string props_str = m[3].str();
 
-    // Extract the FIRST property as the match key (e.g., id: 999)
+    // Validate that the prop map contains at least one parseable entry —
+    // an empty `{}` (or one with no recognisable key:val pair) cannot
+    // form a MATCH predicate.
     std::regex prop_re(R"((\w+)\s*:\s*('[^']*'|"[^"]*"|\d+))");
     auto prop_begin = std::sregex_iterator(props_str.begin(), props_str.end(), prop_re);
-    string match_key, match_val;
-    if (prop_begin != std::sregex_iterator()) {
-        match_key = (*prop_begin)[1].str();
-        match_val = (*prop_begin)[2].str();
-    }
-
-    if (match_key.empty()) {
+    if (prop_begin == std::sregex_iterator()) {
         set_error(TURBOLYNX_ERROR_INVALID_PLAN, "MERGE requires at least one property for matching");
         return TURBOLYNX_ERROR;
     }
 
-    // Step 1: MATCH check
-    string match_q = "MATCH (" + var + ":" + label + " {" + match_key + ": " + match_val + "}) RETURN count(" + var + ") AS cnt";
+    // Step 1: MATCH check — use the full property map so MERGE is rejected
+    // for a partial match (issue #12). Cypher's map pattern is conjunctive,
+    // so `props_str` reproduces the user's intent verbatim.
+    string match_q = "MATCH (" + var + ":" + label + " {" + props_str + "}) RETURN count(" + var + ") AS cnt";
     auto* match_prep = turbolynx_prepare(conn_id, const_cast<char*>(match_q.c_str()));
     if (!match_prep) return TURBOLYNX_ERROR;
     turbolynx_resultset_wrapper* match_result = nullptr;
@@ -3695,8 +3694,17 @@ static turbolynx_num_rows turbolynx_execute_mutation(ConnectionHandle* h,
                     // partition bootstrapped only with {name}) still need
                     // the per-CREATE PS so the converter can resolve every
                     // projected key.
+                    // Pick the owning PropertySchema for this CREATE: the
+                    // first existing PS whose key set is a superset of
+                    // the supplied keys. If none qualify, materialise a
+                    // new PS with exactly the supplied keys. Either way
+                    // we then expand the row to the PS's full key set
+                    // (NULL-padding missing keys) so each in-memory
+                    // extent in a partition corresponds 1:1 to a
+                    // PropertySchema and downstream scans don't have
+                    // to handle subset / superset matching.
+                    vector<string> chosen_keys;
                     if (part_cat) {
-                        bool covered_by_existing = false;
                         if (auto *ps_ids = part_cat->GetPropertySchemaIDs()) {
                             auto &cat = h->database->instance->GetCatalog();
                             for (auto ps_oid : *ps_ids) {
@@ -3716,24 +3724,53 @@ static turbolynx_num_rows turbolynx_execute_mutation(ConnectionHandle* h,
                                     }
                                 }
                                 if (has_all) {
-                                    covered_by_existing = true;
+                                    chosen_keys = *ps_keys;
                                     break;
                                 }
                             }
                         }
-                        if (!covered_by_existing) {
+                        if (chosen_keys.empty()) {
                             EnsureExactNodePropertySchema(h, part_cat, keys,
                                                           row);
+                            chosen_keys = keys;
+                        }
+                    } else {
+                        chosen_keys = keys;
+                    }
+
+                    // NULL-pad the row to chosen_keys layout. Existing
+                    // values keep their positions per chosen_keys order;
+                    // unsupplied keys become typed-NULLs.
+                    vector<Value> padded_row;
+                    padded_row.reserve(chosen_keys.size());
+                    {
+                        std::unordered_map<string, size_t> supplied;
+                        for (size_t i = 0; i < keys.size(); i++) {
+                            supplied[keys[i]] = i;
+                        }
+                        for (auto &k : chosen_keys) {
+                            auto it = supplied.find(k);
+                            if (it != supplied.end()) {
+                                padded_row.push_back(row[it->second]);
+                            } else {
+                                padded_row.push_back(Value());
+                            }
                         }
                     }
-                    uint32_t inmem_eid = delta_store.GetOrAllocateInMemoryExtentID(logical_pid, keys);
+
+                    uint32_t inmem_eid = delta_store.GetOrAllocateInMemoryExtentID(
+                        logical_pid, chosen_keys);
                     uint64_t logical_id = delta_store.AllocateNodeLogicalId();
                     if (h->database->instance->wal_writer) {
+                        // WAL keeps the supplied (sparse) key set —
+                        // replay re-pads via the same PS lookup so we
+                        // don't double the on-disk footprint with
+                        // explicit NULLs (issue #12 follow-up).
                         h->database->instance->wal_writer->LogInsertNodeV2(
                             logical_pid, logical_id, keys, row);
                     }
-                    AppendNodeDeltaRow(h, logical_pid, std::move(keys), std::move(row),
-                                       logical_id);
+                    AppendNodeDeltaRow(h, logical_pid, std::move(chosen_keys),
+                                       std::move(padded_row), logical_id);
                     created_node_lids[node_info.variable_name] = logical_id;
                     spdlog::info("[CREATE] Inserted node label='{}' with {} properties into in-memory extent 0x{:08X} (partition {}, oid {})",
                                  node_info.label, node_info.properties.size(), inmem_eid, logical_pid, part_oid);

--- a/src/storage/wal.cpp
+++ b/src/storage/wal.cpp
@@ -11,7 +11,14 @@
 #include "common/checksum.hpp"
 #include "common/exception.hpp"
 #include "common/fdatasync.hpp"
+#include "main/database.hpp"
+#include "catalog/catalog.hpp"
+#include "catalog/catalog_entry/partition_catalog_entry.hpp"
+#include "catalog/catalog_entry/property_schema_catalog_entry.hpp"
+#include "common/constants.hpp"
 #include "spdlog/spdlog.h"
+#include <unordered_map>
+#include <unordered_set>
 
 #include <cerrno>
 #include <cstring>
@@ -492,7 +499,95 @@ static Value MsReadValue(S &s) {
     }
 }
 
-idx_t WALReader::Replay(const std::string &db_path, DeltaStore &ds) {
+// Pad CREATE/UPDATE keys/values to the owning PropertySchema's full
+// key set so each in-memory extent has a canonical layout matching
+// one of the partition's PSs (issue #12 storage refactor).
+// Falls through silently when no client/catalog is available — kept
+// for tooling that replays WAL without a live database.
+static void PadWalRowToOwningPropertySchema(
+    ClientContext *client, uint16_t pid,
+    std::vector<std::string> &keys, std::vector<Value> &values)
+{
+    if (!client || !client->db) return;
+    auto &catalog = client->db->GetCatalog();
+
+    // Find the partition catalog entry by logical partition id (16-bit).
+    PartitionCatalogEntry *part_cat = nullptr;
+    {
+        auto *gcat = (GraphCatalogEntry *)catalog.GetEntry(
+            *client, duckdb::CatalogType::GRAPH_ENTRY, DEFAULT_SCHEMA,
+            DEFAULT_GRAPH, true);
+        if (!gcat) return;
+        auto *vpart_oids = gcat->GetVertexPartitionOids();
+        if (vpart_oids) {
+            for (auto poid : *vpart_oids) {
+                auto *p = (PartitionCatalogEntry *)catalog.GetEntry(
+                    *client, DEFAULT_SCHEMA, (idx_t)poid, true);
+                if (p && p->GetPartitionID() == pid) {
+                    part_cat = p;
+                    break;
+                }
+            }
+        }
+        if (!part_cat) {
+            auto *epart_oids = gcat->GetEdgePartitionOids();
+            if (epart_oids) {
+                for (auto poid : *epart_oids) {
+                    auto *p = (PartitionCatalogEntry *)catalog.GetEntry(
+                        *client, DEFAULT_SCHEMA, (idx_t)poid, true);
+                    if (p && p->GetPartitionID() == pid) {
+                        part_cat = p;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    if (!part_cat) return;
+
+    // Pick the first PS whose key set is a superset of the supplied
+    // keys — same selection rule as `executeMutation`'s CREATE path.
+    std::vector<std::string> chosen_keys;
+    auto *ps_ids = part_cat->GetPropertySchemaIDs();
+    if (ps_ids) {
+        for (auto ps_oid : *ps_ids) {
+            auto *ps = (PropertySchemaCatalogEntry *)catalog.GetEntry(
+                *client, DEFAULT_SCHEMA, ps_oid, true);
+            if (!ps) continue;
+            auto *ps_keys = ps->GetKeys();
+            if (!ps_keys) continue;
+            std::unordered_set<std::string> ps_set(ps_keys->begin(),
+                                                   ps_keys->end());
+            bool has_all = true;
+            for (auto &k : keys) {
+                if (ps_set.find(k) == ps_set.end()) {
+                    has_all = false;
+                    break;
+                }
+            }
+            if (has_all) {
+                chosen_keys = *ps_keys;
+                break;
+            }
+        }
+    }
+    if (chosen_keys.empty()) return;  // no owning PS — leave as-is
+
+    std::unordered_map<std::string, size_t> supplied;
+    for (size_t i = 0; i < keys.size(); i++) supplied[keys[i]] = i;
+    std::vector<Value> padded;
+    padded.reserve(chosen_keys.size());
+    for (auto &k : chosen_keys) {
+        auto it = supplied.find(k);
+        if (it != supplied.end()) padded.push_back(values[it->second]);
+        else padded.push_back(Value());
+    }
+    keys = std::move(chosen_keys);
+    values = std::move(padded);
+}
+
+idx_t WALReader::Replay(const std::string &db_path, DeltaStore &ds,
+                        ClientContext *client) {
     std::string path = wal_path(db_path);
     if (!std::filesystem::exists(path)) return 0;
 
@@ -623,6 +718,7 @@ idx_t WALReader::Replay(const std::string &db_path, DeltaStore &ds) {
                     keys.push_back(MsReadString(ms));
                     values.push_back(MsReadValue(ms));
                 }
+                PadWalRowToOwningPropertySchema(client, pid, keys, values);
                 auto inmem_eid = ds.GetOrAllocateInMemoryExtentID(pid, keys);
                 ds.AppendInsertRow(inmem_eid, std::move(keys), std::move(values),
                                    logical_id);
@@ -643,6 +739,7 @@ idx_t WALReader::Replay(const std::string &db_path, DeltaStore &ds) {
                 }
                 ds.PreserveAdjacencyPidOnUpdate(logical_id);
                 ds.InvalidateCurrentVersion(logical_id);
+                PadWalRowToOwningPropertySchema(client, pid, keys, values);
                 auto inmem_eid = ds.GetOrAllocateInMemoryExtentID(pid, keys);
                 ds.AppendInsertRow(inmem_eid, std::move(keys), std::move(values),
                                    logical_id);

--- a/test/query/test_ldbc_crud.cpp
+++ b/test/query/test_ldbc_crud.cpp
@@ -1305,6 +1305,141 @@ TEST_CASE("MERGE does not crash", "[ldbc][crud][merge]") {
     }
 }
 
+// Cypher's map pattern is conjunctive: a MERGE that matches only some
+// of the requested properties is not a hit. Issue #12 had two layers
+// of the same symptom:
+//
+//   1. The C API regex-based MERGE rewriter (executeMerge in
+//      turbolynx-c.cpp) only used the first parsed property as the
+//      MATCH key, so `MERGE (:Person {id: X, firstName: 'B'})` would
+//      short-circuit to "exists" against any Person with id=X
+//      regardless of firstName, skipping the CREATE.
+//
+//   2. The NodeScan filter-pushdown path didn't handle FP_COMPLEX on
+//      delta rows. When ORCA pushed a multi-property conjunction down,
+//      base extents got filtered correctly but in-memory rows (rows
+//      CREATEd in the same connection) passed through with
+//      `match = true`, so even with fix #1 the MATCH inside
+//      executeMerge would still hit a fresh delta Alice for
+//      `{id: X, firstName: 'Bob'}`.
+TEST_CASE("delta-row multi-property MATCH filters conjunctively",
+          "[ldbc][crud][issue12]") {
+    SKIP_IF_NO_DB();
+    qr->run("CREATE (n:Person {id: 99999999999991, firstName: 'Alice'})", {});
+
+    auto r_alice = qr->run(
+        "MATCH (n:Person {id: 99999999999991, firstName: 'Alice'}) "
+        "RETURN count(n)", {qtest::ColType::INT64});
+    CHECK(r_alice[0].int64_at(0) == 1);
+
+    auto r_bob_map = qr->run(
+        "MATCH (n:Person {id: 99999999999991, firstName: 'Bob'}) "
+        "RETURN count(n)", {qtest::ColType::INT64});
+    CHECK(r_bob_map[0].int64_at(0) == 0);
+
+    auto r_bob_where = qr->run(
+        "MATCH (n:Person) "
+        "WHERE n.id = 99999999999991 AND n.firstName = 'Bob' "
+        "RETURN count(n)", {qtest::ColType::INT64});
+    CHECK(r_bob_where[0].int64_at(0) == 0);
+}
+
+// Graphlet-prune scenarios — multi-PS partitions on the fly via
+// heterogeneous CREATE. Pre-issue #12 the WHERE filter referenced
+// columns that didn't exist on some PSs, and the multi-schema
+// NodeScan's filter expression was bound to the wrong PS layout, so
+// rows leaked.
+TEST_CASE("multi-PS WHERE only matches PS that has the predicate column",
+          "[ldbc][crud][issue12][prune]") {
+    SKIP_IF_NO_DB();
+    qr->run("CREATE (:Person {name: 'KeanuPrune'})", {});
+    qr->run("CREATE (:Person {name: 'CarriePrune', email: 'cam@prune.test'})", {});
+
+    // Single-property WHERE: only Carrie's PS qualifies; pruning must
+    // drop Keanu's PS so the filter is bound to Carrie's layout.
+    auto r = qr->run(
+        "MATCH (p:Person) WHERE p.email = 'cam@prune.test' RETURN p.name",
+        {qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == "CarriePrune");
+}
+
+TEST_CASE("multi-PS WHERE with AND of two props",
+          "[ldbc][crud][issue12][prune]") {
+    SKIP_IF_NO_DB();
+    qr->run("CREATE (:Person {name: 'A', email: 'a@p.test'})", {});
+    qr->run("CREATE (:Person {name: 'B', email: 'b@p.test', firstName: 'Bee'})", {});
+
+    // AND-conjunctive predicate referencing two props — only PSs that
+    // have BOTH should be kept.
+    auto r = qr->run(
+        "MATCH (p:Person) WHERE p.email = 'b@p.test' AND p.firstName = 'Bee' "
+        "RETURN p.name",
+        {qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == "B");
+}
+
+TEST_CASE("multi-PS WHERE with OR keeps all PSs (no over-prune)",
+          "[ldbc][crud][issue12][prune]") {
+    SKIP_IF_NO_DB();
+    qr->run("CREATE (:Person {name: 'KeanuOR'})", {});
+    qr->run("CREATE (:Person {name: 'CarrieOR', email: 'cam@or.test'})", {});
+
+    // `name = 'KeanuOR' OR email = …` is satisfied by Keanu's PS even
+    // though that PS lacks an `email` column. Pruning that PS would
+    // wrongly drop Keanu — the walker must bail on OR and leave
+    // graphlet_ids intact.
+    auto r = qr->run(
+        "MATCH (p:Person) WHERE p.name = 'KeanuOR' OR p.email = 'cam@or.test' "
+        "RETURN p.name "
+        "ORDER BY p.name",
+        {qtest::ColType::STRING});
+    REQUIRE(r.size() == 2);
+    CHECK(r[0].str_at(0) == "CarrieOR");
+    CHECK(r[1].str_at(0) == "KeanuOR");
+}
+
+TEST_CASE("plain MATCH without predicates is unaffected by prune",
+          "[ldbc][crud][issue12][prune]") {
+    SKIP_IF_NO_DB();
+    auto before = qr->run("MATCH (n:Person) RETURN count(n)",
+                           {qtest::ColType::INT64});
+    qr->run("CREATE (:Person {name: 'PlainA'})", {});
+    qr->run("CREATE (:Person {name: 'PlainB', email: 'b@plain.test'})", {});
+    auto after = qr->run("MATCH (n:Person) RETURN count(n)",
+                          {qtest::ColType::INT64});
+    CHECK(after[0].int64_at(0) == before[0].int64_at(0) + 2);
+}
+
+TEST_CASE("MERGE multi-property does not match on first-property only",
+          "[ldbc][crud][merge][issue12]") {
+    SKIP_IF_NO_DB();
+    try {
+        auto before = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                               {qtest::ColType::INT64});
+        int64_t cnt_before = before[0].int64_at(0);
+
+        // Same id as the fixture's anchor (SAMPLE_ID_S = 14, firstName
+        // 'Hossein' in mini), deliberately wrong firstName. MERGE must
+        // CREATE a new node rather than hit Hossein.
+        qr->run("MERGE (n:Person {id: " SAMPLE_ID_S ", firstName: 'IssueTwelveProbe'})",
+                {});
+
+        auto after = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                              {qtest::ColType::INT64});
+        CHECK(after[0].int64_at(0) == cnt_before + 1);
+
+        auto probe = qr->run(
+            "MATCH (n:Person {id: " SAMPLE_ID_S
+            ", firstName: 'IssueTwelveProbe'}) RETURN count(n) AS cnt",
+            {qtest::ColType::INT64});
+        CHECK(probe[0].int64_at(0) == 1);
+    } catch (const std::exception& e) {
+        FAIL("MERGE multi-property: " << e.what());
+    }
+}
+
 // ============================================================
 // Stress / bulk CRUD tests
 // ============================================================


### PR DESCRIPTION
## Summary

Issue #12 surfaced two layered correctness bugs:

1. **C API regex MERGE rewriter** in `executeMerge` only used the *first* parsed property as the MATCH key, so `MERGE (n:Person {id: X, firstName: 'B'})` short-circuited to \"exists\" against any node with `id = X` and skipped the CREATE. Fixed by handing the full `props_str` to the synthesised MATCH check.

2. **Multi-PropertySchema partitions** (heterogeneous CREATEs into one partition, e.g. Bug E's Keanu+Carrie or any LDBC partition that grows new keys mid-run) sent ORCA a multi-schema CLogicalGet whose filter expression's column refs were folded against a single PS's layout. PSs that didn't have the predicate column produced `NULL = literal` comparisons, silently letting through rows from PSs the user never intended to read against.

The pre-M20 logical planner had `lPruneUnnecessaryGraphlets` doing exactly the right thing — dropping graphlets that lacked any filter-referenced property before ORCA optimisation. That pass vanished in the Kuzu→ORCA converter cutover. This PR ports it to the new converter.

## Logical-stage graphlet prune

`Cypher2OrcaConverter::PruneGraphletsByFilterPredicates` runs in `PlanMatchClause` before `PlanRegularMatch`. For each CNF conjunct in `BoundMatchClause::predicates`:

- Walks `PROPERTY` / `COMPARISON` / `AND` / `FUNCTION` / `LITERAL` nodes — collects the `(var_name, property_key_id)` refs that must hold true for the conjunct.
- `OR` / `NOT` / `IS NULL` / unhandled tree shapes abort the walk for that conjunct — those are satisfiable on PSs without the column, so over-pruning would drop valid rows.

For every node variable in the match's query graphs, drops graphlets whose PS keys don't include all of that variable's collected filter keys. Empty result leaves the original list alone — ORCA still emits a valid (zero-row) plan rather than crashing.

`BoundNodeExpression::SetGraphletIDs` lets the converter mutate `graphlet_ids` in place; the rest of the planner's `multi_vertex_partitions` / DSI logic walks the surviving list.

## Storage layout refactor

In-memory extents are now keyed 1:1 to PropertySchemas: every extent's `schema_keys` equals exactly its owning PS's `GetKeys()`. CREATE / WAL replay / scan paths all agree on that invariant.

- **CREATE path** (`executeMutation`): picks the chosen PS (first existing superset, otherwise freshly materialised). Pads the row to chosen PS's full key set so the in-memory extent has canonical layout. Partial CREATEs no longer fork into subset extents.
- **WAL** still serialises the sparse `(key, value)` pairs the user supplied — on-disk format unchanged. `WALReader::Replay` re-pads at replay time via a new optional `ClientContext` parameter (so anything that replays without a live DB still works, just without padding).
- **Delta scan** (`ScanDeltaPhaseChunk`): skips in-memory extents whose key set doesn't match any kept oid. With the storage invariant in place this is a strict equality check, no subset traversal needed. Previously the partition-keyed `GetInMemoryExtentIDs(pid)` leaked rows from pruned PSs.
- **`DeltaStore::GetInMemoryExtentIDsForSchema`** — per-schema variant for callers that want the lookup at the source.
- **FP_COMPLEX delta filter** kept under `num_schemas == 1` gate as a single-schema fallback — multi-PS is now handled by the converter prune so the conservative gate is fine.

## Tests

Under `[ldbc][crud][issue12]` and `[prune]`:

- MERGE multi-property must not match on first-property only
- delta-row multi-property MATCH filters conjunctively (map + WHERE forms)
- multi-PS WHERE on a column only in some PSs prunes correctly
- multi-PS AND-of-two-props prunes to the intersection
- multi-PS OR-of-different-cols leaves both PSs (OR aborts walk)
- plain MATCH without predicates is unaffected by prune

## Out of scope (follow-up)

The narrow case of \"filter on column absent from every PS\" (binder folds `n.col` to a constant NULL literal, delta scan still emits the row through the FP_EQ fallback path) is a separate engine bug — being tracked in a follow-up issue, not blocking this PR.

## Test plan

- [x] `ninja` clean build
- [x] `query_test [tpch]~[stress]` — 55 cases / 1047 assertions
- [x] `query_test [ldbc]~[!mayfail]~[stress]` — 531 cases / 1936 assertions
- [x] `query_test [crud]~[!mayfail]~[stress]` — 147 cases / 462 assertions
- [x] `query_test [issue12]` — 6 cases / 13 assertions
- [x] `query_test [prune]` — 4 cases / 8 assertions
- [x] `query_test [bug-e]` — Bug E multi-PS regression
- [x] `query_test [ldbc][crud][wal]` — WAL replay path exercised by the existing reconnect tests
- [ ] CI on macOS + Linux