### PR TITLE
fix(#10): DELETE targets the named variable via __mut_<var> alias

### DIFF
--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -153,7 +153,9 @@ struct ConnectionHandle {
     bool                                 has_return_clause = false;
     // For MATCH+SET: SET items extracted at compile time, applied after ORCA execution
     std::vector<duckdb::BoundSetItem>    pending_set_items;
-    // For MATCH+DELETE: flag extracted at compile time
+    // For MATCH+DELETE: target variable names extracted at compile time.
+    // Empty when no DELETE clause is pending.
+    std::vector<std::string>             pending_delete_vars;
     bool                                 pending_delete = false;
     bool                                 pending_detach_delete = false;
 };
@@ -1356,9 +1358,20 @@ static bool ApplyPendingSetMutations(
 
 static bool ApplyPendingDeleteMutations(
     ConnectionHandle *h,
-    const std::vector<std::shared_ptr<duckdb::DataChunk>> &query_results) {
+    const std::vector<std::shared_ptr<duckdb::DataChunk>> &query_results,
+    const std::vector<std::string> &col_names) {
     if (!h->pending_delete) {
         return false;
+    }
+
+    // DELETE may target several variables (`DELETE n, m`). Each variable's
+    // vid lives in its own `__mut_<var>` alias column, injected by
+    // EnsureImplicitMutationReadbackProjection. Fall back to the first
+    // ID column when no aliases are present (legacy single-variable path
+    // or pre-#10 query shape).
+    std::vector<std::string> target_vars = h->pending_delete_vars;
+    if (target_vars.empty()) {
+        target_vars.push_back(std::string());  // sentinel → fallback to FindIdColumn
     }
 
     auto &delta_store = h->database->instance->delta_store;
@@ -1368,10 +1381,18 @@ static bool ApplyPendingDeleteMutations(
         if (!chunk || chunk->ColumnCount() == 0 || chunk->size() == 0) {
             continue;
         }
-        idx_t vid_col = FindIdColumn(*chunk);
-        if (vid_col == duckdb::DConstants::INVALID_INDEX) {
-            continue;
-        }
+        for (auto &var : target_vars) {
+            idx_t vid_col = duckdb::DConstants::INVALID_INDEX;
+            if (!var.empty()) {
+                vid_col = FindMutationAliasColumn(col_names, var);
+            }
+            if (vid_col == duckdb::DConstants::INVALID_INDEX) {
+                vid_col = FindIdColumn(*chunk);
+            }
+            if (vid_col == duckdb::DConstants::INVALID_INDEX ||
+                vid_col >= chunk->ColumnCount()) {
+                continue;
+            }
         // Same vector-safe access reasoning as ApplyPendingSetMutations: a
         // CONSTANT or DICTIONARY result vector with raw `GetData()[row]`
         // would index into the underlying storage past its valid range and
@@ -1457,9 +1478,11 @@ static bool ApplyPendingDeleteMutations(
                          detach_delete ? "DETACH DELETE" : "DELETE",
                          logical_id, extent_id, row_offset);
         }
+        }
     }
 
     h->pending_delete = false;
+    h->pending_delete_vars.clear();
     h->pending_detach_delete = false;
     return true;
 }
@@ -2305,6 +2328,7 @@ static void turbolynx_compile_query(ConnectionHandle* h, string query) {
     }
     // Extract SET items before handing boundQuery to ORCA (which may consume it)
     h->pending_set_items.clear();
+    h->pending_delete_vars.clear();
     h->pending_delete = false;
     // Note: pending_detach_delete is set in prepare, not here
     if (has_updating && !is_mutation) {
@@ -2320,6 +2344,10 @@ static void turbolynx_compile_query(ConnectionHandle* h, string query) {
                     }
                 }
                 else if (uc->GetClauseType() == duckdb::BoundUpdatingClauseType::DELETE_CLAUSE) {
+                    auto* dc = static_cast<const duckdb::BoundDeleteClause*>(uc);
+                    for (auto& var : dc->GetVariables()) {
+                        h->pending_delete_vars.push_back(var);
+                    }
                     h->pending_delete = true;
                 }
             }
