### PR TITLE
fix(#186): handle anchor-less OPTIONAL MATCH via LEFT OUTER cartesian

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -883,6 +883,79 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
             "Bind at least one variable in a preceding MATCH/WITH clause.");
     }
 
+    // Anchor-less OPTIONAL MATCH (no endpoint visible in prev_plan):
+    // build the subquery standalone and LOJ it against prev_plan.
+    // WHERE predicates split three ways — sub-only become a Selection
+    // on the subquery, prev+sub combined become the LOJ ON condition
+    // (so ORCA can pick something better than cart prod), prev-only
+    // become a Selection over the LOJ. Spec-correct: NULL-fill rows
+    // are never filtered by the OPTIONAL pattern's own WHERE (#186).
+    bool any_anchored = false;
+    for (uint32_t qg_idx = 0; qg_idx < qgc.GetNumQueryGraphs() && !any_anchored;
+         ++qg_idx) {
+        const BoundQueryGraph *qg = qgc.GetQueryGraph(qg_idx);
+        for (auto &node : qg->GetQueryNodes()) {
+            if (prev_plan->getSchema()->isNodeBound(node->GetUniqueName())) {
+                any_anchored = true;
+                break;
+            }
+        }
+    }
+    if (!any_anchored) {
+        turbolynx::LogicalPlan *sub_only = PlanRegularMatch(qgc, nullptr);
+
+        bound_expression_vector optional_preds;
+        for (auto &pred : predicates) {
+            CollectPredicateConjuncts(pred, optional_preds);
+        }
+        std::vector<bool> applied(optional_preds.size(), false);
+
+        bound_expression_vector sub_only_preds;
+        CExpression *loj_extra_pred = nullptr;
+        turbolynx::LogicalSchema combined_schema = *prev_plan->getSchema();
+        combined_schema.appendSchema(sub_only->getSchema());
+        turbolynx::LogicalPlan combined_plan(prev_plan->getPlanExpr(),
+                                             combined_schema);
+        for (idx_t i = 0; i < optional_preds.size(); ++i) {
+            auto &pred = optional_preds[i];
+            if (PredicateCanBeEvaluatedOnOptionalJoin(
+                    *pred, *sub_only->getSchema())) {
+                sub_only_preds.push_back(pred);
+                applied[i] = true;
+                continue;
+            }
+            if (PredicateCanBeEvaluatedOnOptionalJoin(
+                    *pred, *combined_plan.getSchema())) {
+                AppendAndPredicate(
+                    mp_, loj_extra_pred,
+                    ConvertExpression(*pred, &combined_plan));
+                applied[i] = true;
+            }
+        }
+        if (!sub_only_preds.empty()) {
+            sub_only = PlanSelection(sub_only_preds, sub_only);
+        }
+
+        CExpression *cond = loj_extra_pred
+            ? loj_extra_pred
+            : CUtils::PexprScalarConstBool(mp_, true);
+        prev_plan->getPlanExpr()->AddRef();
+        sub_only->getPlanExpr()->AddRef();
+        CExpression *loj = CUtils::PexprLogicalJoin<CLogicalLeftOuterJoin>(
+            mp_, prev_plan->getPlanExpr(), sub_only->getPlanExpr(), cond);
+        prev_plan->getSchema()->appendSchema(sub_only->getSchema());
+        prev_plan->addBinaryParentOp(loj, sub_only);
+
+        bound_expression_vector leftover;
+        for (idx_t i = 0; i < optional_preds.size(); ++i) {
+            if (!applied[i]) leftover.push_back(optional_preds[i]);
+        }
+        if (!leftover.empty()) {
+            prev_plan = PlanSelection(leftover, prev_plan);
+        }
+        return prev_plan;
+    }
+
     auto loj_type = gpopt::COperator::EopLogicalLeftOuterJoin;
     auto ij_type  = gpopt::COperator::EopLogicalInnerJoin;
     bound_expression_vector optional_predicates;

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -1116,13 +1116,87 @@ TEST_CASE("MATCH after WITH p reuses the binding rather than reopening it",
     CHECK(r[0].int64_at(0) == 1);  // would be > 1 if p were freshly scanned
 }
 
