### PR TITLE
cleanup: trim verbose comments and drop dead ExprLogicalGet parameter

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -44,13 +44,10 @@
 namespace duckdb {
 
 namespace {
-// Tracks whether the current BindExpression call is nested inside a
-// `__list_comprehension` body. Bare `__pattern_comprehension` outside any
-// list comprehension cannot be reduced to a supported plan (only the
-// IC14 weighted-path collapse pattern is supported), and letting it reach
-// the ORCA converter would throw an exception inside an ORCA frame and
-// SIGSEGV in CAutoMemoryPool teardown (#136). Reject in the binder, which
-// is the last layer above ORCA where it is safe to throw. (#17)
+// >0 while binding inside a `__list_comprehension` body. Bare
+// `__pattern_comprehension` is only legal inside one (IC14 collapse) —
+// outside, the binder rejects it before it reaches ORCA, where the throw
+// would not unwind safely (#17, #136).
 thread_local int g_list_comp_bind_depth = 0;
 
 struct ListCompBindDepthGuard {
@@ -2098,13 +2095,10 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
     // with lowercase names. The binder lowercases fname above, so they
     // just fall through to the general function binding path.
 
-    // __pattern_comprehension(...) → preserve metadata for the IC14
-    // weighted-path collapse. The only supported use is inside a
-    // `__list_comprehension` body that the IC14 rewrite will collapse into
-    // `path_weight`. A bare pattern comprehension reaching the converter
-    // throws inside an ORCA frame and SIGSEGVs in CAutoMemoryPool teardown
-    // (#136), so reject it here at the binder layer with a clean message
-    // instead of letting it slip through (#17).
+    // Reject bare `__pattern_comprehension`; the only supported placement
+    // is inside a `__list_comprehension` body that the IC14 rewrite
+    // collapses into `path_weight`. Rejecting here keeps the SIGSEGV-on-
+    // throw inside an ORCA frame (#136) from surfacing. (#17)
     if (fname == "__pattern_comprehension") {
         if (g_list_comp_bind_depth == 0) {
             throw BinderException(

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -1386,8 +1386,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                                          });
 
             auto planned = ExprLogicalGetNodeOrEdge(
-                name, single_graphlets, used_col_idx, &mapping,
-                node.IsWholeNodeRequired(), nullptr);
+                name, single_graphlets, used_col_idx, &mapping, nullptr);
             CExpression *plan_expr = planned.first;
             CColRefArray *colrefs = planned.second;
 
@@ -1796,7 +1795,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                         // base+temporal graphlet branches.
                         auto np_planned = ExprLogicalGetNodeOrEdge(
                             lhs_name, np_graphlets, node_used_col_idx,
-                            &node_mapping, lhs_node->IsWholeNodeRequired());
+                            &node_mapping);
                         CExpression *np_expr = np_planned.first;
                         CColRefArray *np_colrefs = np_planned.second;
 
@@ -1805,7 +1804,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                                            np_colrefs, np_schema);
                         auto ep_planned = ExprLogicalGetNodeOrEdge(
                             edge_name, ep_graphlets, edge_used_col_idx,
-                            &edge_mapping, false);
+                            &edge_mapping);
                         CExpression *ep_expr = ep_planned.first;
                         CColRefArray *ep_colrefs = ep_planned.second;
                         turbolynx::LogicalSchema ep_schema;
