### PR TITLE
fix(#24): per-vertex Neo4j-compatible composite key encoding

### DIFF
--- a/src/include/loader/composite_key_map.hpp
+++ b/src/include/loader/composite_key_map.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "common/exception.hpp"
+#include "common/typedef.hpp"
+#include <cstdint>
+#include <limits>
+#include <utility>
+
+namespace duckdb {
+
+#ifndef LIDPAIR
+#define LIDPAIR
+typedef std::pair<idx_t, idx_t> LidPair;
+struct LidPairHash {
+    size_t operator()(const LidPair& p) const noexcept {
+        uint64_t h = static_cast<uint64_t>(p.first) * 0x9e3779b97f4a7c15ULL
+                   ^ static_cast<uint64_t>(p.second);
+        h ^= h >> 30; h *= 0xbf58476d1ce4e5b9ULL;
+        h ^= h >> 27; h *= 0x94d049bb133111ebULL;
+        return static_cast<size_t>(h ^ (h >> 31));
+    }
+};
+#endif
+
+}
+
+namespace turbolynx {
+
+using namespace duckdb;
+
+// Single-column reference for a composite (key1, key2) vertex follows
+// Neo4j's string-concat encoding: parseUInt(str(k1) + str(k2)).
+// Numerically: k1 * 10^digits(k2) + k2 (with digits("0") = 1).
+// Throws InvalidInputException on uint64 overflow so the loader fails
+// fast on un-representable composites instead of silently aliasing rows.
+// (#24)
+inline idx_t EncodeNeo4jCompositeKey(idx_t k1, idx_t k2) {
+    idx_t mult = 1, t = k2;
+    do { mult *= 10; t /= 10; } while (t > 0);
+    constexpr idx_t kMax = std::numeric_limits<idx_t>::max();
+    if (k1 != 0 && mult > kMax / k1) {
+        throw InvalidInputException(
+            "Composite vertex key overflows uint64 when encoded as a "
+            "single column (#24): key1=%llu, key2=%llu",
+            (unsigned long long)k1, (unsigned long long)k2);
+    }
+    idx_t hi = k1 * mult;
+    if (hi > kMax - k2) {
+        throw InvalidInputException(
+            "Composite vertex key overflows uint64 when encoded as a "
+            "single column (#24): key1=%llu, key2=%llu",
+            (unsigned long long)k1, (unsigned long long)k2);
+    }
+    return hi + k2;
+}
+
+}

--- a/src/loader/bulkload_pipeline.cpp
+++ b/src/loader/bulkload_pipeline.cpp
@@ -1,4 +1,5 @@
 #include "loader/bulkload_pipeline.hpp"
+#include "loader/composite_key_map.hpp"
 #include "main/database.hpp"
 #include "main/client_context.hpp"
 #include "main/capi/turbolynx.h"
@@ -941,26 +942,18 @@ static void PopulateLidToPidMap(FlatHashMap<LidPair, idx_t, LidPairHash> *lid_to
     } else if (key_column_idxs.size() == 2) {
         auto key_column_1 = reinterpret_cast<idx_t *>(data.data[key_column_idxs[0]].GetData());
         auto key_column_2 = reinterpret_cast<idx_t *>(data.data[key_column_idxs[1]].GetData());
-
-        // Determine the multiplier for combined key: 10^(digits of max key2).
-        // Edge files reference composite keys as a single combined value
-        // (e.g., ORDERKEY=1, LINENUMBER=3 → 13 with multiplier=10).
-        idx_t max_key2 = 0;
+        // Register both forms per vertex: the true (k1, k2) tuple for
+        // multi-column edge references, and the Neo4j-compatible
+        // single-column encoding parseUInt(str(k1)+str(k2)) for legacy
+        // single-column references. Encoding is per-vertex so it's
+        // stable across chunks (#24).
         for (idx_t seqno = 0; seqno < data.size(); seqno++) {
-            if (key_column_2[seqno] > max_key2) max_key2 = key_column_2[seqno];
-        }
-        idx_t multiplier = 1;
-        while (multiplier <= max_key2) multiplier *= 10;
-
-        for (idx_t seqno = 0; seqno < data.size(); seqno++) {
-            lid_key.first = key_column_1[seqno];
-            lid_key.second = key_column_2[seqno];
-            lid_to_pid_map_instance->emplace(lid_key, pid_base + seqno);
-
-            // Also register combined single-key form for edge lookup compatibility.
-            // Edge CSVs with single :START_ID use combined value = key1 * multiplier + key2.
-            LidPair combined_key{key_column_1[seqno] * multiplier + key_column_2[seqno], 0};
-            lid_to_pid_map_instance->emplace(combined_key, pid_base + seqno);
+            idx_t k1 = key_column_1[seqno];
+            idx_t k2 = key_column_2[seqno];
+            lid_to_pid_map_instance->emplace(LidPair{k1, k2}, pid_base + seqno);
+            lid_to_pid_map_instance->emplace(
+                LidPair{turbolynx::EncodeNeo4jCompositeKey(k1, k2), 0},
+                pid_base + seqno);
         }
     } else {
         throw InvalidInputException("Do not support # of compound keys >= 3 currently");

--- a/test/common/test_composite_key_map.cpp
+++ b/test/common/test_composite_key_map.cpp
@@ -1,0 +1,68 @@
+// =============================================================================
+// [common] EncodeNeo4jCompositeKey — composite-vertex-key encoding (#24)
+// =============================================================================
+// Single-column references to a composite (key1, key2) vertex follow Neo4j's
+// string-concat encoding: parseUInt(str(key1) + str(key2)). Pre-fix the
+// loader computed a chunk-local 10^digits(max(key2)) multiplier, so the same
+// (key1, key2) could encode differently across chunks. The fixed encoder is
+// per-vertex (mult = 10^digits(key2_of_this_vertex)), matching Neo4j 1:1, and
+// throws InvalidInputException on uint64 overflow.
+
+#include "catch.hpp"
+#include "common/exception.hpp"
+#include "loader/composite_key_map.hpp"
+#include <limits>
+
+using namespace duckdb;
+using namespace turbolynx;
+
+TEST_CASE("EncodeNeo4jCompositeKey matches Neo4j string-concat",
+          "[common][composite-key][issue24]") {
+    CHECK(EncodeNeo4jCompositeKey(1, 3)    == 13);     // "1"  + "3"   = "13"
+    CHECK(EncodeNeo4jCompositeKey(5, 70)   == 570);    // "5"  + "70"  = "570"
+    CHECK(EncodeNeo4jCompositeKey(5, 7)    == 57);     // "5"  + "7"   = "57"
+    CHECK(EncodeNeo4jCompositeKey(13, 570) == 13570);  // "13" + "570" = "13570"
+}
+
+TEST_CASE("EncodeNeo4jCompositeKey treats key2==0 as digit width 1",
+          "[common][composite-key][issue24]") {
+    // String "0" has width 1, so (5, 0) → "5"+"0" = "50".
+    CHECK(EncodeNeo4jCompositeKey(5, 0)  == 50);
+    CHECK(EncodeNeo4jCompositeKey(13, 0) == 130);
+    CHECK(EncodeNeo4jCompositeKey(0, 0)  == 0);
+}
+
+TEST_CASE("EncodeNeo4jCompositeKey is per-vertex, not file-wide",
+          "[common][composite-key][issue24]") {
+    // The pre-fix file-wide multiplier picked the digit width of max(key2)
+    // across the entire file and applied it uniformly, which zero-pads
+    // small key2 values. Neo4j does not zero-pad.
+    //   File-wide (broken):   (1, 3)  with max(key2)=70 → 1*100+3   = 103
+    //   Per-vertex (correct): (1, 3)  → 1*10+3                       = 13
+    CHECK(EncodeNeo4jCompositeKey(1, 3) == 13);  // not 103
+    // The encoding of (5, 70) is the same under either rule, confirming
+    // they only diverge for entries whose key2 is narrower than max(key2).
+    CHECK(EncodeNeo4jCompositeKey(5, 70) == 570);
+}
+
+TEST_CASE("EncodeNeo4jCompositeKey throws on uint64 overflow",
+          "[common][composite-key][issue24]") {
+    // key1 * 10^digits(key2) overflows: 10^19 fits in uint64 but
+    // 10 * 10^19 does not.
+    constexpr idx_t kMax = std::numeric_limits<idx_t>::max();
+    REQUIRE_THROWS_AS(EncodeNeo4jCompositeKey(kMax, 5), InvalidInputException);
+    REQUIRE_THROWS_AS(EncodeNeo4jCompositeKey(2'000'000'000ULL,
+                                              10'000'000'000ULL),
+                      InvalidInputException);
+    // (k1 * mult) + k2 step also has a guard: max representable key1
+    // alone is fine, but appending any non-zero key2 overflows.
+    REQUIRE_THROWS_AS(EncodeNeo4jCompositeKey(kMax / 10, 9),
+                      InvalidInputException);
+}
+
+TEST_CASE("EncodeNeo4jCompositeKey accepts non-overflowing large keys",
+          "[common][composite-key][issue24]") {
+    // 10^18 * 10 + 9 = 10^19 + 9, fits in uint64 (max ≈ 1.8 * 10^19).
+    CHECK(EncodeNeo4jCompositeKey(1'000'000'000'000'000'000ULL, 9)
+          == 10'000'000'000'000'000'009ULL);
+}


### PR DESCRIPTION
closes #24

## Problem

When a vertex has a composite `(key1, key2)` ID, edge CSVs can reference that vertex either via a multi-column header (`:START_ID, :START_ID`) or via a single concatenated column. The loader implemented the single-column form with a **chunk-local** multiplier — `10^digits(max(key2))` recomputed for every `DataChunk` — so the same `(key1, key2)` could encode to different single values across chunks of the same vertex file. Edge rows that referenced the composite vertex via a single column then failed to resolve for some chunks.

## Fix

Match Neo4j's import semantics. The single-column reference for `(key1, key2)` is `parseUInt(str(key1) + str(key2))`. Numerically:

```
combined = key1 * 10^digits(key2) + key2,  digits("0") = 1
```

This is **per vertex** — independent of chunk boundary and of other rows — so it is stable for the life of the vertex file. The encoder lives in `loader/composite_key_map.hpp` and throws `InvalidInputException` on `uint64` overflow so out-of-range composites fail loudly instead of silently aliasing rows.

This matches Neo4j's defined collision behavior (e.g. `(1, 30)` and `(13, 0)` both encode to `"130"` — Neo4j accepts this; users avoid it via key-space design). Switching to a true `string` id-type to remove that ambiguity entirely is a separate, larger change tracked for later (touches storage / partition catalog / delta store).

## Test plan

- [x] New unit tests in `test/common/test_composite_key_map.cpp` cover:
  - the Neo4j encoding against hand-computed oracles
  - `key2 == 0` → digit-width = 1
  - per-vertex vs file-wide divergence (the pre-fix bug)
  - `uint64` overflow guard (throws)
  - large non-overflowing case (10^18 * 10 + 9)
- [x] `unittest` 216/216
- [x] LDBC mini 587/587
- [x] TPCH mini 55/55 (composite `ORDERKEY/LINENUMBER` vertex referenced from LINEITEM-derived edges — direct regression coverage)
- [x] OSS 6/6, types 23/23