### PR TITLE
fix(#17): reject bare pattern comprehensions in the binder

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -43,6 +43,22 @@
 
 namespace duckdb {
 
+namespace {
+// Tracks whether the current BindExpression call is nested inside a
+// `__list_comprehension` body. Bare `__pattern_comprehension` outside any
+// list comprehension cannot be reduced to a supported plan (only the
+// IC14 weighted-path collapse pattern is supported), and letting it reach
+// the ORCA converter would throw an exception inside an ORCA frame and
+// SIGSEGV in CAutoMemoryPool teardown (#136). Reject in the binder, which
+// is the last layer above ORCA where it is safe to throw. (#17)
+thread_local int g_list_comp_bind_depth = 0;
+
+struct ListCompBindDepthGuard {
+    ListCompBindDepthGuard() { ++g_list_comp_bind_depth; }
+    ~ListCompBindDepthGuard() { --g_list_comp_bind_depth; }
+};
+}  // namespace
+
 static bool ExtractReduceVarName(const ParsedExpression &expr, string &out) {
     if (expr.GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
         return false;
@@ -2022,11 +2038,20 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
     // just fall through to the general function binding path.
 
     // __pattern_comprehension(...) → preserve metadata for the IC14
-    // weighted-path collapse. Bare pattern comprehensions are rejected by
-    // the converter instead of returning a placeholder list.
-    // Children are pattern metadata (constants), not bindable expressions.
-    // Full binding + decorrelation happens in M5 converter integration.
+    // weighted-path collapse. The only supported use is inside a
+    // `__list_comprehension` body that the IC14 rewrite will collapse into
+    // `path_weight`. A bare pattern comprehension reaching the converter
+    // throws inside an ORCA frame and SIGSEGVs in CAutoMemoryPool teardown
+    // (#136), so reject it here at the binder layer with a clean message
+    // instead of letting it slip through (#17).
     if (fname == "__pattern_comprehension") {
+        if (g_list_comp_bind_depth == 0) {
+            throw BinderException(
+                "Pattern comprehension `[(...)-[:R]->(...) | expr]` is only "
+                "supported inside the IC14 weighted-path collapse pattern "
+                "(list comprehension over reduce/list_sum). Bare pattern "
+                "comprehensions are not yet implemented.");
+        }
         bound_expression_vector children;
         for (auto &c : expr.children) {
             // Bind constants and simple expressions, skip complex pattern refs
@@ -2520,6 +2545,10 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
     // __list_comprehension(source, 'loop_var', filter, [map])
     // Bind with loop variable temporarily added to context
     if (fname == "__list_comprehension" && expr.children.size() >= 3) {
+        // Mark every sub-bind that happens inside this list comprehension
+        // body so a nested `__pattern_comprehension` (the only place it is
+        // legal) is allowed through the binder. See the guard at line ~2029.
+        ListCompBindDepthGuard list_comp_guard;
         // child 0: source list
         auto source = BindExpression(*expr.children[0], ctx);
         LogicalType source_type = source->GetDataType();

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -809,3 +809,76 @@ TEST_CASE("STARTS WITH in WHERE", "[ldbc][filter][stringpred]") {
     REQUIRE(r.size() == 1);
     CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
 }
+
+// ============================================================
+// Issue #17 — list comprehension WHERE/| mapping must actually run
+// (used to return the unfiltered source list silently).
+// ============================================================
+
+TEST_CASE("list comprehension WHERE filters by predicate",
+          "[ldbc][filter][listcomp][issue17]") {
+    SKIP_IF_NO_DB();
+    // Pin every element of the expected output so a wrong middle entry
+    // can't slip past a size/first/last spot check.
+    auto r = qr->run(
+        "WITH [1,2,3,4,5] AS xs "
+        "WITH [x IN xs WHERE x > 2] AS r "
+        "RETURN size(r) AS n, r[0] AS e0, r[1] AS e1, r[2] AS e2",
+        {qtest::ColType::INT64, qtest::ColType::INT64,
+         qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 3);   // size == 3
+    CHECK(r[0].int64_at(1) == 3);   // r[0]
+    CHECK(r[0].int64_at(2) == 4);   // r[1]
+    CHECK(r[0].int64_at(3) == 5);   // r[2]
+}
+
+TEST_CASE("list comprehension | mapping applies projection",
+          "[ldbc][filter][listcomp][issue17]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "WITH [1,2,3,4] AS xs "
+        "WITH [x IN xs | x*x] AS r "
+        "RETURN size(r) AS n, r[0] AS e0, r[1] AS e1, r[2] AS e2, r[3] AS e3",
+        {qtest::ColType::INT64, qtest::ColType::INT64, qtest::ColType::INT64,
+         qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 4);   // size == 4
+    CHECK(r[0].int64_at(1) == 1);   // 1*1
+    CHECK(r[0].int64_at(2) == 4);   // 2*2
+    CHECK(r[0].int64_at(3) == 9);   // 3*3
+    CHECK(r[0].int64_at(4) == 16);  // 4*4
+}
+
+TEST_CASE("list comprehension WHERE + mapping combined",
+          "[ldbc][filter][listcomp][issue17]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "WITH [1,2,3,4,5] AS xs "
+        "WITH [x IN xs WHERE x > 2 | x*10] AS r "
+        "RETURN size(r) AS n, r[0] AS e0, r[1] AS e1, r[2] AS e2",
+        {qtest::ColType::INT64, qtest::ColType::INT64,
+         qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 3);    // size == 3
+    CHECK(r[0].int64_at(1) == 30);   // 3*10
+    CHECK(r[0].int64_at(2) == 40);   // 4*10
+    CHECK(r[0].int64_at(3) == 50);   // 5*10
+}
+
+TEST_CASE("bare pattern comprehension throws a clean binder error",
+          "[ldbc][filter][listcomp][issue17]") {
+    SKIP_IF_NO_DB();
+    // Pre-fix: this query reached the converter, where `throw
+    // NotImplementedException` fired inside an ORCA frame and SIGSEGVed
+    // in CAutoMemoryPool teardown (sig=11). Post-fix: the binder rejects
+    // it cleanly.
+    auto q = std::string("MATCH (p:Person {id: ") + sample_person_id_str() +
+             "}) RETURN [(p)-[:KNOWS]->(f) | f.firstName] AS friends";
+    bool caught = false;
+    std::string err;
+    try { qr->run(q.c_str()); }
+    catch (const std::exception &e) { caught = true; err = e.what(); }
+    REQUIRE(caught);
+    CHECK(err.find("Pattern comprehension") != std::string::npos);
+}


### PR DESCRIPTION
closes #17 (the SIGSEGV / silent-wrong-result behavior)
tracking #184 for the full pattern-comprehension implementation

Stacks on #183.

## Summary

- The converter at `cypher2orca_scalar.cpp:831-835` already throws `NotImplementedException` for bare `__pattern_comprehension`. The throw fires inside an ORCA frame and SIGSEGVs in `CAutoMemoryPool::~CAutoMemoryPool()` (long-standing #136 — ORCA cleanup is not exception-safe), so what reaches the user is `signal trapped (sig=11)` instead of either the placeholder list #17 reported or the intended clean error.
- This change **does not implement** general pattern comprehension. It only closes the SIGSEGV / silent-wrong-result gap by rejecting the unsupported shape **before ORCA is entered**. The full implementation is tracked in #184.
- Fix: thread-local `g_list_comp_bind_depth` incremented by a RAII guard around the binder's `__list_comprehension` body. The `__pattern_comprehension` handler now throws a `BinderException` whenever depth is zero — the only supported placement is inside a list comprehension that the IC14 weighted-path rewrite will collapse into `path_weight`.

## Behavior change

| query | pre-fix | post-fix |
|---|---|---|
| `MATCH (p:Person {id: 14}) RETURN [(p)-[:KNOWS]->(f) \| f.firstName]` | SIGSEGV (sig=11) | clean BinderException: \"Pattern comprehension … is only supported inside the IC14 weighted-path collapse pattern\" |
| IC14 weighted shortest path | works | works (3/3) |
| `[x IN xs WHERE x>2 \| x*10]` | works | works |

## Regression coverage

Four new tests in `test/query/test_ldbc_filter.cpp` under `[ldbc][filter][listcomp][issue17]`:

- list comp WHERE → oracle `[3,4,5]`
- list comp `|` mapping → oracle `[1,4,9,16]`
- list comp WHERE + mapping → oracle `[30,40,50]`
- bare pattern comp → BinderException with \"Pattern comprehension\" in the message

Pre-fix verified by stashing the binder change and re-running the new tests: the bare-pattern-comp test fails the message-content assertion because the SIGSEGV trap surfaces a different string. Re-applying the fix, all four pass.

## Out of scope

Pattern comprehensions placed **inside** a list comprehension body in shapes that the IC14 rewrite does not recognize (different hop count, different reduce form) still pass the binder via the depth guard and can hit the same SIGSEGV path in ORCA. That requires the general implementation tracked in #184.

## Suite results (post-fix)

- LDBC 567/567 (4 issue17 tests added), TPCH 55/55, types 23/23, unittest 208/208
- oss-supply-chain pytest 22/22, `[oss][regression68]` 3/3

## Test plan

- [x] `ldbc` 567/567
- [x] `tpch~broken-mini~stress` 55/55
- [x] `types` 23/23
- [x] `unittest` 208/208
- [x] `oss-supply-chain` pytest 22/22
- [x] pre-fix verification: `bare pattern comp` test fails on \"Pattern comprehension\" message check before the binder change, passes after