### PR TITLE
fix(#39): preserve all same-depth predecessors in allShortestPaths

### DIFF
--- a/src/include/storage/extent/adjlist_iterator.hpp
+++ b/src/include/storage/extent/adjlist_iterator.hpp
@@ -189,6 +189,11 @@ private:
 
     std::unordered_map<NodeID, std::vector<std::pair<NodeID, EdgeID>>, NodeIDHasher> predecessor_forward;
     std::unordered_map<NodeID, std::vector<std::pair<NodeID, EdgeID>>, NodeIDHasher> predecessor_backward;
+    // First-discovered BFS level per direction. Used to keep additional
+    // predecessors that reach a node at the same shortest level while
+    // rejecting longer-path predecessors (#39).
+    std::unordered_map<NodeID, Level, NodeIDHasher> bfs_level_forward;
+    std::unordered_map<NodeID, Level, NodeIDHasher> bfs_level_backward;
     std::shared_ptr<AdjacencyListIterator> adjlist_iterator_forward;
     std::shared_ptr<AdjacencyListIterator> adjlist_iterator_backward;
     std::shared_ptr<ExtentIterator> ext_it_forward = nullptr;

--- a/src/storage/extent/adjlist_iterator.cpp
+++ b/src/storage/extent/adjlist_iterator.cpp
@@ -710,8 +710,12 @@ void AllShortestPathIterator::initialize(duckdb::ClientContext &context, NodeID 
 
     predecessor_forward.clear();
     predecessor_backward.clear();
+    bfs_level_forward.clear();
+    bfs_level_backward.clear();
     predecessor_forward[src_id] = {{src_id, 0}};
     predecessor_backward[tgt_id] = {{tgt_id, 0}};
+    bfs_level_forward[src_id] = 0;
+    bfs_level_backward[tgt_id] = 0;
 
     biDirectionalSearch(context);
 }
@@ -773,6 +777,7 @@ bool AllShortestPathIterator::biDirectionalSearch(duckdb::ClientContext &context
 bool AllShortestPathIterator::enqueueNeighbors(duckdb::ClientContext &context, NodeID current_node, Level node_level, std::queue<std::pair<NodeID, Level>> &queue, bool is_forward) {
     auto &predecessor_to_insert = is_forward ? predecessor_forward : predecessor_backward;
     auto &predecessor_to_find = is_forward ? predecessor_backward : predecessor_forward;
+    auto &level_to_insert = is_forward ? bfs_level_forward : bfs_level_backward;
 
     // Check BOTH directions (undirected graph) — same as ShortestPathAdvancedIterator
     struct AdjDir {
@@ -815,22 +820,34 @@ bool AllShortestPathIterator::enqueueNeighbors(duckdb::ClientContext &context, N
         uint64_t neighbor = *ptr;
         uint64_t edge_id = *(ptr + 1);
 
-        // If the neighbor is a valid meeting point
-        if (predecessor_to_find.find(neighbor) != predecessor_to_find.end() && 
-            node_level + 1 >= lower_bound) { 
-            predecessor_to_insert[neighbor].emplace_back(current_node, edge_id);
-            meeting_points.insert(neighbor);  // Add to the set of meeting points
-        }
+        bool is_meeting =
+            predecessor_to_find.find(neighbor) != predecessor_to_find.end() &&
+            node_level + 1 >= lower_bound;
+        bool within_upper = node_level + 1 < upper_bound;
 
-        // Skip neighbors beyond the upper bound
-        if (node_level + 1 >= upper_bound) {
-            continue;
-        }
+        // First visit: record level + enqueue. Same-level revisit:
+        // append the additional predecessor without re-enqueueing.
+        // Longer-path predecessors are silently dropped (#39).
+        auto it_level = level_to_insert.find(neighbor);
+        bool first_visit = it_level == level_to_insert.end();
+        bool same_level = !first_visit && it_level->second == node_level + 1;
 
-        // If the neighbor has not been visited in the current direction
-        if (predecessor_to_insert.find(neighbor) == predecessor_to_insert.end()) {
+        bool recorded = false;
+        if (first_visit && within_upper) {
+            level_to_insert[neighbor] = node_level + 1;
             queue.emplace(neighbor, node_level + 1);
             predecessor_to_insert[neighbor].emplace_back(current_node, edge_id);
+            recorded = true;
+        } else if (same_level) {
+            predecessor_to_insert[neighbor].emplace_back(current_node, edge_id);
+            recorded = true;
+        }
+
+        if (is_meeting) {
+            if (!recorded) {
+                predecessor_to_insert[neighbor].emplace_back(current_node, edge_id);
+            }
+            meeting_points.insert(neighbor);
         }
     }
     } // end for (dirs)

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -1215,9 +1215,13 @@ TEST_CASE("Heterogeneous edge zero-hop respects vertex label predicate",
                     "RETURN count(*)") == 0);
 }
 
-// VarLen 1+-hop output filter must follow the dst vertex pattern, not
-// the edge-schema terminal set. Oracles below are Neo4j-verified on
-// the SF0.003 mini fixture (#36).
+// VarLen 1+-hop output filtering must come from the vertex-pattern
+// label predicate, not the edge-schema's terminal partition set. For
+// REPLY_OF (Comment→Comment + Comment→Post), the planner previously
+// computed `dst_partition_ids = dst_pids − src_pids = {Post}` and used
+// that as the operator-level output filter, silently dropping all
+// Comment results from any *N..M VLE traversal (#36). Oracles below
+// are Neo4j-verified against the SF0.003 mini fixture.
 
 #ifdef TURBOLYNX_LDBC_FIXTURE_MINI
 TEST_CASE("REPLY_OF *1..2 returns all dst vertices when no label is bound",
@@ -1292,4 +1296,51 @@ TEST_CASE("REPLY_OF *1..2 label partition is disjoint",
                             "RETURN count(*)");
     CHECK(both == only_c + only_p);
 }
+
+// allShortestPaths must enumerate every same-depth predecessor. The BFS
+// previously stored only the first parent that reached an intermediate
+// node, so converging diamond shapes silently dropped all but one path.
+// Oracles below are Neo4j-verified against the LDBC SF0.003 mini
+// fixture (#39).
+
+#ifdef TURBOLYNX_LDBC_FIXTURE_MINI
+TEST_CASE("allShortestPaths enumerates every diamond at hop=3",
+          "[ldbc][filter][allshortest][issue39]") {
+    SKIP_IF_NO_DB();
+    // Person 14 ↔ {16, 13194139533352, 35184372088850, 10995116277761}
+    // sit at hop=3 with multiple shortest paths each. These cases all
+    // happened to be correct under the old code because the
+    // meeting-point branch picked up the extra predecessors; they are
+    // here as regression locks.
+    CHECK(qr->count("MATCH path = allShortestPaths("
+                    "(p1:Person {id:14})-[:KNOWS*0..]-"
+                    "(p2:Person {id:13194139533352})) "
+                    "RETURN count(path)") == 11);
+    CHECK(qr->count("MATCH path = allShortestPaths("
+                    "(p1:Person {id:14})-[:KNOWS*0..]-"
+                    "(p2:Person {id:16})) "
+                    "RETURN count(path)") == 7);
+    CHECK(qr->count("MATCH path = allShortestPaths("
+                    "(p1:Person {id:14})-[:KNOWS*0..]-"
+                    "(p2:Person {id:35184372088850})) "
+                    "RETURN count(path)") == 6);
+    CHECK(qr->count("MATCH path = allShortestPaths("
+                    "(p1:Person {id:14})-[:KNOWS*0..]-"
+                    "(p2:Person {id:10995116277761})) "
+                    "RETURN count(path)") == 4);
+}
+
+TEST_CASE("allShortestPaths enumerates every diamond at hop=4",
+          "[ldbc][filter][allshortest][issue39]") {
+    SKIP_IF_NO_DB();
+    // Person 14 ↔ 19791209299987 has 11 shortest paths of length 4
+    // (Neo4j-verified). Pre-fix we returned only 6 — five same-depth
+    // predecessors were dropped at an intermediate forward-BFS
+    // frontier before backward-BFS reached the meeting point.
+    CHECK(qr->count("MATCH path = allShortestPaths("
+                    "(p1:Person {id:14})-[:KNOWS*0..]-"
+                    "(p2:Person {id:19791209299987})) "
+                    "RETURN count(path)") == 11);
+}
+#endif
 #endif


### PR DESCRIPTION
closes #39

> Stacked on [#194](https://github.com/turbolynx-dslab/TurboLynx/pull/194). Base auto-retargets to main when #194 merges.

## Problem

`AllShortestPathIterator::enqueueNeighbors` decided "visited" purely by presence in `predecessor_to_insert`:

```cpp
// pre-fix
if (predecessor_to_insert.find(neighbor) == predecessor_to_insert.end()) {
    queue.emplace(neighbor, node_level + 1);
    predecessor_to_insert[neighbor].emplace_back(current_node, edge_id);
}
```

Once any predecessor was recorded for a node, additional same-depth predecessors that reached it later in the same BFS frontier were silently discarded. In a converging diamond, two parents at the same level can hit the same intermediate node before backward BFS gets there; the second parent (and every subsequent same-level parent) was lost, so path enumeration recovered only a subset of the shortest paths.

## Why it was invisible at shallow depths

The meeting-point branch (`predecessor_to_find.find(...) != end() && node_level + 1 >= lower_bound`) emplaces the extra predecessor whenever backward BFS visits the node first. For LDBC `Person 14` distance-3 targets that's usually true, so every one of those `count(path)` values matched Neo4j. At hop ≥ 4 the forward frontier visits intermediates well before backward catches up, and the symptom shows: `(Person 14)-[:KNOWS*0..]-(Person 19791209299987)` returns 6 paths against Neo4j's 11.

## Fix

Track BFS levels per direction in two new maps `bfs_level_forward / bfs_level_backward`. In `enqueueNeighbors`:

- First visit and within `upper_bound`: enqueue + emplace_back + record level.
- Already visited at the **same** level: emplace_back only (no re-enqueue).
- Already visited at a **smaller** level: drop the predecessor (it would extend the path).

The meeting-point and same-level branches share a single emplace_back per direction — meeting points at a converging frontier don't double-register.

## Test plan

5 new `[issue39]` assertions in `test_ldbc_filter.cpp`, Neo4j-verified on the LDBC SF0.003 mini fixture:

- [x] Diamond at hop=3 (4 endpoints) — regression locks (old code happened to be correct here).
- [x] Diamond at hop=4 — `Person 14 → 19791209299987` = 11 (was 6).

Regression:
- [x] LDBC 597 + 2 skipped (the `!shouldfail` from #36 — separate defect, unchanged here)
- [x] TPCH 55/55
- [x] OSS 6/6
- [x] types 23/23
- [x] unittest 216/216
- [x] oss-supply-chain pytest 22/22