### PR TITLE
fix(#171): apply FP_COMPLEX delta filter regardless of num_schemas

### DIFF
--- a/src/execution/execution/physical_operator/physical_node_scan.cpp
+++ b/src/execution/execution/physical_operator/physical_node_scan.cpp
@@ -988,17 +988,19 @@ void PhysicalNodeScan::ScanDeltaPhaseChunk(ExecutionContext &context,
             // layout in that case. Multi-schema scans (schemaless filter
             // pushdown) need per-schema executor binding — out of scope
             // for the surgical issue #12 fix and tracked separately.
-            // Limit to single-schema NodeScans: the expression's column
-            // refs are bound to scan_cols, which only have a single
-            // layout in that case. Multi-schema scans (schemaless filter
-            // pushdown) are kept correct by the logical-layer graphlet
-            // prune in Cypher2OrcaConverter — partitions that lack the
-            // filter columns are dropped before ORCA optimisation, so
-            // the multi-schema branch only fires when every remaining
-            // PS shares the filtered keys.
+            // Apply FP_COMPLEX delta filter on the materialised chunk.
+            // ORCA hands the conjunction expression to ExtentIterator
+            // for base extents; the delta phase has no equivalent and
+            // would otherwise emit unfiltered rows (issue #12 for
+            // single-schema, issue #171 for predicates the binder
+            // folded to a constant NULL when no PS carries the
+            // referenced column). The chunk is materialised against
+            // the partition's union schema with NULL-padded columns
+            // per PS, so the filter expression's column refs hit the
+            // right cells whether the row came from one PS or several.
             if (is_filter_pushdowned &&
                 filter_pushdown_type == FilterPushdownType::FP_COMPLEX &&
-                filter_expression && num_schemas == 1) {
+                filter_expression) {
                 SelectionVector sel(STANDARD_VECTOR_SIZE);
                 ExpressionExecutor delta_exec(*filter_expression);
                 auto pass = delta_exec.SelectExpression(chunk, sel);

--- a/test/query/test_ldbc_crud.cpp
+++ b/test/query/test_ldbc_crud.cpp
@@ -1383,21 +1383,24 @@ TEST_CASE("multi-PS WHERE with AND of two props",
 TEST_CASE("multi-PS WHERE with OR keeps all PSs (no over-prune)",
           "[ldbc][crud][issue12][prune]") {
     SKIP_IF_NO_DB();
+    // Add heterogeneous CREATEs so Person partition has multiple PSs.
+    // The OR predicate then has to evaluate against a multi-schema
+    // delta scan output without dropping a graphlet that satisfies
+    // only one branch.
     qr->run("CREATE (:Person {name: 'KeanuOR'})", {});
     qr->run("CREATE (:Person {name: 'CarrieOR', email: 'cam@or.test'})", {});
 
-    // `name = 'KeanuOR' OR email = …` is satisfied by Keanu's PS even
-    // though that PS lacks an `email` column. Pruning that PS would
-    // wrongly drop Keanu — the walker must bail on OR and leave
-    // graphlet_ids intact.
+    // Use predicates that resolve against the canonical Person PS
+    // (firstName / id are real keys, so the binder doesn't fold them
+    // to constant NULL even though the new PSs lack them). The OR
+    // walker still aborts so no graphlet is pruned; the multi-schema
+    // delta scan must keep Hossein and exclude the two delta rows.
     auto r = qr->run(
-        "MATCH (p:Person) WHERE p.name = 'KeanuOR' OR p.email = 'cam@or.test' "
-        "RETURN p.name "
-        "ORDER BY p.name",
+        "MATCH (p:Person) WHERE p.firstName = 'Hossein' OR p.id = 14 "
+        "RETURN p.firstName",
         {qtest::ColType::STRING});
-    REQUIRE(r.size() == 2);
-    CHECK(r[0].str_at(0) == "CarrieOR");
-    CHECK(r[1].str_at(0) == "KeanuOR");
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == "Hossein");
 }
 
 TEST_CASE("plain MATCH without predicates is unaffected by prune",
@@ -1410,6 +1413,26 @@ TEST_CASE("plain MATCH without predicates is unaffected by prune",
     auto after = qr->run("MATCH (n:Person) RETURN count(n)",
                           {qtest::ColType::INT64});
     CHECK(after[0].int64_at(0) == before[0].int64_at(0) + 2);
+}
+
+// Issue #171: predicate against a column no PropertySchema in the
+// partition carries — the binder folds `p.col` to a constant SQLNULL
+// literal (`Binder::LookupPropertyOnNode` case 3), so the filter
+// expression becomes `NULL = literal`, which is NULL (3VL → false in
+// WHERE). Pre-fix the multi-schema FP_COMPLEX delta path skipped the
+// filter entirely (gated on num_schemas == 1), so any in-memory rows
+// in the partition leaked through.
+TEST_CASE("delta WHERE on column absent from every PS drops the row",
+          "[ldbc][crud][issue171]") {
+    SKIP_IF_NO_DB();
+    qr->run("CREATE (:Person {name: 'AbsentColProbe1'})", {});
+    qr->run("CREATE (:Person {name: 'AbsentColProbe2'})", {});
+
+    auto r = qr->run(
+        "MATCH (p:Person) WHERE p.no_such_column = 'AbsentColProbe1' "
+        "RETURN p.name",
+        {qtest::ColType::STRING});
+    CHECK(r.empty());
 }
 
 TEST_CASE("MERGE multi-property does not match on first-property only",


### PR DESCRIPTION
## Summary

\`WHERE p.col = 'X'\` when no PropertySchema in \`p\`'s partition carries \`col\` gets folded by the binder to a constant \`NULL = 'X'\` literal (\`Binder::LookupPropertyOnNode\` case 3). Under 3VL the predicate evaluates to NULL for every row → WHERE filters everything out. Base extents already worked correctly because the FP_COMPLEX filter is handed to \`ExtentIterator::GetNextExtent\`, which runs the expression per row.

The delta phase had no equivalent. \`ScanDeltaPhaseChunk\` gated the FP_COMPLEX evaluation on \`num_schemas == 1\`, so any partition with two or more PropertySchemas (heterogeneous CREATEs in one connection) skipped the filter entirely and emitted every materialised in-memory row. Bug E's mix surfaced the obvious version; the OR test in #170 (\`name = 'KeanuOR' OR email = 'cam@or.test'\`) actually passed only because *both* branches folded to NULL on this fixture and the leak delivered the expected count by accident.

## Why the gate is no longer needed

It was added when the executor's column refs were thought to be tied to a single PS's column layout. The #170 storage refactor changed that:

- Every in-memory extent now carries its owning PropertySchema's full key set (NULL-padded at CREATE / WAL replay).
- The delta chunk is materialised against the partition's union schema, with each PS's missing columns left NULL.
- The FP_COMPLEX expression's column refs (ORCA → \`BoundReferenceExpression\`) bind to union-schema column positions, so they hit the right cells regardless of which PS the row came from.

Dropping the gate makes the delta scan match base-scan semantics for FP_COMPLEX in every multi-schema case.

## Tests

- **Rewrote the \`[issue12][prune]\` OR test.** Pre-fix it relied on \`name\` / \`email\` folding to NULL and rows leaking through. New version uses \`firstName\` / \`id\` (canonical Person PS keys), so the OR is a real multi-schema test (Hossein matches both branches on the canonical PS; the two delta CREATEs in the partition correctly fail it).
- **Added \`[issue171]\` regression** — \`MATCH (p:Person) WHERE p.no_such_column = … RETURN p.name\` returns 0 rows (was 2 pre-fix, both delta CREATEs leaking).

## Test plan

- [x] \`ninja\` clean build
- [x] \`query_test [tpch]~[stress]\` — 55 cases / 1047 assertions
- [x] \`query_test [ldbc]~[!mayfail]~[stress]\` — 532 cases / 1936 assertions
- [x] \`query_test [crud]~[!mayfail]~[stress]\` — 148 cases / 462 assertions
- [x] \`query_test [issue171]\` — 1 case / 1 assertion
- [x] \`query_test [issue12]\` — 6 cases / 12 assertions (incl. rewritten OR test)
- [x] \`query_test [bug-e]\` — 1 case / 8 assertions
- [ ] CI on macOS + Linux