### PR TITLE
fix(#138): BOTH self-ref edge — match either storage orientation

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -1478,9 +1478,18 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                 //   direction=RIGHT → LHS is the "from" side = stored SRC → lhs_is_src=true
                 bool lhs_is_src = true;
                 bool is_both = (qedge->GetDirection() == RelDirection::BOTH);
+                bool is_both_self_ref = false;
                 auto &catalog = context_->db->GetCatalog();
                 auto expanded_lhs_pids = ExpandRealVertexPartitions(
                     catalog, *context_, lhs_node->GetPartitionIDs());
+                // Computed early so the self-ref BOTH branch below can
+                // choose between the edge-UnionAll wrap and the physical
+                // dual-CSR scan.
+                bool use_per_partition_join = !is_pathjoin
+                    && !qedge->IsVariableLength()
+                    && (qedge->GetPartitionIDs().size() > 1 ||
+                        expanded_lhs_pids.size() > 1 ||
+                        lhs_node->GetGraphletIDs().size() > 1);
                 if (!qedge->GetPartitionIDs().empty() && !lhs_node->GetPartitionIDs().empty()) {
                     // Classify edge partitions by how LHS matches src/dst
                     bool any_src_only = false, any_dst_only = false, any_self_ref = false;
@@ -1501,10 +1510,19 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                     }
 
                     if (is_both && any_self_ref) {
-                        // Self-referential BOTH: dual-phase scan
+                        // Self-ref BOTH: when the edge-UnionAll wrap below
+                        // handles this edge, both_edge_partitions_ must
+                        // stay unset to avoid double-counting with the
+                        // physical dual-CSR scan.
                         lhs_is_src = true;
-                        for (auto ep_oid : qedge->GetPartitionIDs()) {
-                            both_edge_partitions_.insert((idx_t)ep_oid);
+                        is_both_self_ref = true;
+                        bool logical_rewrite_will_handle =
+                            !is_pathjoin && !use_per_partition_join &&
+                            !lhs_is_subquery_outer && !rhs_is_subquery_outer;
+                        if (!logical_rewrite_will_handle) {
+                            for (auto ep_oid : qedge->GetPartitionIDs()) {
+                                both_edge_partitions_.insert((idx_t)ep_oid);
+                            }
                         }
                     } else if (is_both) {
                         // Heterogeneous BOTH: resolve to single direction
@@ -1532,18 +1550,97 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                 uint64_t lhs_edge_key = lhs_is_src ? SID_KEY_ID : TID_KEY_ID;
                 uint64_t rhs_edge_key = lhs_is_src ? TID_KEY_ID : SID_KEY_ID;
 
-                // --- A join R ---
-                // When edge has multiple partitions, create per-partition (node, edge) joins
-                // then union the results. This ensures ORCA generates IndexNLJoin (→ AdjIdxJoin)
-                // for each pair, instead of HashJoin over two UnionAlls.
-                // Works for both multi-partition LHS (Message=Comment+Post) and single-partition
-                // LHS (Person) — each edge partition gets its own AdjIdxJoin.
-                bool use_per_partition_join = !is_pathjoin
-                    && !qedge->IsVariableLength()
-                    && (qedge->GetPartitionIDs().size() > 1 ||
-                        expanded_lhs_pids.size() > 1 ||
-                        lhs_node->GetGraphletIDs().size() > 1);
+                // BOTH self-ref edge wrap (issue #138): expose every edge
+                // row twice — once as (sid, tid), once swapped. The outer
+                // IJ stays a single equi-predicate so the AdjIdxJoin
+                // transform still fires, and either storage orientation
+                // matches through the swap branch.
+                auto wrap_edge_for_both_self_ref =
+                    [&](turbolynx::LogicalPlan *edge_first)
+                        -> turbolynx::LogicalPlan *
+                {
+                    if (!is_both_self_ref || is_pathjoin ||
+                        use_per_partition_join ||
+                        lhs_is_subquery_outer || rhs_is_subquery_outer) {
+                        return edge_first;
+                    }
+                    turbolynx::LogicalPlan *edge_second = PlanEdgeScan(*qedge);
 
+                    CColRef *a_sid = edge_first->getSchema()->getColRefOfKey(
+                        edge_name, SID_KEY_ID);
+                    CColRef *a_tid = edge_first->getSchema()->getColRefOfKey(
+                        edge_name, TID_KEY_ID);
+                    CColRef *b_sid = edge_second->getSchema()->getColRefOfKey(
+                        edge_name, SID_KEY_ID);
+                    CColRef *b_tid = edge_second->getSchema()->getColRefOfKey(
+                        edge_name, TID_KEY_ID);
+
+                    // ORCA's SerialUnionAll matches child columns by position
+                    // (it ignores input_colrefs cross-mapping at this stage),
+                    // so the sid/tid swap has to be encoded as an explicit
+                    // Project on the second branch.
+                    CColumnFactory *col_factory =
+                        COptCtxt::PoctxtFromTLS()->Pcf();
+                    idx_t num_cols = edge_first->getSchema()->size();
+                    CExpressionArray *proj_elems =
+                        GPOS_NEW(mp_) CExpressionArray(mp_);
+                    CColRefArray *new_b_cols =
+                        GPOS_NEW(mp_) CColRefArray(mp_);
+                    for (idx_t c = 0; c < num_cols; c++) {
+                        CColRef *col_a =
+                            edge_first->getSchema()->getColRefofIndex(c);
+                        CColRef *col_b =
+                            edge_second->getSchema()->getColRefofIndex(c);
+                        CColRef *src_col;
+                        if      (col_a == a_sid) src_col = b_tid;
+                        else if (col_a == a_tid) src_col = b_sid;
+                        else                     src_col = col_b;
+                        CColRef *new_col = col_factory->PcrCopy(src_col);
+                        proj_elems->Append(GPOS_NEW(mp_) CExpression(
+                            mp_,
+                            GPOS_NEW(mp_) CScalarProjectElement(mp_, new_col),
+                            GPOS_NEW(mp_) CExpression(
+                                mp_, GPOS_NEW(mp_) CScalarIdent(mp_, src_col))));
+                        new_b_cols->Append(new_col);
+                    }
+                    CExpression *proj_list = GPOS_NEW(mp_) CExpression(
+                        mp_, GPOS_NEW(mp_) CScalarProjectList(mp_), proj_elems);
+                    CExpression *edge_second_swapped = GPOS_NEW(mp_) CExpression(
+                        mp_, GPOS_NEW(mp_) CLogicalProject(mp_),
+                        edge_second->getPlanExpr(), proj_list);
+
+                    CColRefArray *output_colrefs =
+                        GPOS_NEW(mp_) CColRefArray(mp_);
+                    CColRefArray *a_input = GPOS_NEW(mp_) CColRefArray(mp_);
+                    CColRefArray *b_input = GPOS_NEW(mp_) CColRefArray(mp_);
+                    for (idx_t c = 0; c < num_cols; c++) {
+                        CColRef *col_a =
+                            edge_first->getSchema()->getColRefofIndex(c);
+                        output_colrefs->Append(col_a);
+                        a_input->Append(col_a);
+                        b_input->Append((*new_b_cols)[c]);
+                    }
+                    CColRef2dArray *input_colrefs =
+                        GPOS_NEW(mp_) CColRef2dArray(mp_);
+                    input_colrefs->Append(a_input);
+                    input_colrefs->Append(b_input);
+                    CExpressionArray *children =
+                        GPOS_NEW(mp_) CExpressionArray(mp_);
+                    children->Append(edge_first->getPlanExpr());
+                    children->Append(edge_second_swapped);
+                    CExpression *union_expr = GPOS_NEW(mp_) CExpression(
+                        mp_,
+                        GPOS_NEW(mp_) CLogicalUnionAll(
+                            mp_, output_colrefs, input_colrefs),
+                        children);
+                    return new turbolynx::LogicalPlan(
+                        union_expr, *edge_first->getSchema());
+                };
+
+                // --- A join R ---
+                // Per-partition path builds (node, edge) joins per
+                // partition pair so ORCA emits IndexNLJoin (→ AdjIdxJoin)
+                // for each, instead of HashJoin over two UnionAlls.
                 if (use_per_partition_join) {
                     // Build per-partition A→R joins.
                     auto expanded_node_pids = expanded_lhs_pids;
@@ -1825,11 +1922,12 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                             siblings.push_back((idx_t)qedge->GetPartitionIDs()[pi]);
                         }
                     }
-                    edge_plan = is_pathjoin
-                        ? PlanPathGet(*qedge)
-                        : (is_lhs_bound && qedge->GetPartitionIDs().size() > 1
-                            ? PlanEdgeScanSinglePartition(*qedge, 0)
-                            : PlanEdgeScan(*qedge));
+                    edge_plan = wrap_edge_for_both_self_ref(
+                        is_pathjoin
+                            ? PlanPathGet(*qedge)
+                            : (is_lhs_bound && qedge->GetPartitionIDs().size() > 1
+                                ? PlanEdgeScanSinglePartition(*qedge, 0)
+                                : PlanEdgeScan(*qedge)));
                     auto ar_join_type = gpopt::COperator::EOperatorId::EopLogicalInnerJoin;
                     CExpression *a_r_join_expr = is_pathjoin
                         ? ExprLogicalPathJoin(

--- a/test/query/test_ldbc_traversal.cpp
+++ b/test/query/test_ldbc_traversal.cpp
@@ -712,10 +712,10 @@ TEST_CASE("MATCH BOTH (mini): plain MATCH single-clause edge a→b matches",
     CHECK(rd[0].int64_at(0) == ldbc::IS3_FRIENDS[1].friendship_ms);
 }
 
-// [!mayfail] until #138 is fixed — plain MATCH BOTH self-ref both-bound
-// with backward-stored storage misses the edge.
+// Regression for #138: plain MATCH BOTH self-ref with both endpoints
+// id-bound; backward-stored storage was previously missing the edge.
 TEST_CASE("MATCH BOTH (mini): plain MATCH single-clause edge b→a matches",
-          "[ldbc][traversal][both][!mayfail]") {
+          "[ldbc][traversal][both][issue138]") {
     SKIP_IF_NO_DB();
     const char* prefix =
         "MATCH (a:Person {id: 10995116277782}), (b:Person {id: 14}) "
@@ -742,14 +742,81 @@ TEST_CASE("MATCH BOTH (mini): single-clause inline ids edge a→b matches",
         "RETURN count(r)") == 1);
 }
 
-// [!mayfail] until #138 is fixed — single-MATCH inline form takes a
-// different planner path but hits the same forward-only IJ chain.
+// Regression for #138: single-MATCH inline form takes a different
+// planner path but previously hit the same forward-only IJ chain.
 TEST_CASE("MATCH BOTH (mini): single-clause inline ids edge b→a matches",
-          "[ldbc][traversal][both][!mayfail]") {
+          "[ldbc][traversal][both][issue138]") {
     SKIP_IF_NO_DB();
     REQUIRE(qr->count(
         "MATCH (a:Person {id: 10995116277782})-[r:KNOWS]-(b:Person {id: 14}) "
         "RETURN count(r)") == 1);
+}
+
+// Regression for #138: composed BOTH-direction self-ref edges. A path
+// (a {id})-[r1]-(b)-[r2]-(c {id}) must give the same count when a/c are
+// swapped; otherwise one direction is being silently dropped.
+TEST_CASE("MATCH BOTH multi-edge (mini): a-r1-b-r2-c composes symmetrically",
+          "[ldbc][traversal][both][issue138]") {
+    SKIP_IF_NO_DB();
+    const auto count_xy = qr->count(
+        "MATCH (a:Person {id: 14})-[r1:KNOWS]-(b:Person)-[r2:KNOWS]-(c:Person {id: 2199023255594}) "
+        "RETURN count(*)");
+    const auto count_yx = qr->count(
+        "MATCH (a:Person {id: 2199023255594})-[r1:KNOWS]-(b:Person)-[r2:KNOWS]-(c:Person {id: 14}) "
+        "RETURN count(*)");
+    REQUIRE(count_xy > 0);
+    CHECK(count_xy == count_yx);
+}
+
+// Regression for #138 (oracle): SAMPLE_PERSON is the storage source of
+// every IS3 KNOWS edge — (SAMPLE_PERSON -> friend) is stored, the reverse
+// is not. With the anchor swapped, each query becomes a backward-storage
+// lookup. The Neo4j-verified `r.creationDate` (= IS3_FRIENDS[i].friendship_ms)
+// must still come back for every friend, proving the fix sweeps every
+// IS3 friend, not only the single case the [!mayfail] tests pinned.
+TEST_CASE("MATCH BOTH (mini): friend-anchor lookup finds SAMPLE_PERSON via backward edge for every IS3 friend",
+          "[ldbc][traversal][both][issue138]") {
+    SKIP_IF_NO_DB();
+    constexpr size_t N = sizeof(ldbc::IS3_FRIENDS) / sizeof(ldbc::IS3_FRIENDS[0]);
+    for (size_t i = 0; i < N; ++i) {
+        const auto &exp = ldbc::IS3_FRIENDS[i];
+        INFO("backward via friend " << exp.first_name);
+        auto q = "MATCH (a:Person {id: " + std::to_string(exp.person_id) +
+                 "})-[r:KNOWS]-(b:Person {id: " +
+                 std::to_string(ldbc::SAMPLE_PERSON_ID) + "}) "
+                 "RETURN r.creationDate AS d";
+        auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+        REQUIRE(r.size() == 1);
+        CHECK(r[0].int64_at(0) == exp.friendship_ms);
+    }
+}
+
+// Regression for #138 (invariant): for each IS3 friend (whose only
+// incoming edge in the mini fixture is from SAMPLE_PERSON), the BOTH
+// friend count must equal directed-OUT + directed-IN. If backward-stored
+// rows are silently dropped, BOTH drops below this sum and the assertion
+// fires. IS3_FRIENDS guarantees IN > 0, so the invariant exercises the
+// backward path.
+TEST_CASE("MATCH BOTH KNOWS (mini): friend anchor — BOTH count == OUT + IN",
+          "[ldbc][traversal][both][issue138]") {
+    SKIP_IF_NO_DB();
+    constexpr size_t N = sizeof(ldbc::IS3_FRIENDS) / sizeof(ldbc::IS3_FRIENDS[0]);
+    for (size_t i = 0; i < N; ++i) {
+        const auto &fr = ldbc::IS3_FRIENDS[i];
+        INFO("anchor " << fr.first_name);
+        const auto pid = std::to_string(fr.person_id);
+        auto out_cnt = qr->count(
+            ("MATCH (a:Person {id: " + pid +
+             "})-[:KNOWS]->(b:Person) RETURN count(DISTINCT b)").c_str());
+        auto in_cnt = qr->count(
+            ("MATCH (a:Person {id: " + pid +
+             "})<-[:KNOWS]-(b:Person) RETURN count(DISTINCT b)").c_str());
+        auto both_cnt = qr->count(
+            ("MATCH (a:Person {id: " + pid +
+             "})-[:KNOWS]-(b:Person) RETURN count(DISTINCT b)").c_str());
+        CHECK(in_cnt > 0);
+        CHECK(both_cnt == out_cnt + in_cnt);
+    }
 }
 
 // Mixed match/no-match across multiple anchors: SAMPLE_PERSON has a


### PR DESCRIPTION
## Summary
- BOTH-direction self-ref edges (e.g. `(a)-[:KNOWS]-(b)`) silently dropped rows whose physical storage was the reverse of the query's lhs/rhs assignment (closes #138).
- Fix: in `Cypher2OrcaConverter::PlanRegularMatch`, wrap the edge scan in a `UnionAll` whose second branch projects sid/tid swapped. The outer IJ stays a single equi-predicate (AdjIdxJoin-friendly), and the swap branch exposes the same physical row under `(tid, sid)` so either storage orientation matches.
- Scoped to fixed-length, single-partition, non-subquery BOTH self-ref edges. Variable-length, per-partition, and EXISTS subquery paths keep the physical dual-CSR scan (`both_edge_partitions_`); for the wrapped path that flag is cleared so the two layers don't double-count.

## Why not the issue's proposed UNION ALL of two prev_plan IJs
- Sharing `prev_plan` via `AddRef` across the two UnionAll children produced a logical-plan DAG that ORCA's optimizer crashed on (SIGSEGV during `eng.Optimize()`).
- An empty-mapping `PexprCopyWithRemappedColumns` still left ColRefs shared between the two copies, which also crashed.
- The edge-side UnionAll keeps `prev_plan` referenced once and avoids the DAG entirely.

## Notes
- ORCA's `SerialUnionAll` matches child columns by position rather than by the `input_colrefs` cross-mapping, so the sid/tid swap is encoded as an explicit `CLogicalProject` on the second branch (not just via `input_colrefs`).
- EXISTS subquery + BOTH self-ref + backward-stored still misses (`lhs_is_subquery_outer` guard excludes that path). Will open a follow-up issue.

## Test plan
- [x] `./test/query/query_test "[issue138]" --ldbc-path …` — 5 cases / 19 assertions, all pass
  - Drop `[!mayfail]` from the two pinned regressions (forward / backward, id-bound both endpoints).
  - Add multi-edge composition `(a {id})-[r1]-(b)-[r2]-(c {id})` — swap a/c, same count.
  - Add oracle backward-anchor lookups for every IS3 friend — Neo4j-verified `friendship_ms` per friend (every friend exercises the backward path because SAMPLE_PERSON is the storage source of all three edges).
  - Add `BOTH count == OUT + IN` invariant per IS3 anchor with `IN > 0` to prove backward edges are actually present.
- [x] `./test/query/query_test "[ldbc]"` — 2001 assertions / 550 test cases pass (incl. IC2/IC3 BOTH-KNOWS rewrites)
- [x] `./test/query/query_test "[tpch]"` — 1109 assertions / 58 cases pass
- [x] `./test/unittest` — 835 assertions / 208 cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)