@@ -2605,18 +2633,22 @@ static bool EnsureImplicitMutationReadbackProjection(
     ConnectionHandle *h, CypherPreparedStatement *cypher_stmt) {
     // Pure-CREATE mutations (`is_mutation_query`) flow through the
     // turbolynx_execute_mutation path and don't need readback columns.
-    if (!h || !cypher_stmt || h->is_mutation_query ||
-        h->pending_set_items.empty()) {
+    if (!h || !cypher_stmt || h->is_mutation_query) {
+        return false;
+    }
+    if (h->pending_set_items.empty() && h->pending_delete_vars.empty()) {
         return false;
     }
 
-    // Group SET items by target variable while preserving first-seen order.
-    // Per-variable PS keys come from the binder (BoundSetItem.target_ps_keys),
-    // so we can spell out each variable's read-back columns explicitly:
+    // Group SET items + DELETE targets by variable while preserving
+    // first-seen order. Per-variable PS keys come from the binder
+    // (BoundSetItem.target_ps_keys), so we can spell out each variable's
+    // read-back columns explicitly:
     //   id(v) AS __mut_v, v.k1 AS __mut_v_k1, v.k2 AS __mut_v_k2, ...
-    // ApplyPendingSet then locates each variable's row by alias instead of
-    // grabbing the chunk's first ID column — necessary when the user's
-    // explicit RETURN doesn't include `id(v)` (e.g. `RETURN v.name`).
+    // ApplyPendingSet/Delete then locate each row by alias instead of
+    // grabbing the chunk's first ID column — required when the user's
+    // RETURN doesn't include `id(v)` (e.g. `MATCH (a), (b) DELETE b`).
+    // DELETE targets only need the id alias, not property reload.
     vector<string> return_vars;
     std::unordered_map<string, vector<string>> per_var_keys;
     for (auto &item : h->pending_set_items) {
@@ -2630,6 +2662,13 @@ static bool EnsureImplicitMutationReadbackProjection(
         auto &slot = per_var_keys[item.variable_name];
         if (slot.empty() && !item.target_ps_keys.empty()) {
             slot = item.target_ps_keys;
+        }
+    }
+    for (auto &var : h->pending_delete_vars) {
+        if (var.empty()) continue;
+        if (std::find(return_vars.begin(), return_vars.end(), var) ==
+            return_vars.end()) {
+            return_vars.push_back(var);
         }
     }
     if (return_vars.empty()) {
@@ -4453,7 +4492,7 @@ int64_t turbolynx_execute_raw(int64_t conn_id,
             out_is_mutation = true;
         }
         if (h->pending_delete) {
-            ApplyPendingDeleteMutations(h, query_results);
+            ApplyPendingDeleteMutations(h, query_results, out_col_names);
             out_is_mutation = true;
         }
 

--- a/test/query/test_ldbc_crud.cpp
+++ b/test/query/test_ldbc_crud.cpp
@@ -676,6 +676,215 @@ TEST_CASE("DETACH DELETE does not affect other nodes", "[ldbc][crud][delete]") {
     }
 }
 
+// Issue #10: when the MATCH binds multiple variables, DELETE must hit
+// the named variable, not whichever ID column the result chunk happens
+// to expose first. Pre-fix the heuristic could delete the wrong node
+// because the binder never carried the DELETE target through to the
+// result chunk. Verifies against the LDBC mini Person oracle.
+TEST_CASE("DETACH DELETE with multiple bound variables deletes only the named target",
+          "[ldbc][crud][delete][issue10]") {
+    SKIP_IF_NO_DB();
+    try {
+        auto before = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                               {qtest::ColType::INT64});
+        int64_t cnt_before = before[0].int64_at(0);
+
+        // Bind two different anchors; DELETE only the second one.
+        qr->run("MATCH (a:Person {id: " SAMPLE_ID_S "}), "
+                "      (b:Person {id: " SECOND_ID_S "}) DETACH DELETE b", {});
+
+        auto after = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                              {qtest::ColType::INT64});
+        CHECK(after[0].int64_at(0) == cnt_before - 1);
+
+        // a survives — oracle-checked against Hossein Forouhar.
+        auto a_row = qr->run(
+            "MATCH (n:Person {id: " SAMPLE_ID_S "}) "
+            "RETURN n.firstName AS f, n.lastName AS l",
+            {qtest::ColType::STRING, qtest::ColType::STRING});
+        REQUIRE(a_row.size() == 1);
+        CHECK(a_row[0].str_at(0) == ldbc::SAMPLE_PERSON_FIRST_NAME);
+        CHECK(std::string(a_row[0].str_at(0)) + " " + a_row[0].str_at(1) ==
+              ldbc::SAMPLE_PERSON_FULL_NAME);
+
+        auto b_gone = qr->run(
+            "MATCH (n:Person {id: " SECOND_ID_S "}) RETURN count(n) AS c",
+            {qtest::ColType::INT64});
+        CHECK(b_gone[0].int64_at(0) == 0);
+    } catch (const std::exception &e) {
+        FAIL("DETACH DELETE multi-var target: " << e.what());
+    }
+}
+
+// Issue #10: comma DELETE removes every named variable.
+TEST_CASE("DETACH DELETE with comma list removes every named variable",
+          "[ldbc][crud][delete][issue10]") {
+    SKIP_IF_NO_DB();
+    try {
+        auto before = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                               {qtest::ColType::INT64});
+        int64_t cnt_before = before[0].int64_at(0);
+
+        qr->run("MATCH (a:Person {id: " THIRD_ID_S "}), "
+                "      (b:Person {id: " FOURTH_ID_S "}) DETACH DELETE a, b", {});
+
+        auto after = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                              {qtest::ColType::INT64});
+        CHECK(after[0].int64_at(0) == cnt_before - 2);
+    } catch (const std::exception &e) {
+        FAIL("DETACH DELETE comma list: " << e.what());
+    }
+}
+
+// Issue #10: an explicit user RETURN must not block the implicit
+// readback alias injection — `__mut_b` is wedged into the existing
+// projection so the chunk still carries b's id, even though the user
+// only asked for a.id. Pre-fix the readback path was SET-only, so this
+// query deleted whichever ID happened to come first.
+TEST_CASE("DETACH DELETE with explicit RETURN still targets the named variable",
+          "[ldbc][crud][delete][issue10]") {
+    SKIP_IF_NO_DB();
+    try {
+        auto before = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                               {qtest::ColType::INT64});
+        int64_t cnt_before = before[0].int64_at(0);
+
+        // Sanity: a appears before b in the MATCH pattern AND in RETURN.
+        // The wrong-target heuristic would pick a's id from the chunk.
+        qr->run("MATCH (a:Person {id: " SAMPLE_ID_S "}), "
+                "      (b:Person {id: " SECOND_ID_S "}) "
+                "DETACH DELETE b RETURN a.id", {});
+
+        auto after = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                              {qtest::ColType::INT64});
+        CHECK(after[0].int64_at(0) == cnt_before - 1);
+
+        auto a_alive = qr->run(
+            "MATCH (n:Person {id: " SAMPLE_ID_S "}) RETURN count(n) AS c",
+            {qtest::ColType::INT64});
+        CHECK(a_alive[0].int64_at(0) == 1);
+
+        auto b_gone = qr->run(
+            "MATCH (n:Person {id: " SECOND_ID_S "}) RETURN count(n) AS c",
+            {qtest::ColType::INT64});
+        CHECK(b_gone[0].int64_at(0) == 0);
+    } catch (const std::exception &e) {
+        FAIL("DETACH DELETE with explicit RETURN: " << e.what());
+    }
+}
+
+// Issue #10: three bound variables, only the middle one is deleted.
+// Each of a, c carries an ID column too; the wrong-target heuristic
+// would deterministically pick whichever the planner laid first.
+// Surviving nodes are oracle-checked (Hossein, Miguel).
+TEST_CASE("DETACH DELETE picks middle variable out of three bound nodes",
+          "[ldbc][crud][delete][issue10]") {
+    SKIP_IF_NO_DB();
+    try {
+        auto before = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                               {qtest::ColType::INT64});
+        int64_t cnt_before = before[0].int64_at(0);
+
+        qr->run("MATCH (a:Person {id: " SAMPLE_ID_S "}), "
+                "      (b:Person {id: " SECOND_ID_S "}), "
+                "      (c:Person {id: " THIRD_ID_S "}) DETACH DELETE b", {});
+
+        auto after = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                              {qtest::ColType::INT64});
+        CHECK(after[0].int64_at(0) == cnt_before - 1);
+
+        // Survivors keep their identities; b is gone.
+        struct Expected { const char *id; const char *first; };
+        const Expected survivors[] = {
+            {SAMPLE_ID_S, "Hossein"},
+            {THIRD_ID_S,  "Miguel"},
+        };
+        for (const auto &e : survivors) {
+            INFO("id " << e.id);
+            auto q = std::string("MATCH (n:Person {id: ") + e.id +
+                     "}) RETURN n.firstName AS f";
+            auto r = qr->run(q.c_str(), {qtest::ColType::STRING});
+            REQUIRE(r.size() == 1);
+            CHECK(r[0].str_at(0) == e.first);
+        }
+        auto b_gone = qr->run(
+            "MATCH (n:Person {id: " SECOND_ID_S "}) RETURN count(n) AS c",
+            {qtest::ColType::INT64});
+        CHECK(b_gone[0].int64_at(0) == 0);
+    } catch (const std::exception &e) {
+        FAIL("DETACH DELETE three-bound: " << e.what());
+    }
+}
+
+// Issue #10: SET and DELETE in the same query must each route through
+// their own variable's __mut_<var> column. Pre-fix DELETE would have
+// fallen back to the first ID column — which the SET injection placed
+// at a's slot — so SET-on-a + DELETE-on-b would silently delete a.
+TEST_CASE("MATCH+SET+DELETE targets the right variable on each side",
+          "[ldbc][crud][delete][issue10]") {
+    SKIP_IF_NO_DB();
+    try {
+        // SET a.firstName, DELETE b — distinct variables, distinct effects.
+        qr->run("MATCH (a:Person {id: " SAMPLE_ID_S "}), "
+                "      (b:Person {id: " SECOND_ID_S "}) "
+                "SET a.firstName = 'IssueTenProbe' DETACH DELETE b", {});
+
+        // a still alive with the new firstName.
+        auto a_row = qr->run(
+            "MATCH (n:Person {id: " SAMPLE_ID_S "}) RETURN n.firstName AS f",
+            {qtest::ColType::STRING});
+        REQUIRE(a_row.size() == 1);
+        CHECK(a_row[0].str_at(0) == "IssueTenProbe");
+
+        // b deleted.
+        auto b_gone = qr->run(
+            "MATCH (n:Person {id: " SECOND_ID_S "}) RETURN count(n) AS c",
+            {qtest::ColType::INT64});
+        CHECK(b_gone[0].int64_at(0) == 0);
+    } catch (const std::exception &e) {
+        FAIL("MATCH+SET+DELETE: " << e.what());
+    }
+}
+
+// Issue #10 + edge: DELETE the destination of an edge-bound pattern.
+// MATCH (a)-[r]-(b) still produces an a column first; the heuristic
+// would delete a, breaking the source rather than the target.
+TEST_CASE("DETACH DELETE of edge-bound destination removes only that node",
+          "[ldbc][crud][delete][issue10]") {
+    SKIP_IF_NO_DB();
+    try {
+        // SAMPLE_PERSON_ID (=14) has Person friends in IS3 — pick the
+        // first IS3 friend as `b` and verify DELETE only removes b.
+        auto neighbor = qr->run(
+            "MATCH (a:Person {id: " SAMPLE_ID_S "})-[r:KNOWS]-(b:Person) "
+            "RETURN b.id AS bid LIMIT 1",
+            {qtest::ColType::INT64});
+        REQUIRE(neighbor.size() == 1);
+        int64_t bid = neighbor[0].int64_at(0);
+
+        auto before = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                               {qtest::ColType::INT64});
+        int64_t cnt_before = before[0].int64_at(0);
+
+        // The edge pattern binds both a and b; DELETE b only.
+        qr->run(("MATCH (a:Person {id: " SAMPLE_ID_S
+                 "})-[r:KNOWS]-(b:Person {id: " + std::to_string(bid) +
+                 "}) DETACH DELETE b").c_str(),
+                {});
+
+        auto after = qr->run("MATCH (n:Person) RETURN count(n) AS cnt",
+                              {qtest::ColType::INT64});
+        CHECK(after[0].int64_at(0) == cnt_before - 1);
+
+        auto a_alive = qr->run(
+            "MATCH (n:Person {id: " SAMPLE_ID_S "}) RETURN count(n) AS c",
+            {qtest::ColType::INT64});
+        CHECK(a_alive[0].int64_at(0) == 1);
+    } catch (const std::exception &e) {
+        FAIL("DETACH DELETE edge-bound destination: " << e.what());
+    }
+}
+
 TEST_CASE("multiple DETACH DELETEs decrement count", "[ldbc][crud][delete]") {
     SKIP_IF_NO_DB();
     try {


### PR DESCRIPTION
Stacked on top of #179 (→ #178 → #176 → #175).

## Summary
- `ApplyPendingDeleteMutations` resolved the row to delete via `FindIdColumn` — the first `LogicalTypeId::ID` column in the result chunk. With multiple bound variables (`MATCH (a), (b) DELETE b`) that's whichever side the planner laid first, not the named target.
- SET already routes through per-variable `__mut_<var>` aliases (`EnsureImplicitMutationReadbackProjection`); DELETE was still on the heuristic path.
- Capture `BoundDeleteClause::variables` into `ConnectionHandle::pending_delete_vars`, inject `id(v) AS __mut_v` for every DELETE target alongside the SET ones, and resolve each variable's vid via `FindMutationAliasColumn` in `ApplyPendingDeleteMutations`. Comma DELETE (`DELETE a, b`) now hits every named variable.

## Test plan
Six new cases in `test_ldbc_crud.cpp` (all on LDBC mini fixture — 50 Person / 88 KNOWS / 4175 Message):
- Multi-bound DELETE removes only the named target; survivor's firstName/lastName oracle-checked (Hossein Forouhar).
- Comma-list DELETE removes both named variables.
- Explicit user RETURN still gets `__mut_b` wedged into the existing projection.
- Three bound variables, only the middle is deleted; survivors oracle-checked (Hossein, Miguel).
- MATCH+SET+DELETE on distinct variables — SET lands on a (`a.firstName = 'IssueTenProbe'`), DELETE removes b.
- DELETE the destination of an edge-bound pattern.

Regression:
- `query_test "[ldbc]"` — 2085 / 562 pass
- `query_test "[tpch]"` — 1109 / 58 pass
- `unittest` — 835 / 208 pass

CI will additionally cross-check `pytest applications/oss-supply-chain/tests` (covers a non-LDBC schema that also goes through the mutation paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)