### PR TITLE
fix(#35): emit zero-length VLE path unconditionally

### DIFF
--- a/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
+++ b/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
@@ -351,17 +351,13 @@ uint64_t PhysicalVarlenAdjIdxJoin::VarlengthExpand_internal(ExecutionContext& co
 		}
 		state.dfs_it->initialize(*context.client, src_vid, state.adj_col_idxs, adj_col_is_fwds, state.src_partition_ids);
 		if (state.cur_lv >= state.start_lv) {
-			bool src_is_terminal = state.src_partition_ids.empty() ||
-			                       state.src_partition_ids.count((uint16_t)(src_vid >> 48)) == 0;
-			bool dst_ok = dst_partition_ids.empty() ||
-			              dst_partition_ids.count((uint16_t)(src_vid >> 48)) > 0;
-				if (src_is_terminal && dst_ok) {
-					addNewPathToOutput(tgt_adj_column, eid_adj_column,
-					                   state.output_idx + num_found_paths,
-					                   state.current_path, src_vid, 0);
-					if (++num_found_paths == remaining_output) return num_found_paths;
-				}
-			}
+			// Zero-length VLE: emit source unconditionally; dst label
+			// check happens at the plan-level filter, not here (#35).
+			addNewPathToOutput(tgt_adj_column, eid_adj_column,
+			                   state.output_idx + num_found_paths,
+			                   state.current_path, src_vid, 0);
+			if (++num_found_paths == remaining_output) return num_found_paths;
+		}
 	}
 
 	// if (state.start_lv == 0) {

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -1140,3 +1140,77 @@ TEST_CASE("bare pattern comprehension throws a clean binder error",
     REQUIRE(caught);
     CHECK(err.find("Pattern comprehension") != std::string::npos);
 }
+
+// Cypher zero-length variable-length paths: `*0..N` must emit the
+// source vertex as the length-0 binding whenever the destination
+// pattern accepts it. Pre-fix the loader gated zero-hop emission on a
+// terminal-partition heuristic (`src_is_terminal`), so non-terminal
+// source vertices silently dropped the zero-length match (#35).
+
+TEST_CASE("KNOWS *0..0 emits the source vertex (zero-hop self)",
+          "[ldbc][filter][varlen][issue35]") {
+    SKIP_IF_NO_DB();
+    // `*0..0` is a single-node match: b must equal a.
+    auto q = "MATCH (a:Person {id: " + sample_person_id_str() +
+             "})-[:KNOWS*0..0]-(b:Person) RETURN b.id ORDER BY b.id";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
+}
+
+#ifdef TURBOLYNX_LDBC_FIXTURE_MINI
+TEST_CASE("KNOWS *0..1 includes self plus 1-hop friends",
+          "[ldbc][filter][varlen][issue35]") {
+    SKIP_IF_NO_DB();
+    // Person 14's three KNOWS neighbours in the mini fixture are
+    // 10995116277782, 24189255811081, 26388279066668. The *0..1
+    // closure must additionally contain person 14 itself.
+    auto q = "MATCH (a:Person {id: " + sample_person_id_str() +
+             "})-[:KNOWS*0..1]-(b:Person) "
+             "RETURN DISTINCT b.id ORDER BY b.id";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() == 4);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
+    CHECK(r[1].int64_at(0) == 10995116277782LL);
+    CHECK(r[2].int64_at(0) == 24189255811081LL);
+    CHECK(r[3].int64_at(0) == 26388279066668LL);
+}
+#endif
+
+TEST_CASE("KNOWS *0..1 size exceeds *1..1 by exactly the source",
+          "[ldbc][filter][varlen][issue35]") {
+    SKIP_IF_NO_DB();
+    // |distinct b : (a)-[*0..1]-(b)| - |distinct b : (a)-[*1..1]-(b)|
+    // equals 1 (the source itself, contributed only by the
+    // zero-length path).
+    auto q0 = "MATCH (a:Person {id: " + sample_person_id_str() +
+              "})-[:KNOWS*0..1]-(b:Person) RETURN count(DISTINCT b)";
+    auto q1 = "MATCH (a:Person {id: " + sample_person_id_str() +
+              "})-[:KNOWS*1..1]-(b:Person) RETURN count(DISTINCT b)";
+    CHECK(qr->count(q0.c_str()) - qr->count(q1.c_str()) == 1);
+}
+
+TEST_CASE("Same-variable zero-hop binds the source to itself",
+          "[ldbc][filter][varlen][issue35]") {
+    SKIP_IF_NO_DB();
+    // Both endpoints reuse `p`. A length-0 path forces p == p, so the
+    // single result is the source person itself.
+    auto q = "MATCH (p:Person {id: " + sample_person_id_str() +
+             "})-[:KNOWS*0..0]-(p) RETURN p.id";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
+}
+
+TEST_CASE("Heterogeneous edge zero-hop respects vertex label predicate",
+          "[ldbc][filter][varlen][issue35]") {
+    SKIP_IF_NO_DB();
+    // HAS_TYPE has Tag → TagClass schema. Cypher zero-length only
+    // checks the vertex pattern, not the edge schema's dst, so
+    // (t:Tag)-[*0..0]->(tc:Tag) binds tc to every Tag (16080 rows in
+    // the mini fixture) while (tc:TagClass) rejects all of them.
+    CHECK(qr->count("MATCH (t:Tag)-[:HAS_TYPE*0..0]->(tc:Tag) "
+                    "RETURN count(*)") == ldbc::TAG_COUNT);
+    CHECK(qr->count("MATCH (t:Tag)-[:HAS_TYPE*0..0]->(tc:TagClass) "
+                    "RETURN count(*)") == 0);
+}