-// Note: OPTIONAL MATCH that reintroduces a dropped name alongside other
-// new bindings (`OPTIONAL MATCH (f:Person)-[:R]->(t:Tag)` after a WITH
-// that drops f) is the spec-correct case where the planner must
-// materialise a cartesian product against prev_plan and then apply the
-// WHERE filter. Our converter currently rejects this shape and SEGVs
-// through ORCA cleanup (#136). The fix lives in the converter and is
-// tracked in #186; the test will land alongside that fix.
+// Anchor-less OPTIONAL MATCH (every endpoint freshly introduced) must
+// materialise a LEFT OUTER cartesian against prev_plan, not throw.
+// WHERE predicates referencing both sides become the LOJ ON condition;
+// the NULL-fill row is preserved when the subquery has no match.
+// Oracles Neo4j-verified on the SF0.003 mini fixture (#186).
+TEST_CASE("anchor-less OPTIONAL MATCH yields prev × subquery cardinality",
+          "[ldbc][filter][optmatch][issue186]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (x:Forum) WITH count(x) AS c "
+        "OPTIONAL MATCH (p:Person)-[:HAS_INTEREST]->(t:Tag) "
+        "RETURN c, count(*) AS n",
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 400);
+    CHECK(r[0].int64_at(1) == 1256);
+}
+
+TEST_CASE("anchor-less OPTIONAL MATCH absorbs WHERE into LOJ condition",
+          "[ldbc][filter][optmatch][issue186]") {
+    SKIP_IF_NO_DB();
+    // Forum.id and Person.id are disjoint, so the WHERE p.id IN fids
+    // condition rejects every subquery row; the single prev row
+    // survives with NULL-filled p, t and count(*) = 1.
+    auto r = qr->run(
+        "MATCH (x:Forum) WITH count(x) AS c, collect(x.id) AS fids "
+        "OPTIONAL MATCH (p:Person)-[:HAS_INTEREST]->(t:Tag) "
+        "WHERE p.id IN fids "
+        "RETURN c, count(*) AS n",
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 400);
+    CHECK(r[0].int64_at(1) == 1);
+}
+
+TEST_CASE("anchor-less OPTIONAL MATCH pushes sub-only WHERE into subquery",
+          "[ldbc][filter][optmatch][issue186]") {
+    SKIP_IF_NO_DB();
+    // WHERE references only subquery columns → Selection pushed onto
+    // the subquery (LOJ condition stays TRUE). 51 HAS_INTEREST edges
+    // sourced from the Hossein person.
+    auto r = qr->run(
+        "MATCH (x:Forum) WITH count(x) AS c "
+        "OPTIONAL MATCH (p:Person)-[:HAS_INTEREST]->(t:Tag) "
+        "WHERE p.firstName = 'Hossein' "
+        "RETURN c, count(*) AS n",
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 400);
+    CHECK(r[0].int64_at(1) == 51);
+}
+
+TEST_CASE("anchor-less OPTIONAL MATCH preserves prev row when subquery is empty",
+          "[ldbc][filter][optmatch][issue186]") {
+    SKIP_IF_NO_DB();
+    // Empty subquery → LEFT OUTER semantics fills the prev row with
+    // NULL columns rather than dropping it.
+    auto r = qr->run(
+        "MATCH (x:Forum) WITH count(x) AS c "
+        "OPTIONAL MATCH (p:Person {id: 99999999999999}) "
+        "RETURN c, count(*) AS n",
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 400);
+    CHECK(r[0].int64_at(1) == 1);
+}
+
+TEST_CASE("anchor-less node-only OPTIONAL MATCH yields prev × scan",
+          "[ldbc][filter][optmatch][issue186]") {
+    SKIP_IF_NO_DB();
+    // No edges in the OPTIONAL pattern — single node scan LOJ'd
+    // against prev. 50 Person × 1 prev row.
+    auto r = qr->run(
+        "MATCH (x:Forum) WITH count(x) AS c "
+        "OPTIONAL MATCH (p:Person) "
+        "RETURN c, count(p) AS n",
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 400);
+    CHECK(r[0].int64_at(1) == 50);
+}
 
 TEST_CASE("bare pattern comprehension throws a clean binder error",
           "[ldbc][filter][listcomp][issue17]") {


### PR DESCRIPTION
closes #186

> Stacked on [#196](https://github.com/turbolynx-dslab/TurboLynx/pull/196). Base auto-retargets to main when #196 merges.

## Problem

\`Cypher2OrcaConverter::PlanOptionalMatch\` threw \`\"OPTIONAL MATCH requires at least one anchor\"\` whenever every endpoint of every query graph was freshly introduced (no name in \`prev_plan\`'s schema). Cypher spec for that shape is a **LEFT OUTER cartesian** between prev_plan and the subquery, with WHERE applied per its column-set. Combined with #136 (ORCA cleanup is not exception-safe) the throw surfaced as a \`sig=11\` trap at compile time — every query the issue body listed crashed.

Example:

\`\`\`cypher
MATCH (x:Forum) WITH count(x) AS c            -- aggregation collapses bindings
OPTIONAL MATCH (p:Person)-[:HAS_INTEREST]->(t:Tag)
RETURN c, count(*) AS n
\`\`\`

Neo4j: \`c=400, n=1256\`. Ours: SIGSEGV.

## Fix

At the head of \`PlanOptionalMatch\`, scan every query graph's nodes. If none of them is in \`prev_plan\`'s schema:

1. Build the subquery standalone: \`PlanRegularMatch(qgc, nullptr)\`.
2. LOJ it against \`prev_plan\`, splitting WHERE predicates **three ways**:
   - **sub-only** → \`Selection\` pushed onto the subquery (LOJ ON stays \`TRUE\`).
   - **prev + sub combined** → AND'd into the LOJ \`ON\` condition, so NULL-fill rows aren't filtered out. A \`Selection\` above the LOJ would drop them, which violates the LEFT OUTER spec.
   - **prev-only / unrelated** → \`Selection\` over the LOJ (cannot affect NULL semantics).

The anchored path is unchanged.

## Why \`Selection\`-above-LOJ wouldn't work for both-side predicates

\`WHERE p.id IN fids\` (\`fids\` from prev, \`p.id\` from sub). With an empty subquery match, LEFT OUTER leaves \`p.id = NULL\`. A Selection above would evaluate \`list_contains(fids, NULL) = NULL\` and drop the prev row — wrong by spec. Folding the predicate into LOJ \`ON\` means it's only evaluated against actual matches; NULL-fill rows survive untouched.

## What's not improved

ORCA still picks \`CPhysicalLeftOuterNLJoin\` over a cart prod here because there's no equi-join key. That's the inherent cost of anchor-less OPTIONAL MATCH — Plan B just makes the result correct (NULL-fill preserved) and gives ORCA the join condition in the right place so a smarter physical operator can be reached if/when one becomes applicable.

## Test plan

5 new \`[issue186]\` tests in \`test_ldbc_filter.cpp\`, Neo4j-verified on the LDBC SF0.003 mini fixture:

- [x] WHERE-less: \`c=400, n=1256\` (prev × subquery cardinality)
- [x] WHERE prev+sub (LOJ ON absorb): \`c=400, n=1\` (NULL-fill survives)
- [x] WHERE sub-only (Selection push): \`c=400, n=51\`
- [x] Empty subquery: \`c=400, n=1\` (LEFT OUTER preserves prev row)
- [x] Node-only anchor-less: \`c=400, n=50\`

Regression:
- [x] LDBC 606/606
- [x] TPCH 55/55
- [x] OSS 6/6
- [x] types 23/23
- [x] unittest 216/216
- [x] oss-supply-chain pytest 22/22