### PR TITLE
fix(#6): preserve DeltaStore and WAL on checkpoint catalog mismatch

### DIFF
--- a/src/include/main/capi/turbolynx.h
+++ b/src/include/main/capi/turbolynx.h
@@ -295,6 +295,12 @@ void turbolynx_clear_delta(int64_t conn_id);
 // Compact: flush DeltaStore to base extents, truncate WAL.
 void turbolynx_checkpoint(int64_t conn_id);
 
+// Test-only: inject an InsertBuffer for a partition_id that is NOT in the
+// catalog. Used by #6 regression tests to drive checkpoint into the
+// fail-fast path that preserves DeltaStore + WAL on catalog inconsistency.
+int turbolynx_test_inject_orphan_insert_buffer(int64_t conn_id,
+                                               uint16_t orphan_partition_id);
+
 // Set auto compaction thresholds. Set row_threshold=0 to disable.
 void turbolynx_set_auto_compact_threshold(size_t row_threshold, size_t extent_threshold);
 

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -1592,10 +1592,22 @@ void turbolynx_checkpoint_ctx(duckdb::ClientContext &context) {
             }
             if (live_rows.empty()) continue;
 
-            // Find the partition catalog entry.
+            // Find the partition catalog entry. A missing entry means the
+            // buffer's partition is no longer in the catalog (drop without
+            // matching delta wipe, catalog corruption, or a concurrent
+            // mutation race). Continuing here would silently drop the
+            // buffer rows once the checkpoint reaches ClearInsertData /
+            // wal->Truncate later; instead, abort the checkpoint so the
+            // WAL and DeltaStore stay replayable (#6).
             duckdb::PartitionCatalogEntry *part_cat =
                 FindPartitionCatalogByLogicalId(context, partition_id);
-            if (!part_cat) continue;
+            if (!part_cat) {
+                throw std::runtime_error(
+                    "checkpoint aborted: no catalog partition for "
+                    "in-memory extent 0x" + std::to_string(inmem_eid) +
+                    " (partition_id=" + std::to_string(partition_id) +
+                    ")");
+            }
 
             // Find matching PropertySchema (exact key match)
             duckdb::PropertySchemaCatalogEntry *match_ps = nullptr;
@@ -1633,7 +1645,13 @@ void turbolynx_checkpoint_ctx(duckdb::ClientContext &context) {
                 target_ps = (duckdb::PropertySchemaCatalogEntry *)catalog.GetEntry(
                     context, DEFAULT_SCHEMA, (*ps_ids)[0], true);
             }
-            if (!target_ps) continue;
+            if (!target_ps) {
+                throw std::runtime_error(
+                    "checkpoint aborted: partition " +
+                    std::to_string(partition_id) +
+                    " has no PropertySchema for in-memory extent 0x" +
+                    std::to_string(inmem_eid));
+            }
 
             auto col_types = target_ps->GetTypesWithCopy();
             auto *ps_keys = target_ps->GetKeys();
@@ -1765,6 +1783,24 @@ void turbolynx_checkpoint_ctx(duckdb::ClientContext &context) {
         "[CHECKPOINT] Complete: flushed {} rows, rewrote {} row deletes, {} edge inserts, {} edge deletes",
         flushed_rows, delete_mask_entries, inserted_edge_entries,
         deleted_edge_entries);
+}
+
+// Test-only: inject an InsertBuffer for a partition_id that is NOT in the
+// catalog. Used by #6 regression tests to verify that checkpoint refuses
+// to clear DeltaStore / truncate WAL when it discovers an orphan buffer.
+// Returns 0 on success, -1 if the connection is invalid.
+extern "C" int turbolynx_test_inject_orphan_insert_buffer(int64_t conn_id,
+                                                          uint16_t orphan_partition_id) {
+    auto *h = get_handle(conn_id);
+    if (!h) return -1;
+    auto &ds = h->database->instance->delta_store;
+    uint32_t eid = ds.AllocateInMemoryExtentID(orphan_partition_id);
+    std::vector<std::string> keys = {"_id"};
+    std::vector<duckdb::Value> values = {
+        duckdb::Value::UBIGINT(static_cast<uint64_t>(0))};
+    ds.AppendInsertRow(eid, std::move(keys), std::move(values),
+                       /*logical_id=*/0);
+    return 0;
 }
 
 void turbolynx_checkpoint(int64_t conn_id) {

--- a/test/query/test_ldbc_crud.cpp
+++ b/test/query/test_ldbc_crud.cpp
@@ -2622,6 +2622,46 @@ TEST_CASE("checkpoint then more mutations then checkpoint", "[ldbc][crud][compac
 }
 
 // ============================================================
+// Issue #6 — checkpoint must preserve DeltaStore + WAL on catalog
+// inconsistency (no silent skip → no data loss).
+// ============================================================
+
+TEST_CASE("checkpoint fails fast and preserves WAL when buffer references a missing partition",
+          "[ldbc][crud][compaction][issue6]") {
+    COMPACTION_SETUP();
+    try {
+        // 1) Real mutation that lives in DeltaStore + WAL.
+        qr->run("CREATE (n:Person {id: 12612612612606, firstName: 'CP6Survive'})", {});
+
+        // 2) Inject an orphan InsertBuffer whose partition_id is not in the
+        //    catalog. Use 0xFFFE — well outside the catalog's assigned ids
+        //    for the LDBC fixture.
+        REQUIRE(turbolynx_test_inject_orphan_insert_buffer(qr->conn_id(),
+                                                           (uint16_t)0xFFFE) == 0);
+
+        // 3) Checkpoint must abort. The c API swallows the exception and
+        //    routes the message through turbolynx_get_last_error.
+        qr->checkpoint();
+        char *errmsg = nullptr;
+        turbolynx_get_last_error(&errmsg);
+        REQUIRE(errmsg != nullptr);
+        const std::string err(errmsg);
+        CHECK(err.find("checkpoint aborted") != std::string::npos);
+
+        // 4) Reopen the database. The legitimate CREATE survives via WAL
+        //    replay — proof that checkpoint did not call ClearInsertData /
+        //    Truncate before throwing.
+        qr->reconnect(compact_db_path);
+        auto r = qr->run("MATCH (n:Person {id: 12612612612606}) RETURN n.firstName",
+                          {qtest::ColType::STRING});
+        REQUIRE(r.size() == 1);
+        CHECK(r[0].str_at(0) == "CP6Survive");
+    } catch (const std::exception& e) {
+        FAIL("issue6 fail-fast: " << e.what());
+    }
+}
+
+// ============================================================
 // Filter pushdown after compaction
 // ============================================================
 


### PR DESCRIPTION
closes #6

Stacks on #182.

## Summary

- `turbolynx_checkpoint_ctx` Phase 1 had two silent `continue` paths — one for unresolved `partition_id`, one for partitions with no PropertySchema. The function still reached `ds.ClearInsertData()` + `wal_writer->Truncate()`, so any buffer that hit either branch was silently dropped from both the in-memory delta layer and the WAL replay source. That's the P1 data-loss path described in #6.
- The legitimate write path (`AppendNodeDeltaRow` / `AppendDeltaRow`) always allocates buffers under a partition that's already in the catalog, so those `continue` branches only fire on catalog inconsistency. We treat that as an abortable condition rather than something to silently absorb.
- Fix: both `continue`s now `throw std::runtime_error("checkpoint aborted: ...")`. The throw happens in Phase 1, well before `SaveCatalog` (the "point of no return"), so `ClearInsertData` and `Truncate` never run — DeltaStore stays in memory and the WAL replays on reopen. The c API `turbolynx_checkpoint` catches the throw and surfaces the message through `turbolynx_get_last_error`.

## Regression test

- New test-only API `turbolynx_test_inject_orphan_insert_buffer` adds a buffer for a partition_id that is deliberately not in the catalog (0xFFFE).
- New test `[ldbc][crud][compaction][issue6]` *checkpoint fails fast and preserves WAL when buffer references a missing partition*:
  1. CREATE a node (lands in DeltaStore + WAL),
  2. inject the orphan buffer,
  3. checkpoint — must report \"checkpoint aborted\" via `turbolynx_get_last_error`,
  4. reconnect, then verify the CREATE survives via WAL replay.
- Pre-fix verification: same test, with the two `continue`s temporarily restored, fails on the \"checkpoint aborted\" expectation — the silent-skip path lets the checkpoint complete and truncate the WAL.

## Suite results (post-fix)

- LDBC 563/563, TPCH 55/55, types 23/23, unittest 208/208
- oss-supply-chain pytest 22/22, `[oss][regression68]` 3/3

## Test plan

- [x] `ldbc` 563/563
- [x] `tpch~broken-mini~stress` 55/55
- [x] `types` 23/23
- [x] `unittest` 208/208
- [x] `oss-supply-chain` pytest 22/22
- [x] pre-fix verification: orphan-buffer test FAILS on \"checkpoint aborted\" check before the fix, PASSES after