@@ -2664,11 +2663,9 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanProjection(
                 static_cast<const BoundVariableExpression &>(expr);
             const string &var_name = var_expr.GetVarName();
 
-            // For renames like `WITH p AS q`, the BoundVariableExpression
-            // is built with var_name = "p" (the bound node) and alias = "q".
-            // Surface the node under both names in the output schema so the
-            // next query part can reference the alias and chained renames
-            // (`WITH p AS q WITH q AS r`) keep resolving (#19).
+            // `WITH p AS q`: var_name="p", alias="q". Expose the colrefs
+            // under both names so the alias and chained renames stay
+            // resolvable in later parts (#19).
             const bool rename = var_expr.HasAlias() &&
                                 var_expr.GetAlias() != var_name;
             // Check binding type first — scalar aliases don't have property expansion
@@ -3356,7 +3353,6 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanNodeScan(const BoundNodeExpres
 
     auto planned = ExprLogicalGetNodeOrEdge(name, graphlet_oids,
                                             used_col_idx, &mapping,
-                                            node.IsWholeNodeRequired(),
                                             use_dsi ? &table_oids_in_groups : nullptr);
     CExpression *plan_expr = planned.first;
     CColRefArray *colrefs  = planned.second;
@@ -3432,7 +3428,6 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanEdgeScan(const BoundRelExpress
 
     auto planned = ExprLogicalGetNodeOrEdge(name, graphlet_oids,
                                             used_col_idx, &mapping,
-                                            false,
                                             use_dsi ? &table_oids_in_groups : nullptr);
     CExpression *plan_expr = planned.first;
     CColRefArray *colrefs  = planned.second;
@@ -3478,8 +3473,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanEdgeScanSinglePartition(
                                  });
 
     auto planned = ExprLogicalGetNodeOrEdge(name, single_graphlets,
-                                            used_col_idx, &mapping,
-                                            false);
+                                            used_col_idx, &mapping);
     CExpression *plan_expr = planned.first;
     CColRefArray *colrefs  = planned.second;
     D_ASSERT((idx_t)used_col_idx.size() == colrefs->Size());
@@ -3837,7 +3831,6 @@ void Cypher2OrcaConverter::GenerateEdgeSchema(
 // ============================================================
 CExpression *Cypher2OrcaConverter::ExprLogicalGet(uint64_t obj_id,
                                                     const string &name,
-                                                    bool whole_node_required,
                                                     bool is_instance,
                                                     std::vector<uint64_t> *table_oids_in_group)
 {
@@ -3856,21 +3849,14 @@ CExpression *Cypher2OrcaConverter::ExprLogicalGet(uint64_t obj_id,
         mp_, GPOS_NEW(mp_) CName(mp_, CName(&str_alias)), ptabdesc);
     CExpression *scan_expr = GPOS_NEW(mp_) CExpression(mp_, pop);
 
+    // Stamp every CColRef with the same NodeId so same-label self-joins stay distinguishable (#68).
     CColRefArray *arr = pop->PdrgpcrOutput();
-    // Use the first output colref's id as the binding identifier so that every
-    // CColRef produced by this Get carries the same NodeId. Internal cols
-    // (_id/_sid/_tid) need this too — self-joins on the same label otherwise
-    // can't be distinguished by lineage-walker fallbacks (#68).
-    ULONG node_id = (ULONG)-1;
-    if (arr->Size() > 0) {
-        node_id = (*arr)[0]->Id();
-    }
+    ULONG node_id = arr->Size() > 0 ? (*arr)[0]->Id() : (ULONG)-1;
     for (ULONG ul = 0; ul < arr->Size(); ul++) {
         CColRef *ref = (*arr)[ul];
         ref->MarkAsUnknown();
         ref->SetNodeId(node_id);
     }
-    (void)whole_node_required;
     return scan_expr;
 }
 
@@ -3937,7 +3923,6 @@ pair<CExpression *, CColRefArray *> Cypher2OrcaConverter::ExprLogicalGetNodeOrEd
     vector<uint64_t> &graphlet_oids,
     const vector<int> &used_col_idx,
     map<uint64_t, map<uint64_t, uint64_t>> *mapping,
-    bool whole_node_required,
     std::vector<std::vector<uint64_t>> *table_oids_in_groups)
 {
     // Collect union schema types from the first valid graphlet per column
@@ -4009,7 +3994,7 @@ pair<CExpression *, CColRefArray *> Cypher2OrcaConverter::ExprLogicalGetNodeOrEd
         uint64_t oid = graphlet_oids[idx];
         bool is_instance = (table_oids_in_groups != nullptr);
         std::vector<uint64_t> *grp = is_instance ? &(*table_oids_in_groups)[idx] : nullptr;
-        CExpression *expr = ExprLogicalGet(oid, name, whole_node_required, is_instance, grp);
+        CExpression *expr = ExprLogicalGet(oid, name, is_instance, grp);
 
         // Build projection conforming to union schema
         auto &m = (*mapping)[oid];

--- a/src/include/binder/bind_context.hpp
+++ b/src/include/binder/bind_context.hpp
@@ -111,19 +111,12 @@ public:
 
     bool HasVar(const string& name) const { return HasNode(name) || HasRel(name) || HasPath(name); }
 
-    // Drop every local entry whose name is not in `keep`. Used after a WITH
-    // clause so the next query part only sees projected aliases for
-    // expression-scope lookups — #19.
-    //
-    // Cypher 5 entity-introduction semantics (verified against Neo4j 5):
-    // when a subsequent MATCH/OPTIONAL MATCH introduces a node/rel with
-    // the same name as one visible before the WITH, the previous binding
-    // is reused (no fresh, anchor-less scan). Model that by moving the
-    // dropped node/rel/path bindings into a `shadowed_` map: invisible to
-    // `HasNode`/`HasRel`/`HasPath` (so RETURN/WHERE reject the reference,
-    // matching Neo4j's "Variable ... not defined") but recoverable via
-    // `RecallShadowedNode`/`Rel`/`Path` which the pattern binder calls
-    // when the same name reappears in a MATCH.
+    // Narrow scope to `keep` after a WITH. Names not in `keep` move to
+    // `shadowed_*` — invisible to HasNode/HasRel/HasPath (so RETURN/WHERE
+    // reject them, matching Neo4j) but recoverable when a later MATCH
+    // reintroduces the same name; the pattern binder calls
+    // RecallShadowed*. Matches Cypher 5 entity-introduction semantics
+    // (#19).
     void ResetToProjectedScope(const unordered_set<string>& keep) {
         for (auto it = node_bindings_.begin(); it != node_bindings_.end();) {
             if (keep.count(it->first)) {

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -243,7 +243,6 @@ private:
 
     // ---- ORCA expression builders (identical logic to Planner) ----
     CExpression *ExprLogicalGet(uint64_t obj_id, const string &name,
-                                 bool whole_node_required = false,
                                  bool is_instance = false,
                                  std::vector<uint64_t> *table_oids_in_group = nullptr);
     CExpression *ExprLogicalJoin(CExpression *lhs, CExpression *rhs,
@@ -262,7 +261,6 @@ private:
         vector<uint64_t> &graphlet_oids,
         const vector<int> &used_col_idx,
         map<uint64_t, map<uint64_t, uint64_t>> *mapping,
-        bool whole_node_required,
         std::vector<std::vector<uint64_t>> *table_oids_in_groups = nullptr);
 
     // Schema-conforming projection (for multi-graphlet UnionAll).

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -1592,13 +1592,10 @@ void turbolynx_checkpoint_ctx(duckdb::ClientContext &context) {
             }
             if (live_rows.empty()) continue;
 
-            // Find the partition catalog entry. A missing entry means the
-            // buffer's partition is no longer in the catalog (drop without
-            // matching delta wipe, catalog corruption, or a concurrent
-            // mutation race). Continuing here would silently drop the
-            // buffer rows once the checkpoint reaches ClearInsertData /
-            // wal->Truncate later; instead, abort the checkpoint so the
-            // WAL and DeltaStore stay replayable (#6).
+            // Abort instead of skipping: a continue here would silently
+            // drop the buffer rows once the checkpoint reaches
+            // ClearInsertData/Truncate, losing acked mutations on catalog
+            // inconsistency (#6).
             duckdb::PartitionCatalogEntry *part_cat =
                 FindPartitionCatalogByLogicalId(context, partition_id);
             if (!part_cat) {

--- a/test/query/test_oss_regression.cpp
+++ b/test/query/test_oss_regression.cpp
@@ -138,19 +138,10 @@ TEST_CASE("OSS #63 issue reproduction with filtered traversal",
 // Vertex-count integrity is already verified by the query_test harness
 // in probe_and_verify().
 
-// ============================================================
-// Issue #68 regression: self-join of same-label internal `_id`
-//
-// Two bindings of the same label (e.g. `vuln:Version` and
-// `downstream:Version`) share table MDId and column name `_id`. Before
-// the NodeId-aware fix, planner_physical's lineage-walker fallback
-// (`find_by_table_name(hidden_internal)`) matched the two distinct
-// `_id` columns as if they were the same, causing the downstream
-// Version's id slot to be overwritten with the vuln Version's id at
-// HashJoin output time. The query then incorrectly traversed
-// HAS_VERSION starting from `vuln._id` and returned the vulnerable
-// package itself.
-// ============================================================
+// Two bindings of the same label (vuln:Version, downstream:Version) share
+// table MDId + column name `_id`; before the NodeId-aware fix the lineage
+// walker collapsed them, so HAS_VERSION traversed from vuln._id instead of
+// downstream._id and returned the vulnerable package itself (#68).
 
 TEST_CASE("OSS #68 blast-radius default", "[oss][regression68]") {
     SKIP_IF_NO_OSS_DB();


### PR DESCRIPTION
closes #188

Five small follow-ups from reviewing the recently merged #182 / #183 / #185 / #187 fix PRs.

## What

- **`ExprLogicalGet` parameter cleanup** — after #68, every CColRef out of `ExprLogicalGet` gets a NodeId unconditionally, so `whole_node_required` has no use anywhere in the call chain. Drop the parameter from `ExprLogicalGet` and `ExprLogicalGetNodeOrEdge` plus the five call sites, removing the `(void)whole_node_required;` cast that was only there to silence an unused-parameter warning.
- **Comment trim**: collapse the long "why this fix exists" blocks in `test_oss_regression.cpp` (#68 banner), `turbolynx-c.cpp` (checkpoint guard for #6), `binder.cpp` (two copies of the pattern-comp rejection rationale for #17), `cypher2orca_converter.cpp` (PlanProjection rename branch for #19), and `bind_context.hpp` (`ResetToProjectedScope` for #19). Each comment now states the invariant in 2–4 self-contained lines and references the issue rather than re-narrating the PR body.

No behavior change.

## Test plan

- [x] ldbc 587/587
- [x] tpch~broken-mini~stress 55/55
- [x] types 23/23
- [x] unittest 211/211
- [x] oss-supply-chain pytest 22/22
- [x] [oss][regression68] 3/3