### PR TITLE
fix(#68): same-label binding disambiguation via NodeId

### DIFF
--- a/applications/oss-supply-chain/queries/blast_radius_depth1.cypher
+++ b/applications/oss-supply-chain/queries/blast_radius_depth1.cypher
@@ -1,0 +1,13 @@
+// S1.3 — Blast radius capped at 1-hop direct dependents.
+//
+// Tightens the var-len bound to *1..1 so the only packages returned
+// are those whose own version directly depends on the vulnerable
+// version. This exercises the chained-MATCH + var-len + self-join
+// Version topology at the smallest non-trivial path length.
+
+MATCH (c:CVE {id: 'CVE-2021-44228'})<-[:AFFECTED_BY]-(vuln:Version)
+MATCH (downstream:Version)-[:DEPENDS_ON*1..1]->(vuln)
+MATCH (pkg:Package)-[:HAS_VERSION]->(downstream)
+RETURN DISTINCT pkg.name AS package, pkg.ecosystem AS ecosystem
+ORDER BY package ASC
+LIMIT 10;

--- a/applications/oss-supply-chain/queries/blast_radius_depth1.expected
+++ b/applications/oss-supply-chain/queries/blast_radius_depth1.expected
@@ -1,0 +1,2 @@
+package,ecosystem
+awesome-lib,npm

--- a/applications/oss-supply-chain/queries/blast_radius_other_cve.cypher
+++ b/applications/oss-supply-chain/queries/blast_radius_other_cve.cypher
@@ -1,0 +1,13 @@
+// S1.2 — Blast radius of CVE-2021-23337 (lodash prototype pollution).
+//
+// Same shape as blast_radius.cypher but with a different CVE literal —
+// exercises the same chained-MATCH + var-len + self-join Version
+// topology against a non-default vulnerability to widen #68's
+// regression net.
+
+MATCH (c:CVE {id: 'CVE-2021-23337'})<-[:AFFECTED_BY]-(vuln:Version)
+MATCH (downstream:Version)-[:DEPENDS_ON*1..5]->(vuln)
+MATCH (pkg:Package)-[:HAS_VERSION]->(downstream)
+RETURN DISTINCT pkg.name AS package, pkg.ecosystem AS ecosystem
+ORDER BY package ASC
+LIMIT 10;

--- a/applications/oss-supply-chain/queries/blast_radius_other_cve.expected
+++ b/applications/oss-supply-chain/queries/blast_radius_other_cve.expected
@@ -1,0 +1,2 @@
+package,ecosystem
+webapp,npm

--- a/applications/oss-supply-chain/queries/co_dependents.cypher
+++ b/applications/oss-supply-chain/queries/co_dependents.cypher
@@ -1,0 +1,16 @@
+// S1.4 — Vulnerable package + each downstream package.
+//
+// Adds a second Package binding (vulnpkg) alongside the existing
+// downstream pkg binding so the planner has to distinguish two
+// Package aliases at the same time as it distinguishes the two
+// Version aliases (vuln/downstream). Same chained-MATCH + var-len
+// shape as blast_radius, so the regression net stays focused on #68
+// without doubling the var-len pattern (which can SIGSEGV).
+
+MATCH (c:CVE {id: 'CVE-2021-44228'})<-[:AFFECTED_BY]-(vuln:Version)<-[:HAS_VERSION]-(vulnpkg:Package)
+MATCH (downstream:Version)-[:DEPENDS_ON*1..5]->(vuln)
+MATCH (pkg:Package)-[:HAS_VERSION]->(downstream)
+WHERE pkg.name <> vulnpkg.name
+RETURN DISTINCT vulnpkg.name AS vuln_pkg, pkg.name AS affected
+ORDER BY vuln_pkg ASC, affected ASC
+LIMIT 10;

--- a/applications/oss-supply-chain/queries/co_dependents.expected
+++ b/applications/oss-supply-chain/queries/co_dependents.expected
@@ -1,0 +1,3 @@
+vuln_pkg,affected
+log4j,awesome-lib
+log4j,webapp

--- a/applications/oss-supply-chain/tests/test_correctness.py
+++ b/applications/oss-supply-chain/tests/test_correctness.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from oss_supply_chain.canonicalize import canonicalize
+from oss_supply_chain.loader import connect
 from oss_supply_chain.scenarios import blast_radius
 
 
@@ -30,20 +31,46 @@ def _stringify(rows):
     return [tuple("" if v is None else str(v) for v in r) for r in rows]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Planner regression on chained MATCH + variable-length expand + "
-        "vertex-targeted AdjIdxJoin. Tracked in issue #68 (bisected to "
-        "commits 829799aa + fe4809ae). Remove this marker when the "
-        "engine-side fix lands."
-    ),
-)
+def _run_cypher_file(workspace: Path, scenario: str) -> list[tuple]:
+    cypher = (
+        Path(__file__).resolve().parents[1] / "queries" / f"{scenario}.cypher"
+    ).read_text(encoding="utf-8")
+    conn = connect(workspace)
+    try:
+        return [tuple(r) for r in conn.execute(cypher).fetchall()]
+    finally:
+        conn.close()
+
+
 def test_blast_radius_golden(workspace: Path) -> None:
     """S1.1 — deterministic top-10 against the frozen fixture."""
     rows = blast_radius.run(workspace, cve_id="CVE-2021-44228", top=10)
     actual = _stringify([(r["package"], r["ecosystem"]) for r in rows])
     expected = _read_expected("blast_radius")
