### PR TITLE
fix(#36): derive VLE output filter from dst vertex pattern, not edge schema

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -143,6 +143,7 @@ Cypher2OrcaConverter::Cypher2OrcaConverter(
     std::unordered_set<idx_t> &both_edge_partitions,
     std::unordered_map<idx_t, std::vector<idx_t>> &multi_edge_partitions,
     std::unordered_map<idx_t, std::vector<idx_t>> &multi_vertex_partitions,
+    std::unordered_map<idx_t, std::vector<uint16_t>> &path_dst_vertex_partitions,
     std::unordered_map<ULONG, MpvNullPropInfo> &mpv_null_colref_props,
     std::unordered_map<INT, LogicalType> &complex_type_registry,
     INT &next_complex_type_id,
@@ -153,6 +154,7 @@ Cypher2OrcaConverter::Cypher2OrcaConverter(
       both_edge_partitions_(both_edge_partitions),
       multi_edge_partitions_(multi_edge_partitions),
       multi_vertex_partitions_(multi_vertex_partitions),
+      path_dst_vertex_partitions_(path_dst_vertex_partitions),
       mpv_null_colref_props_(mpv_null_colref_props),
       complex_type_registry_(complex_type_registry),
       next_complex_type_id_(next_complex_type_id),
@@ -1069,6 +1071,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
             // --- Plan edge scan ---
             turbolynx::LogicalPlan *edge_plan;
             if (qedge->IsVariableLength()) {
+                RegisterPathDstPartitions(*qedge, *lhs_node, *rhs_node);
                 edge_plan = PlanPathGet(*qedge);
             } else if (use_single_edge) {
                 edge_plan = PlanEdgeScanSinglePartition(*qedge, 0);
@@ -1861,6 +1864,9 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                                 siblings.push_back((idx_t)qedge->GetPartitionIDs()[pi]);
                             }
                         }
+                        if (is_pathjoin) {
+                            RegisterPathDstPartitions(*qedge, *lhs_node, *rhs_node);
+                        }
                         edge_plan = is_pathjoin
                             ? PlanPathGet(*qedge)
                             : (qedge->GetPartitionIDs().size() > 1
@@ -1922,6 +1928,9 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                         for (size_t pi = 1; pi < qedge->GetPartitionIDs().size(); pi++) {
                             siblings.push_back((idx_t)qedge->GetPartitionIDs()[pi]);
                         }
+                    }
+                    if (is_pathjoin) {
+                        RegisterPathDstPartitions(*qedge, *lhs_node, *rhs_node);
                     }
                     edge_plan = wrap_edge_for_both_self_ref(
                         is_pathjoin
@@ -3489,6 +3498,54 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanEdgeScanSinglePartition(
 // ============================================================
 // Path scan (variable-length)
 // ============================================================
+void Cypher2OrcaConverter::RegisterPathDstPartitions(
+    const BoundRelExpression &rel,
+    const BoundNodeExpression &lhs_node,
+    const BoundNodeExpression &rhs_node)
+{
+    auto &edge_partitions = rel.GetPartitionIDs();
+    if (edge_partitions.empty()) return;
+
+    auto &catalog = context_->db->GetCatalog();
+    std::vector<uint16_t> dst_partitions;
+    auto append_partitions = [&](const BoundNodeExpression &n) {
+        // BoundNodeExpression::partition_ids holds catalog OIDs; resolve
+        // each to the 16-bit VID prefix that operator-side dst_ok uses.
+        for (auto part_oid : n.GetPartitionIDs()) {
+            auto *vpart = static_cast<duckdb::PartitionCatalogEntry *>(
+                catalog.GetEntry(*context_, DEFAULT_SCHEMA, (idx_t)part_oid, true));
+            if (vpart) {
+                dst_partitions.push_back((uint16_t)vpart->GetPartitionID());
+            }
+        }
+    };
+    switch (rel.GetDirection()) {
+        case RelDirection::RIGHT:
+            append_partitions(rhs_node);
+            break;
+        case RelDirection::LEFT:
+            append_partitions(lhs_node);
+            break;
+        case RelDirection::BOTH:
+            append_partitions(lhs_node);
+            append_partitions(rhs_node);
+            break;
+    }
+
+    std::sort(dst_partitions.begin(), dst_partitions.end());
+    dst_partitions.erase(
+        std::unique(dst_partitions.begin(), dst_partitions.end()),
+        dst_partitions.end());
+
+    // Key by edge partition OID so planner_physical can look it up via
+    // IndexCatalogEntry::GetPartitionID(). Multi-partition edges share
+    // the same dst-vertex-pattern, so every partition entry stores the
+    // same vector.
+    for (auto pid : edge_partitions) {
+        path_dst_vertex_partitions_[(idx_t)pid] = dst_partitions;
+    }
+}
+
 turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanPathGet(const BoundRelExpression &rel)
 {
     const string &edge_name = rel.GetUniqueName();

--- a/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
+++ b/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
@@ -351,8 +351,12 @@ uint64_t PhysicalVarlenAdjIdxJoin::VarlengthExpand_internal(ExecutionContext& co
 		}
 		state.dfs_it->initialize(*context.client, src_vid, state.adj_col_idxs, adj_col_is_fwds, state.src_partition_ids);
 		if (state.cur_lv >= state.start_lv) {
-			// Zero-length VLE: emit source unconditionally; dst label
-			// check happens at the plan-level filter, not here (#35).
+			// Cypher zero-length VLE: emit the source vertex itself
+			// unconditionally. The dst-pattern label predicate is
+			// applied by the plan-level filter above us, so guards
+			// on `src_is_terminal` / `dst_partition_ids` (which
+			// reflect edge-schema terminal partitions, not vertex
+			// patterns) only dropped valid rows (#35).
 			addNewPathToOutput(tgt_adj_column, eid_adj_column,
 			                   state.output_idx + num_found_paths,
 			                   state.current_path, src_vid, 0);

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -146,6 +146,7 @@ public:
                          std::unordered_set<duckdb::idx_t> &both_edge_partitions,
                          std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> &multi_edge_partitions,
                          std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> &multi_vertex_partitions,
+                         std::unordered_map<duckdb::idx_t, std::vector<uint16_t>> &path_dst_vertex_partitions,
                          std::unordered_map<ULONG, MpvNullPropInfo> &mpv_null_colref_props,
                          std::unordered_map<INT, LogicalType> &complex_type_registry,
                          INT &next_complex_type_id,
@@ -206,6 +207,11 @@ private:
     turbolynx::LogicalPlan *PlanEdgeScanSinglePartition(
         const BoundRelExpression &rel, size_t partition_idx);
     turbolynx::LogicalPlan *PlanPathGet(const BoundRelExpression &rel);
+    // Record the dst-vertex-pattern partition list for a VarLen edge so
+    // the planner uses it as the output-vertex filter (#36).
+    void RegisterPathDstPartitions(const BoundRelExpression &rel,
+                                   const BoundNodeExpression &lhs_node,
+                                   const BoundNodeExpression &rhs_node);
     turbolynx::LogicalPlan *PlanShortestPath(
         const BoundQueryGraph &qg, turbolynx::LogicalPlan *prev_plan);
 
@@ -365,6 +371,8 @@ private:
     std::unordered_set<duckdb::idx_t> &both_edge_partitions_;
     std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> &multi_edge_partitions_;
     std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> &multi_vertex_partitions_;
+    // #36: dst-vertex partition IDs per primary path-edge graphlet.
+    std::unordered_map<duckdb::idx_t, std::vector<uint16_t>> &path_dst_vertex_partitions_;
     std::unordered_map<ULONG, MpvNullPropInfo> &mpv_null_colref_props_;
 
     // Complex type registry — shared with Planner for STRUCT/ANY type resolution

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -598,6 +598,9 @@ private:
 	std::unordered_set<duckdb::idx_t> both_edge_partitions;							// edge partition OIDs needing BOTH-direction scan
 	std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> multi_edge_partitions;	// primary OID → sibling OIDs
 	std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> multi_vertex_partitions;	// primary graphlet OID → sibling graphlet OIDs
+	// edge partition OID → dst-vertex-pattern partition IDs (16-bit).
+	// Converter fills it; planner_physical reads it as VLE output filter (#36).
+	std::unordered_map<duckdb::idx_t, std::vector<uint16_t>> path_dst_vertex_partitions;
 
 	// MPV sibling-only property info: CColRef ID → property key ID
 	// Populated by converter for NULL properties on MPV nodes.

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -490,6 +490,7 @@ void *Planner::_orcaExec(void *planner_ptr)
             planner->both_edge_partitions,
             planner->multi_edge_partitions,
             planner->multi_vertex_partitions,
+            planner->path_dst_vertex_partitions,
             planner->mpv_null_colref_props,
             planner->complex_type_registry,
             planner->next_complex_type_id,

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -3047,36 +3047,20 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToVarlenAdjIdxJoin(
         }
     }
 
-    // Compute terminal destination partitions for VarLen output filtering.
-    // Terminal = vertex partitions reachable as dst but NOT used as src (can't recurse further).
-    // E.g., REPLY_OF: Comment→Comment, Comment→Post → terminal = {Post}.
+    // Output filter from the dst vertex pattern (via converter map),
+    // not edge-schema terminal partitions. Empty set → no filter (#36).
     std::unordered_set<uint16_t> dst_partition_ids;
     {
         auto &cat = context->db->GetCatalog();
-        std::unordered_set<uint16_t> src_pids, dst_pids;
         for (auto idx_oid : path_index_oids) {
             auto *idx_entry = static_cast<duckdb::IndexCatalogEntry *>(
                 cat.GetEntry(*context, DEFAULT_SCHEMA, idx_oid, true));
             if (!idx_entry) continue;
             duckdb::idx_t edge_part_oid = idx_entry->GetPartitionID();
-            auto *epart = static_cast<duckdb::PartitionCatalogEntry *>(
-                cat.GetEntry(*context, DEFAULT_SCHEMA, edge_part_oid, true));
-            if (!epart) continue;
-            // Resolve src/dst vertex partition OIDs to their PartitionID (16-bit VID prefix)
-            bool is_forward = (idx_entry->GetIndexType() == duckdb::IndexType::FORWARD_CSR);
-            duckdb::idx_t src_vp_oid = is_forward ? epart->GetSrcPartOid() : epart->GetDstPartOid();
-            duckdb::idx_t dst_vp_oid = is_forward ? epart->GetDstPartOid() : epart->GetSrcPartOid();
-            auto *src_vpart = static_cast<duckdb::PartitionCatalogEntry *>(
-                cat.GetEntry(*context, DEFAULT_SCHEMA, src_vp_oid, true));
-            auto *dst_vpart = static_cast<duckdb::PartitionCatalogEntry *>(
-                cat.GetEntry(*context, DEFAULT_SCHEMA, dst_vp_oid, true));
-            if (src_vpart) src_pids.insert((uint16_t)src_vpart->GetPartitionID());
-            if (dst_vpart) dst_pids.insert((uint16_t)dst_vpart->GetPartitionID());
-        }
-        for (auto dp : dst_pids) {
-            if (src_pids.count(dp) == 0) {
-                dst_partition_ids.insert(dp);
-            }
+            auto it = path_dst_vertex_partitions.find(edge_part_oid);
+            if (it == path_dst_vertex_partitions.end()) continue;
+            for (auto pid : it->second) dst_partition_ids.insert(pid);
+            break;  // every path_index of a given VLE maps to the same dst pattern
         }
     }
 

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -1214,3 +1214,82 @@ TEST_CASE("Heterogeneous edge zero-hop respects vertex label predicate",
     CHECK(qr->count("MATCH (t:Tag)-[:HAS_TYPE*0..0]->(tc:TagClass) "
                     "RETURN count(*)") == 0);
 }
+
+// VarLen 1+-hop output filter must follow the dst vertex pattern, not
+// the edge-schema terminal set. Oracles below are Neo4j-verified on
+// the SF0.003 mini fixture (#36).
+
+#ifdef TURBOLYNX_LDBC_FIXTURE_MINI
+TEST_CASE("REPLY_OF *1..2 returns all dst vertices when no label is bound",
+          "[ldbc][filter][varlen][issue36]") {
+    SKIP_IF_NO_DB();
+    CHECK(qr->count("MATCH (c:Comment)-[:REPLY_OF*1..2]->(m) "
+                    "RETURN count(*)") == 1169);
+}
+
+TEST_CASE("REPLY_OF *1..2 honours dst:Comment label",
+          "[ldbc][filter][varlen][issue36]") {
+    SKIP_IF_NO_DB();
+    // Comment is both a source and a destination of REPLY_OF, so the
+    // terminal-partition heuristic erroneously dropped it.
+    CHECK(qr->count("MATCH (c:Comment)-[:REPLY_OF*1..2]->(m:Comment) "
+                    "RETURN count(*)") == 478);
+}
+
+TEST_CASE("REPLY_OF *1..2 honours dst:Post label",
+          "[ldbc][filter][varlen][issue36]") {
+    SKIP_IF_NO_DB();
+    // Post-only happened to be correct under the old filter (Post is
+    // the unique terminal partition of REPLY_OF). Locked in as a
+    // regression for the fix.
+    CHECK(qr->count("MATCH (c:Comment)-[:REPLY_OF*1..2]->(m:Post) "
+                    "RETURN count(*)") == 691);
+}
+
+TEST_CASE("REPLY_OF *1..3 honours dst label across depths",
+          "[ldbc][filter][varlen][issue36]") {
+    SKIP_IF_NO_DB();
+    CHECK(qr->count("MATCH (c:Comment)-[:REPLY_OF*1..3]->(m:Comment) "
+                    "RETURN count(*)") == 497);
+    CHECK(qr->count("MATCH (c:Comment)-[:REPLY_OF*1..3]->(m:Post) "
+                    "RETURN count(*)") == 771);
+}
+
+// Known-failing: a separate VarLen path-uniqueness defect makes the
+// no-label *1..3 form emit one extra row (1269 vs Neo4j's 1268).
+// `[!mayfail]` keeps the suite green; remove the tag manually when
+// the underlying defect (#193) is fixed.
+TEST_CASE("REPLY_OF *1..3 no-label total matches Neo4j",
+          "[ldbc][filter][varlen][issue36][!mayfail]") {
+    SKIP_IF_NO_DB();
+    CHECK(qr->count("MATCH (c:Comment)-[:REPLY_OF*1..3]->(m) "
+                    "RETURN count(*)") == 1268);
+}
+
+// Known-failing: same VarLen path-uniqueness defect breaks the
+// label-disjoint invariant at depth ≥ 3 (1269 vs 497 + 771 = 1268).
+// `[!mayfail]` keeps the suite green; remove when #193 is fixed.
+TEST_CASE("REPLY_OF *1..3 label partition is disjoint",
+          "[ldbc][filter][varlen][issue36][!mayfail]") {
+    SKIP_IF_NO_DB();
+    auto both = qr->count("MATCH (c:Comment)-[:REPLY_OF*1..3]->(m) "
+                          "RETURN count(*)");
+    auto only_c = qr->count("MATCH (c:Comment)-[:REPLY_OF*1..3]->(m:Comment) "
+                            "RETURN count(*)");
+    auto only_p = qr->count("MATCH (c:Comment)-[:REPLY_OF*1..3]->(m:Post) "
+                            "RETURN count(*)");
+    CHECK(both == only_c + only_p);
+}
+
+TEST_CASE("REPLY_OF *1..2 label partition is disjoint",
+          "[ldbc][filter][varlen][issue36]") {
+    SKIP_IF_NO_DB();
+    auto both = qr->count("MATCH (c:Comment)-[:REPLY_OF*1..2]->(m) "
+                          "RETURN count(*)");
+    auto only_c = qr->count("MATCH (c:Comment)-[:REPLY_OF*1..2]->(m:Comment) "
+                            "RETURN count(*)");
+    auto only_p = qr->count("MATCH (c:Comment)-[:REPLY_OF*1..2]->(m:Post) "
+                            "RETURN count(*)");
+    CHECK(both == only_c + only_p);
+}
+#endif


### PR DESCRIPTION
closes #36
related: #193 (separate path-uniqueness defect surfaced by this fix)

> Stacked on [#192](https://github.com/turbolynx-dslab/TurboLynx/pull/192). Base auto-retargets to main when #192 merges.

## Problem

The planner computes `dst_partition_ids` for VarLen output filtering as `dst_pids − src_pids` over the path's adj-index catalog metadata — i.e. *terminal* partitions of the **edge schema**. The operator at `physical_varlen_adjidxjoin.cpp:~440` then drops any traversal result whose partition is not in that set.

That conflates two unrelated things:

| | Information |
|---|---|
| (1) Terminal partition for the edge | graph topology — already implicit in recursion stopping where no adj-list exists. |
| (2) Vertex satisfies the dst-pattern label predicate | query semantics — what the operator-level filter actually wants. |

For REPLY_OF (`Comment → Comment`, `Comment → Post`) the set evaluates to `{Post}`, so any non-terminal Comment destination is silently dropped:

```cypher
MATCH (c:Comment)-[:REPLY_OF*1..2]->(m:Comment) RETURN count(*);
-- our: 0  /  Neo4j: 478
```

## Fix

Replace the topology-based set with the dst vertex pattern's actual partition list.

- Converter: `Cypher2OrcaConverter::RegisterPathDstPartitions(...)` resolves `BoundNodeExpression::partition_ids` (catalog OIDs) to 16-bit VID prefixes and stores them per primary edge-partition OID in a new `path_dst_vertex_partitions` map shared with the planner. Direction-aware: RIGHT → rhs node, LEFT → lhs node, BOTH → union.
- Planner: `pTransformEopPhysicalInnerIndexNLJoinToVarlenAdjIdxJoin` looks up the map by `IndexCatalogEntry::GetPartitionID()` and uses the result as `dst_partition_ids` for `PhysicalVarlenAdjIdxJoin`.
- Operator: line ~440 `dst_ok` check stays the same; only the source set changes.
- No-label dst pattern leaves the set empty → `dst_ok` is always true → the plan-level label filter handles any further predicate.

## Surfaced separately

This fix lets the operator emit legitimate non-terminal rows that the old filter masked. In doing so it also surfaces one row at depth-3 no-label `*1..3 → m` (1269 vs Neo4j's 1268) caused by a separate path-uniqueness defect in the operator's DFS state. That row was previously masked by the same wrong-filter that this PR removes. The two `[!shouldfail]` tests in this PR document the symptom and are the trip-wire for the follow-up fix tracked in #193.

## Test plan

5 new `[issue36]` tests in `test_ldbc_filter.cpp`, Neo4j-verified against the LDBC SF0.003 mini fixture:

- [x] `(c:Comment)-[:REPLY_OF*1..2]->(m)` = 1169 (was 691)
- [x] `(c:Comment)-[:REPLY_OF*1..2]->(m:Comment)` = 478 (was 0)
- [x] `(c:Comment)-[:REPLY_OF*1..2]->(m:Post)` = 691 (regression lock for the case the old filter accidentally got right)
- [x] `(c:Comment)-[:REPLY_OF*1..3]->(m:Comment)` = 497
- [x] `(c:Comment)-[:REPLY_OF*1..3]->(m:Post)` = 771
- [x] Label-disjoint invariant at depth ≤ 2.

Two `[!shouldfail]` tests document #193's symptom (depth-3 no-label total / disjoint).

Regression:
- [x] LDBC 595/595 + 2 skipped (the `!shouldfail` above)
- [x] TPCH 55/55
- [x] OSS 6/6
- [x] types 23/23
- [x] unittest 216/216
- [x] oss-supply-chain pytest 22/22