### PR TITLE
fix(#4): retry io_submit until every iocb is queued

### DIFF
--- a/src/storage/cache/disk_aio/disk_aio_thread.cpp
+++ b/src/storage/cache/disk_aio/disk_aio_thread.cpp
@@ -1,8 +1,10 @@
 #include "storage/cache/disk_aio/disk_aio_thread.hpp"
 #include "storage/cache/disk_aio/disk_aio_interface.hpp"
 #include <chrono>
+#include <cerrno>
 #include <cstring>
 #include <cstdio>
+#include <thread>
 
 namespace diskaio
 {
@@ -28,18 +30,43 @@ int DiskAioThread::FetchRequests(int num) {
 }
 
 void DiskAioThread::SubmitToKernel(int num) {
-	int rc = io_submit(ctx_, num, (struct iocb**) requests_);
-	if (rc < 0) {
-		fprintf(stderr, "[SubmitToKernel] io_submit failed: rc=%d errno=%d (%s), num=%d\n",
-		        rc, errno, strerror(errno), num);
-		if (num > 0 && requests_[0]) {
-			struct iocb* cb = (struct iocb*) requests_[0];
+#if defined(TURBOLYNX_WASM) || defined(TURBOLYNX_PORTABLE_DISK_IO)
+	// Portable / WASM libaio shim is a no-op; the DiskAioThread loop
+	// never drives kernel AIO in those builds.
+	(void) io_submit(ctx_, num, (struct iocb**) requests_);
+	return;
+#else
+	// io_submit may submit fewer iocbs than requested (kernel queue
+	// full, EAGAIN, EINTR). Slide requests_ forward by the accepted
+	// count and retry the remainder so num_ongoing_ stays consistent
+	// with what the kernel actually holds.
+	int submitted = 0;
+	while (submitted < num) {
+		struct iocb** cbs =
+		    ((struct iocb**) requests_) + submitted;
+		int rc = io_submit(ctx_, num - submitted, cbs);
+		if (rc > 0) {
+			submitted += rc;
+			continue;
+		}
+		// libaio normalizes errors to negative errno values.
+		int e = (rc < 0) ? -rc : 0;
+		if (rc == 0 || e == EAGAIN || e == EINTR) {
+			// Transient — give the kernel a chance to drain.
+			std::this_thread::yield();
+			continue;
+		}
+		fprintf(stderr, "[SubmitToKernel] io_submit failed: rc=%d errno=%d (%s), num=%d, submitted=%d\n",
+		        rc, e, strerror(e), num, submitted);
+		if (submitted < num && requests_[submitted]) {
+			struct iocb* cb = (struct iocb*) requests_[submitted];
 			fprintf(stderr, "  iocb: opcode=%d fd=%d offset=%lld nbytes=%llu buf=%p\n",
 			        cb->aio_lio_opcode, cb->aio_fildes,
 			        (long long)cb->u.c.offset, (unsigned long long)cb->u.c.nbytes, cb->u.c.buf);
 		}
-		assert (false);
+		assert(false);
 	}
+#endif
 }
 
 int DiskAioThread::WaitKernel(struct timespec* to, int num) {


### PR DESCRIPTION
Stacked on top of #178 (which is itself stacked on #176 → #175).

## Summary
- `DiskAioThread::SubmitToKernel` discarded the io_submit return value and the caller blindly incremented `num_ongoing_`. Under I/O pressure Linux AIO returns `0 < rc < num` (queue full), so unsubmitted requests dropped and the wait loop hung.
- EAGAIN / EINTR also hit `assert(false)`, killing the process on transient conditions.
- Replace the single-shot call with a slide-and-retry loop: advance `requests_` by the actually-submitted count, yield-and-retry on `rc == 0` / EAGAIN / EINTR, abort only on a genuine unrecoverable errno. Caller's `num_ongoing_ += fetched` stays correct because the loop only returns once every iocb is queued.

## Portable / WASM builds
The no-op libaio shim returns 0 from `io_submit`, which would spin the retry loop forever. macOS / WASM builds don't drive kernel AIO at all — `DiskAioInterface::Request` calls `ExecuteSyncIo` (sync pread/pwrite) inline, so WAL append, checkpoint, and store.db writes go through correctly without `SubmitToKernel`. Gate the retry behind `!TURBOLYNX_WASM && !TURBOLYNX_PORTABLE_DISK_IO`; the stub path is just for symmetry and returns immediately.

## Test plan
- [x] `./test/query/query_test "[ldbc]" --ldbc-path …` — 2064 / 556 pass
- [x] `./test/query/query_test "[tpch]"` — 1109 / 58 pass
- [x] `./test/unittest` — 835 / 208 pass

No new test: partial `io_submit` is hard to drive deterministically without injecting a syscall shim. The change is a strict superset of the old behavior on the success path, so existing IO-heavy tests cover the no-regression side. A targeted shim-based test belongs to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)