+    assert canonicalize(actual) == canonicalize(expected)
+
+
+def test_blast_radius_other_cve(workspace: Path) -> None:
+    """S1.2 — same shape, different CVE (lodash). Self-join regression for #68."""
+    rows = _run_cypher_file(workspace, "blast_radius_other_cve")
+    actual = _stringify(rows)
+    expected = _read_expected("blast_radius_other_cve")
+    assert canonicalize(actual) == canonicalize(expected)
+
+
+def test_blast_radius_depth1(workspace: Path) -> None:
+    """S1.3 — var-len capped to *1..1, only direct dependents. #68 regression."""
+    rows = _run_cypher_file(workspace, "blast_radius_depth1")
+    actual = _stringify(rows)
+    expected = _read_expected("blast_radius_depth1")
+    assert canonicalize(actual) == canonicalize(expected)
+
+
+def test_co_dependent_packages(workspace: Path) -> None:
+    """S1.4 — Package and Version each self-joined twice; doubles #68's invariant."""
+    rows = _run_cypher_file(workspace, "co_dependents")
+    actual = _stringify(rows)
+    expected = _read_expected("co_dependents")
     assert canonicalize(actual) == canonicalize(expected)
 
 

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -3832,16 +3832,20 @@ CExpression *Cypher2OrcaConverter::ExprLogicalGet(uint64_t obj_id,
     CExpression *scan_expr = GPOS_NEW(mp_) CExpression(mp_, pop);
 
     CColRefArray *arr = pop->PdrgpcrOutput();
+    // Use the first output colref's id as the binding identifier so that every
+    // CColRef produced by this Get carries the same NodeId. Internal cols
+    // (_id/_sid/_tid) need this too — self-joins on the same label otherwise
+    // can't be distinguished by lineage-walker fallbacks (#68).
     ULONG node_id = (ULONG)-1;
-    if (whole_node_required) {
-        CColRef *pid_ref = (*arr)[0];
-        node_id = pid_ref->Id();
+    if (arr->Size() > 0) {
+        node_id = (*arr)[0]->Id();
     }
     for (ULONG ul = 0; ul < arr->Size(); ul++) {
         CColRef *ref = (*arr)[ul];
         ref->MarkAsUnknown();
         ref->SetNodeId(node_id);
     }
+    (void)whole_node_required;
     return scan_expr;
 }
 

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -201,12 +201,14 @@ duckdb::idx_t Planner::pFindColRefIndex(CColRefArray *cols,
         return gpos::ulong_max;
     };
     auto find_by_table_name = [&](CColRefArray *haystack,
-                                  const CColRef *needle) -> duckdb::idx_t {
+                                  const CColRef *needle,
+                                  bool require_node_id) -> duckdb::idx_t {
         auto *target_table = needle->GetMdidTable();
         if (!IMDId::IsValid(target_table)) {
             return gpos::ulong_max;
         }
         auto *target_name = needle->Name().Pstr()->GetBuffer();
+        const ULONG target_node = needle->NodeId();
         duckdb::idx_t match = gpos::ulong_max;
         for (ULONG i = 0; i < haystack->Size(); i++) {
             if (is_skipped(i)) {
@@ -223,6 +225,14 @@ duckdb::idx_t Planner::pFindColRefIndex(CColRefArray *cols,
             }
             if (std::wcscmp(candidate->Name().Pstr()->GetBuffer(),
                             target_name) != 0) {
+                continue;
+            }
+            // For internal cols (_id/_sid/_tid) of the same label, table+name
+            // alone can't tell two bindings apart in a self-join. Require the
+            // binding-identifier NodeId to match when both sides carry one.
+            if (require_node_id && target_node != gpos::ulong_max &&
+                candidate->NodeId() != gpos::ulong_max &&
+                candidate->NodeId() != target_node) {
                 continue;
             }
             if (match != gpos::ulong_max) {
@@ -292,7 +302,7 @@ duckdb::idx_t Planner::pFindColRefIndex(CColRefArray *cols,
         return idx;
     }
     if (is_hidden_internal(target)) {
-        idx = find_by_table_name(cols, target);
+        idx = find_by_table_name(cols, target, /*require_node_id=*/true);
         if (idx != gpos::ulong_max) {
             return idx;
         }
@@ -302,7 +312,7 @@ duckdb::idx_t Planner::pFindColRefIndex(CColRefArray *cols,
     if (idx != gpos::ulong_max) {
         return idx;
     }
-    idx = find_by_table_name(cols, target);
+    idx = find_by_table_name(cols, target, /*require_node_id=*/false);
     if (idx != gpos::ulong_max) {
         return idx;
     }

--- a/test/query/test_oss_regression.cpp
+++ b/test/query/test_oss_regression.cpp
@@ -137,3 +137,68 @@ TEST_CASE("OSS #63 issue reproduction with filtered traversal",
 // extent seqno), which corrupts the first vertex of most partitions.
 // Vertex-count integrity is already verified by the query_test harness
 // in probe_and_verify().
+
+// ============================================================
+// Issue #68 regression: self-join of same-label internal `_id`
+//
+// Two bindings of the same label (e.g. `vuln:Version` and
+// `downstream:Version`) share table MDId and column name `_id`. Before
+// the NodeId-aware fix, planner_physical's lineage-walker fallback
+// (`find_by_table_name(hidden_internal)`) matched the two distinct
+// `_id` columns as if they were the same, causing the downstream
+// Version's id slot to be overwritten with the vuln Version's id at
+// HashJoin output time. The query then incorrectly traversed
+// HAS_VERSION starting from `vuln._id` and returned the vulnerable
+// package itself.
+// ============================================================
+
+TEST_CASE("OSS #68 blast-radius default", "[oss][regression68]") {
+    SKIP_IF_NO_OSS_DB();
+    const char* query =
+        "MATCH (c:CVE {id: 'CVE-2021-44228'})<-[:AFFECTED_BY]-(vuln:Version) "
+        "MATCH (downstream:Version)-[:DEPENDS_ON*1..5]->(vuln) "
+        "MATCH (pkg:Package)-[:HAS_VERSION]->(downstream) "
+        "RETURN DISTINCT pkg.name AS package, pkg.ecosystem AS ecosystem "
+        "ORDER BY package ASC;";
+    auto r = qr->run(query, {qtest::ColType::STRING, qtest::ColType::STRING});
+    REQUIRE(r.size() == 2);
+    CHECK(r[0].str_at(0) == "awesome-lib");
+    CHECK(r[0].str_at(1) == "npm");
+    CHECK(r[1].str_at(0) == "webapp");
+    CHECK(r[1].str_at(1) == "npm");
+}
+
+TEST_CASE("OSS #68 blast-radius alternate CVE", "[oss][regression68]") {
+    SKIP_IF_NO_OSS_DB();
+    const char* query =
+        "MATCH (c:CVE {id: 'CVE-2021-23337'})<-[:AFFECTED_BY]-(vuln:Version) "
+        "MATCH (downstream:Version)-[:DEPENDS_ON*1..5]->(vuln) "
+        "MATCH (pkg:Package)-[:HAS_VERSION]->(downstream) "
+        "RETURN DISTINCT pkg.name AS package, pkg.ecosystem AS ecosystem "
+        "ORDER BY package ASC;";
+    auto r = qr->run(query, {qtest::ColType::STRING, qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == "webapp");
+    CHECK(r[0].str_at(1) == "npm");
+}
+
+TEST_CASE("OSS #68 vulnpkg vs affected pkg (Package self-join layer)",
+          "[oss][regression68]") {
+    SKIP_IF_NO_OSS_DB();
+    // Adds a second Package binding (`vulnpkg`) so both Package and
+    // Version bindings appear twice in the same plan.
+    const char* query =
+        "MATCH (c:CVE {id: 'CVE-2021-44228'})"
+        "<-[:AFFECTED_BY]-(vuln:Version)<-[:HAS_VERSION]-(vulnpkg:Package) "
+        "MATCH (downstream:Version)-[:DEPENDS_ON*1..5]->(vuln) "
+        "MATCH (pkg:Package)-[:HAS_VERSION]->(downstream) "
+        "WHERE pkg.name <> vulnpkg.name "
+        "RETURN DISTINCT vulnpkg.name AS vp, pkg.name AS ap "
+        "ORDER BY vp ASC, ap ASC;";
+    auto r = qr->run(query, {qtest::ColType::STRING, qtest::ColType::STRING});
+    REQUIRE(r.size() == 2);
+    CHECK(r[0].str_at(0) == "log4j");
+    CHECK(r[0].str_at(1) == "awesome-lib");
+    CHECK(r[1].str_at(0) == "log4j");
+    CHECK(r[1].str_at(1) == "webapp");
+}


### PR DESCRIPTION
closes #68

## Summary

- Same-label self-joins (e.g. `vuln:Version` and `downstream:Version`) carry the same table MDId and the same internal column name `_id`. The planner's lineage-walker fallback `find_by_table_name(hidden_internal)` matched these two distinct `_id` colrefs as if they were the same, routing `vuln._id` onto the output slot labelled `downstream._id` at HashJoin transform time. Subsequent HAS_VERSION traversals read `vuln._id` as the start, so `blast_radius` returned the vulnerable package itself (`log4j`) instead of its dependents (`awesome-lib`, `webapp`).
- Two-line fix: (1) `ExprLogicalGet` now sets `NodeId` on every output colref of every Get (including internal `_id`/`_sid`/`_tid`), keyed by the first colref's id so all cols of a binding share the same id. (2) `find_by_table_name` in the `is_hidden_internal` path requires `NodeId` match when both sides carry one — preventing two distinct same-label bindings from collapsing onto each other.

## Regression coverage

| Test | Pre-fix | Post-fix | Notes |
|---|---|---|---|
| `test_blast_radius_golden` (pytest) | **FAIL** | PASS | xfail marker removed |
| `test_blast_radius_other_cve` (pytest, new) | **FAIL** | PASS | CVE-2021-23337 / lodash |
| `OSS #68 blast-radius default` (C++, new) | **FAIL** | PASS | mirror of the pytest case |
| `OSS #68 blast-radius alternate CVE` (C++, new) | **FAIL** | PASS | mirror of the pytest case |
| `test_blast_radius_depth1` (pytest, new) | pass | PASS | regression net |
| `test_co_dependent_packages` (pytest, new) | pass | PASS | Package self-join layer |
| `OSS #68 vulnpkg vs affected pkg` (C++, new) | pass | PASS | regression net |

All four exact-invariant tests fail on `main` and pass with the fix.

## Suite results (post-fix)

- LDBC 562/562, TPCH 55/55, types 23/23, unittest 208/208
- oss-supply-chain pytest 22/22, `[oss][regression68]` 3/3

## Out of scope

Filed #181 for a separate SIGSEGV that fires whenever a query has two var-len expansions sharing an endpoint (e.g. `p1`/`p2` with `v1`/`v2` both `DEPENDS_ON*->vuln`). It reproduces identically before and after this fix; not addressed here.

## Test plan

- [x] `ldbc` 562/562
- [x] `tpch~broken-mini~stress` 55/55
- [x] `types` 23/23
- [x] `unittest` 208/208
- [x] `oss-supply-chain` pytest 22/22 (incl. 4 new correctness tests)
- [x] `[oss][regression68]` 3/3
- [x] pre-fix verification: each fix-trigger test confirmed FAIL on `main`