### PR TITLE
fix(#171): comparison with NULL must follow Cypher 3VL

### DIFF
--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -545,25 +545,18 @@ CExpression *Cypher2OrcaConverter::ConvertComparison(const CypherBoundComparison
     const BoundExpression *l_expr = expr.GetLeft();
     const BoundExpression *r_expr = expr.GetRight();
 
-    // In Cypher/Neo4j, any comparison with NULL yields NULL (falsy),
-    // so `x = NULL` and `x <> NULL` both return no rows.
-    // Emit constant FALSE to match Neo4j semantics and avoid SQLNULL
-    // hitting an unsupported type path in ORCA serialization.
+    // Cypher 3VL: every comparison with NULL evaluates to null, which
+    // WHERE filters out. Fold to an always-false predicate so it works
+    // uniformly across operators (#171). Bare ScalarConst(false) trips
+    // ORCA (sig 11); IsNull(true) is the same value in a shape ORCA
+    // accepts.
     auto is_null_literal = [](const BoundExpression *e) -> bool {
         if (e->GetExprType() != BoundExpressionType::LITERAL) return false;
         return static_cast<const BoundLiteralExpression *>(e)->GetValue().IsNull();
     };
     if (is_null_literal(r_expr) || is_null_literal(l_expr)) {
-        // Rewrite `x = NULL` → IS NULL, `x <> NULL` → IS NOT NULL.
-        // In strict Cypher both should return 0 rows, but that requires
-        // an always-false predicate that the NodeScan filter executor
-        // cannot yet evaluate. For now, IS NULL / IS NOT NULL is the
-        // closest approximation and avoids the SQLNULL assertion.
-        const BoundExpression *non_null = is_null_literal(r_expr) ? l_expr : r_expr;
-        CExpression *child = ConvertExpression(*non_null, plan);
-        bool is_eq = (expr.GetCmpType() == ExpressionType::COMPARE_EQUAL);
-        return is_eq ? CUtils::PexprIsNull(mp_, child)
-                     : CUtils::PexprIsNotNull(mp_, child);
+        CExpression *true_const = CUtils::PexprScalarConstBool(mp_, true);
+        return CUtils::PexprIsNull(mp_, true_const);
     }
 
     CExpression *lhs = ConvertExpression(*l_expr, plan);

--- a/test/query/test_ldbc_crud.cpp
+++ b/test/query/test_ldbc_crud.cpp
@@ -1435,6 +1435,41 @@ TEST_CASE("delta WHERE on column absent from every PS drops the row",
     CHECK(r.empty());
 }
 
+// Issue #171 broader: every comparison operator on a column absent from
+// every PS must drop the row, not just `=`.
+TEST_CASE("WHERE inequality on column absent from every PS drops the row",
+          "[ldbc][crud][issue171]") {
+    SKIP_IF_NO_DB();
+    qr->run("CREATE (:Person {name: 'AbsentRangeProbe'})", {});
+
+    const char *ops[] = {"=", "<>", ">", "<", ">=", "<="};
+    for (const char *op : ops) {
+        INFO("operator " << op);
+        auto q = std::string("MATCH (p:Person) WHERE p.no_such_column ") +
+                 op + " 'A' RETURN p.name";
+        auto r = qr->run(q.c_str(), {qtest::ColType::STRING});
+        CHECK(r.empty());
+    }
+}
+
+// Cypher 3VL — every operator with a NULL literal operand returns
+// null → WHERE excludes the row. Includes `NULL = NULL` (also null).
+TEST_CASE("WHERE comparison with NULL literal excludes all rows (3VL)",
+          "[ldbc][crud][issue171]") {
+    SKIP_IF_NO_DB();
+    const char *rhs[] = {"'A'", "NULL", "0"};
+    const char *ops[] = {"=", "<>", ">", "<", ">=", "<="};
+    for (const char *op : ops) {
+        for (const char *r : rhs) {
+            INFO("NULL " << op << " " << r);
+            auto q = std::string("MATCH (p:Person) WHERE NULL ") + op + " " +
+                     r + " RETURN p.id LIMIT 5";
+            auto rs = qr->run(q.c_str(), {qtest::ColType::INT64});
+            CHECK(rs.empty());
+        }
+    }
+}
+
 TEST_CASE("MERGE multi-property does not match on first-property only",
           "[ldbc][crud][merge][issue12]") {
     SKIP_IF_NO_DB();

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -539,9 +539,9 @@ TEST_CASE("Special characters in label", "[ldbc][robustness]") {
 
 TEST_CASE("Null literal in WHERE", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
-    // C3 fix: `= null` is rewritten to IS NULL (avoids SQLNULL assertion).
+    // Cypher 3VL: `n.id = null` evaluates to null → row excluded by WHERE.
     auto r = qr->run("MATCH (n:Person) WHERE n.id = null RETURN n.id LIMIT 5");
-    REQUIRE(r.size() <= 5);    // no crash
+    CHECK(r.empty());
 }
 
 TEST_CASE("Boolean literal in id filter", "[ldbc][robustness]") {
@@ -1667,12 +1667,11 @@ TEST_CASE("huge integer constant", "[ldbc][robustness]") {
 // Target: comparison between property and NULL
 TEST_CASE("compare with NULL", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
-    // C3 fix: `= NULL` is rewritten to IS NULL, `<> NULL` to IS NOT NULL.
-    // This prevents the SQLNULL assertion crash; both must not crash.
+    // Cypher 3VL: both `= NULL` and `<> NULL` evaluate to null → 0 rows.
     auto r1 = qr->run("MATCH (p:Person) WHERE p.id = NULL RETURN p.firstName LIMIT 5");
-    REQUIRE(r1.size() <= 5);    // no crash; may find null-id rows
+    CHECK(r1.empty());
     auto r2 = qr->run("MATCH (p:Person) WHERE p.id <> NULL RETURN p.firstName LIMIT 5");
-    REQUIRE(r2.size() == 5);    // IS NOT NULL on id returns rows
+    CHECK(r2.empty());
 }
 
 // Target: multiple aggregates with different GROUP BY keys


### PR DESCRIPTION
Stacked on top of #176 (which is itself stacked on #175).

## Summary
- Cypher2OrcaConverter used to rewrite `x = NULL` → IsNull(x) and every other comparison (`<>`, `<`, `>`, `<=`, `>=`) → IsNotNull(x). The accompanying comment called this an "approximation". It worked for `=` by coincidence but inverted every other operator on non-NULL operands, leaking rows that 3VL would exclude.
- Surfaces both with explicit `NULL` literals and with property references the binder folds to a typed NULL because the column is absent from every PropertySchema on the partition (#171 surface).
- Fix: fold any NULL-operand comparison to an always-false predicate. ORCA crashes on a bare `ScalarConst(false)` at the top of a filter (sig 11), so use the `IsNull(ScalarConstBool(true))` shape — FALSE for every row, same effect, no crash.

## Repros — all returned 51 rows pre-fix, must return 0 post-fix
```cypher
MATCH (p:Person) WHERE p.no_such_column > 'A' RETURN count(p)
MATCH (p:Person) WHERE NULL <> 'A' RETURN count(p)
MATCH (p:Person) WHERE NULL = NULL RETURN count(p)
```

## Why the LDBC suite didn't catch this earlier
LDBC mini queries never compare a NULL literal directly, and the only properties they access exist on every Person PS. The fold path was effectively dead in the regression suite.

## Test plan
- [x] `./test/query/query_test "[issue171]" --ldbc-path ...` — 3 cases / 25 assertions
  - Existing FP_EQ delta repro (unchanged).
  - New sweep across all six comparison operators against a column absent from every PS.
  - New sweep across all six operators with a NULL literal operand (incl. `NULL = NULL`).
- [x] Existing `compare with NULL` and `Null literal in WHERE` robustness tests rewritten to assert Cypher semantics (0 rows) instead of the inverted hack.
- [x] `./test/query/query_test "[ldbc]"` — 2064 assertions / 556 test cases pass
- [x] `./test/query/query_test "[tpch]"` — 1109 / 58 pass
- [x] `./test/unittest` — 835 / 208 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)