### PR DESCRIPTION
closes #35

## Problem

`MATCH (a:Person {id:14})-[:KNOWS*0..N]-(b:Person)` silently dropped the source vertex from its results for every `N >= 0`. The Cypher zero-length path (`*0..0`) is defined as a single-node match where both endpoint patterns are checked against the same vertex, but our `PhysicalVarlenAdjIdxJoin` operator gated zero-hop emission on `src_is_terminal && dst_ok`, and neither boolean actually reflects the destination *vertex pattern* predicate.

## Root cause

| Boolean | What it means |
|---|---|
| `src_is_terminal` | "this vertex's partition has no adj-list for this edge" — i.e. recursion dead-end. Unrelated to label predicate. |
| `dst_ok` (via `dst_partition_ids`) | "this vertex's partition is in `dst_pids − src_pids` of the edge index metadata" — terminal partitions of the *edge schema*. Unrelated to the dst *vertex pattern*. |

Git history (`git log -L 350,365`):

- **2026-03-11** (`924136a`): `src_is_terminal` introduced as a hack for IS6 (`Comment-[:REPLY_OF*0..]->Post`) before destination-label filtering existed.
- **2026-03-15** (`45e02a5`): same author added `dst_partition_ids` / `dst_ok` as the proper destination filter — but the `src_is_terminal` hack was left in alongside it, ANDing the two.

## Why both have to go for zero-hop

- For KNOWS-style same-label edges, `src_is_terminal=false` for any source that has KNOWS neighbours — the most common case — so zero-hop never fires.
- For heterogeneous edges, even `dst_ok` is wrong: `(t:Tag)-[:HAS_TYPE*0..0]->(tc:Tag)` returns 0 rows because HAS_TYPE's schema dst is TagClass, but the dst vertex *pattern* is `:Tag`. The two are not the same predicate.

## Fix

Drop both guards from the zero-hop emit. The plan-level vertex-label filter that already correctly handles 1+-hop results applies equally to zero-hop output.

The 1+-hop `dst_ok` guard later in the same function (line ~440) is **unchanged** — it keeps performing the terminal-partition filter that IS6-style queries depend on for rejecting intermediate Comment hops.

## Test plan

5 new tests in `test_ldbc_filter.cpp` tagged `[issue35]`:
- [x] `*0..0` self-bind returns the source vertex (1 row, oracle).
- [x] `*0..1` returns self plus 1-hop neighbours, hardcoded id oracle.
- [x] `|*0..1| - |*1..1| == 1` invariant.
- [x] Same-variable zero-hop `(p)-[*0..0]-(p)` returns 1 row.
- [x] Heterogeneous edge zero-hop respects vertex-label predicate: `Tag-[:HAS_TYPE*0..0]->(:Tag)` = TAG_COUNT, `->(:TagClass)` = 0.

Regression:
- [x] LDBC 592/592 (587 prior + 5 new)
- [x] TPCH 55/55 (composite key path)
- [x] OSS 6/6
- [x] types 23/23
- [x] unittest 216/216
- [x] oss-supply-chain pytest 22/22