### PR TITLE
fix(#193): clear stale DFS adj-list offsets between sources

### DIFF
--- a/src/storage/extent/adjlist_iterator.cpp
+++ b/src/storage/extent/adjlist_iterator.cpp
@@ -247,11 +247,13 @@ void DFSIterator::initialize(duckdb::ClientContext &context, uint64_t src_id,
         max_lv = 0;
     }
 
-    // Reset all level cursors
+    // Reset all level cursors and adj-list offsets so stale pointers
+    // from a previous source's traversal can't be reused (#193).
     for (int lv = 0; lv < (int)adj_col_cursor_per_level.size(); lv++) {
         adj_col_cursor_per_level[lv] = 0;
         for (int ac = 0; ac < (int)cursor_per_lv_per_col[lv].size(); ac++) {
             cursor_per_lv_per_col[lv][ac] = 0;
+            offsets_per_lv_per_col[lv][ac] = {nullptr, nullptr};
         }
     }
 

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -1259,22 +1259,15 @@ TEST_CASE("REPLY_OF *1..3 honours dst label across depths",
                     "RETURN count(*)") == 771);
 }
 
-// Known-failing: a separate VarLen path-uniqueness defect makes the
-// no-label *1..3 form emit one extra row (1269 vs Neo4j's 1268).
-// `[!mayfail]` keeps the suite green; remove the tag manually when
-// the underlying defect (#193) is fixed.
 TEST_CASE("REPLY_OF *1..3 no-label total matches Neo4j",
-          "[ldbc][filter][varlen][issue36][!mayfail]") {
+          "[ldbc][filter][varlen][issue193]") {
     SKIP_IF_NO_DB();
     CHECK(qr->count("MATCH (c:Comment)-[:REPLY_OF*1..3]->(m) "
                     "RETURN count(*)") == 1268);
 }
 
-// Known-failing: same VarLen path-uniqueness defect breaks the
-// label-disjoint invariant at depth ≥ 3 (1269 vs 497 + 771 = 1268).
-// `[!mayfail]` keeps the suite green; remove when #193 is fixed.
 TEST_CASE("REPLY_OF *1..3 label partition is disjoint",
-          "[ldbc][filter][varlen][issue36][!mayfail]") {
+          "[ldbc][filter][varlen][issue193]") {
     SKIP_IF_NO_DB();
     auto both = qr->count("MATCH (c:Comment)-[:REPLY_OF*1..3]->(m) "
                           "RETURN count(*)");


### PR DESCRIPTION
closes #193

## Problem

`(c:Comment)-[:REPLY_OF*1..3]->(m)` on the LDBC SF0.003 mini fixture returned **1269** rows vs Neo4j's **1268** — a single extra row from one source whose lv=3 traversal followed a stale adj-list pointer. Bound-on-both-ends single-depth queries took a different plan and didn't expose it, which is why bisecting by depth (\`*1..1\`, \`*2..2\`, \`*3..3\` all matched Neo4j) initially looked clean.

## Root cause

\`DFSIterator::initialize\` reset per-level **cursors** but not the **offsets**:

\`\`\`cpp
// pre-fix — comment only mentioned cursors
for (int lv = 0; lv < adj_col_cursor_per_level.size(); lv++) {
    adj_col_cursor_per_level[lv] = 0;
    for (int ac = 0; ac < cursor_per_lv_per_col[lv].size(); ac++) {
        cursor_per_lv_per_col[lv][ac] = 0;
        // offsets_per_lv_per_col[lv][ac] not touched
    }
}
\`\`\`

\`setupAdjListsForNode(lv, src)\` overwrites the offsets whenever it's invoked, so most paths were fine. But \`changeLevel\` skips setup when the next vertex is terminal:

\`\`\`cpp
if (src_partition_ids_.count(part) == 0) {
    return; // terminal — do not call setupAdjListsForNode
}
\`\`\`

That leaves \`offsets_per_lv_per_col[lv][ac]\` pointing at the previous source's adjacency-list memory. The next source that touched the same level via a non-terminal path read the stale pointer and emitted phantom edges.

## Fix

Reset \`offsets_per_lv_per_col[lv][ac]\` to \`{nullptr, nullptr}\` in the same loop that clears cursors. ~6 pointer writes per source init on LDBC-shaped traversals — negligible vs the traversal itself.

## Test plan

The two \`[!mayfail]\` tests we left in place after #36 (\`REPLY_OF *1..3 no-label total matches Neo4j\` and \`REPLY_OF *1..3 label partition is disjoint\`) now pass against Neo4j's hardcoded oracle; \`[!mayfail]\` removed and tag renamed from \`[issue36]\` to \`[issue193]\`.

- [x] LDBC 601/601 (0 skipped, was 595 + 2 mayfail)
- [x] TPCH 55/55
- [x] OSS 6/6
- [x] types 23/23
- [x] unittest 216/216
- [x] oss-supply-chain pytest 22/22