### PR TITLE
fix(#181): double var-len with shared anchor — crash + cardinality

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -1491,7 +1491,26 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
     // Phase 1: process normal QGs
     for (uint32_t qg_idx : normal_order) {
         const BoundQueryGraph *qg = qgc.GetQueryGraph(qg_idx);
-        const vector<shared_ptr<BoundRelExpression>> &rels = qg->GetQueryRels();
+        const vector<shared_ptr<BoundRelExpression>> &rels_raw = qg->GetQueryRels();
+        // Reorder edges so the first one shares an endpoint with a node
+        // already bound in qg_plan. Without this, a chain like
+        // `(p)-[:R]->(v)-[*..]->(anchor)` starts from the unbound (p, v)
+        // edge and cartesian-merges the fresh subtree against qg_plan
+        // (line "CartProd merge" below). For nested var-len queries
+        // sharing an outer anchor this is the cardinality-inflation
+        // source — anchoring the join chain on the bound end keeps every
+        // step equi-joined (#181).
+        vector<shared_ptr<BoundRelExpression>> rels = rels_raw;
+        if (qg_plan != nullptr && rels.size() > 1) {
+            auto endpoint_bound = [&](const BoundRelExpression &r) {
+                return qg_plan->getSchema()->isNodeBound(r.GetSrcNodeName()) ||
+                       qg_plan->getSchema()->isNodeBound(r.GetDstNodeName());
+            };
+            if (!endpoint_bound(*rels.front()) &&
+                endpoint_bound(*rels.back())) {
+                std::reverse(rels.begin(), rels.end());
+            }
+        }
 
         if (!rels.empty()) {
             // Edge-based join loop

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -883,6 +883,79 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
             "Bind at least one variable in a preceding MATCH/WITH clause.");
     }
 
+    // Anchor-less OPTIONAL MATCH (no endpoint visible in prev_plan):
+    // build the subquery standalone and LOJ it against prev_plan.
+    // WHERE predicates split three ways — sub-only become a Selection
+    // on the subquery, prev+sub combined become the LOJ ON condition
+    // (so ORCA can pick something better than cart prod), prev-only
+    // become a Selection over the LOJ. Spec-correct: NULL-fill rows
+    // are never filtered by the OPTIONAL pattern's own WHERE (#186).
+    bool any_anchored = false;
+    for (uint32_t qg_idx = 0; qg_idx < qgc.GetNumQueryGraphs() && !any_anchored;
+         ++qg_idx) {
+        const BoundQueryGraph *qg = qgc.GetQueryGraph(qg_idx);
+        for (auto &node : qg->GetQueryNodes()) {
+            if (prev_plan->getSchema()->isNodeBound(node->GetUniqueName())) {
+                any_anchored = true;
+                break;
+            }
+        }
+    }
+    if (!any_anchored) {
+        turbolynx::LogicalPlan *sub_only = PlanRegularMatch(qgc, nullptr);
+
+        bound_expression_vector optional_preds;
+        for (auto &pred : predicates) {
+            CollectPredicateConjuncts(pred, optional_preds);
+        }
+        std::vector<bool> applied(optional_preds.size(), false);
+
+        bound_expression_vector sub_only_preds;
+        CExpression *loj_extra_pred = nullptr;
+        turbolynx::LogicalSchema combined_schema = *prev_plan->getSchema();
+        combined_schema.appendSchema(sub_only->getSchema());
+        turbolynx::LogicalPlan combined_plan(prev_plan->getPlanExpr(),
+                                             combined_schema);
+        for (idx_t i = 0; i < optional_preds.size(); ++i) {
+            auto &pred = optional_preds[i];
+            if (PredicateCanBeEvaluatedOnOptionalJoin(
+                    *pred, *sub_only->getSchema())) {
+                sub_only_preds.push_back(pred);
+                applied[i] = true;
+                continue;
+            }
+            if (PredicateCanBeEvaluatedOnOptionalJoin(
+                    *pred, *combined_plan.getSchema())) {
+                AppendAndPredicate(
+                    mp_, loj_extra_pred,
+                    ConvertExpression(*pred, &combined_plan));
+                applied[i] = true;
+            }
+        }
+        if (!sub_only_preds.empty()) {
+            sub_only = PlanSelection(sub_only_preds, sub_only);
+        }
+
+        CExpression *cond = loj_extra_pred
+            ? loj_extra_pred
+            : CUtils::PexprScalarConstBool(mp_, true);
+        prev_plan->getPlanExpr()->AddRef();
+        sub_only->getPlanExpr()->AddRef();
+        CExpression *loj = CUtils::PexprLogicalJoin<CLogicalLeftOuterJoin>(
+            mp_, prev_plan->getPlanExpr(), sub_only->getPlanExpr(), cond);
+        prev_plan->getSchema()->appendSchema(sub_only->getSchema());
+        prev_plan->addBinaryParentOp(loj, sub_only);
+
+        bound_expression_vector leftover;
+        for (idx_t i = 0; i < optional_preds.size(); ++i) {
+            if (!applied[i]) leftover.push_back(optional_preds[i]);
+        }
+        if (!leftover.empty()) {
+            prev_plan = PlanSelection(leftover, prev_plan);
+        }
+        return prev_plan;
+    }
+
     auto loj_type = gpopt::COperator::EopLogicalLeftOuterJoin;
     auto ij_type  = gpopt::COperator::EopLogicalInnerJoin;
     bound_expression_vector optional_predicates;

--- a/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
+++ b/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
@@ -214,11 +214,9 @@ void PhysicalVarlenAdjIdxJoin::ProcessLeftJoin(ExecutionContext& context, DataCh
 
 
 OperatorResultType PhysicalVarlenAdjIdxJoin::ExecuteNaiveInput(ExecutionContext& context, DataChunk &input, DataChunk &chunk, OperatorState &lstate) const {
-	auto &state = (VarlenAdjIdxJoinState &)lstate; 
- 
+	auto &state = (VarlenAdjIdxJoinState &)lstate;
+
 	if( !state.first_fetch ) {
-		// values used while processing
-		//state.srcColIdx = schema.getColIdxOfKey(srcName);
 		state.srcColIdx = sid_col_idx;
 		state.cur_lv = 0;
 		state.start_lv = static_cast<int>(std::min(min_length, (uint64_t)INT32_MAX));
@@ -228,14 +226,18 @@ OperatorResultType PhysicalVarlenAdjIdxJoin::ExecuteNaiveInput(ExecutionContext&
 		state.iso_checker->initialize(max_length - min_length + 1);
 #endif
 
+		// inner_col_map is empty when ORCA prunes the path output as
+		// unused (e.g. nested VarLen feeding only count(*)); leave the
+		// indices at -1 and let downstream code skip the tgt/edge
+		// writes (#181).
 		if (load_eid) {
-			state.tgtColIdx = inner_col_map[0];
-			state.edgeColIdx = inner_col_map[1];
+			state.tgtColIdx = inner_col_map.size() > 0 ? inner_col_map[0] : (idx_t)-1;
+			state.edgeColIdx = inner_col_map.size() > 1 ? inner_col_map[1] : (idx_t)-1;
 		} else {
-			state.edgeColIdx = -1;
-			state.tgtColIdx = inner_col_map[0];
+			state.edgeColIdx = (idx_t)-1;
+			state.tgtColIdx = inner_col_map.empty() ? (idx_t)-1 : inner_col_map[0];
 		}
-		
+
 		state.outer_col_map = move(outer_col_map);
 		state.inner_col_map = move(inner_col_map);
 		// Get join matches (sizes) for the LHS. Initialized one time per LHS
@@ -338,7 +340,9 @@ uint64_t PhysicalVarlenAdjIdxJoin::VarlengthExpand_internal(ExecutionContext& co
 	// state.current_path.clear();
 	// state.current_path.push_back(src_vid);
 
-	tgt_adj_column = (uint64_t *)chunk.data[state.tgtColIdx].GetData();	// always flatvector[ID]. so ok to access directly
+	tgt_adj_column = state.tgtColIdx == (idx_t)-1
+		? nullptr
+		: (uint64_t *)chunk.data[state.tgtColIdx].GetData();
 	// eid_adj_column = (uint64_t *)chunk.data[state.edgeColIdx].GetData();	// always flatvector[ID]. so ok to access directly
 	eid_adj_column = nullptr; // jhha: this eid column is not used.
 
@@ -469,8 +473,7 @@ void PhysicalVarlenAdjIdxJoin::addNewPathToOutput(
     uint64_t *tgt_adj_column, uint64_t *eid_adj_column, uint64_t output_idx,
     vector<uint64_t> &current_path, uint64_t new_tgt_id,
     uint64_t new_edge_id) const {
-	// Var-length expansion binds the endpoint vertex to the target column.
-	tgt_adj_column[output_idx] = new_tgt_id;
+	if (tgt_adj_column) tgt_adj_column[output_idx] = new_tgt_id;
 	if (load_eid && eid_adj_column) {
 		eid_adj_column[output_idx] = new_edge_id;
 	}

--- a/src/storage/extent/adjlist_iterator.cpp
+++ b/src/storage/extent/adjlist_iterator.cpp
@@ -247,11 +247,13 @@ void DFSIterator::initialize(duckdb::ClientContext &context, uint64_t src_id,
         max_lv = 0;
     }
 
-    // Reset all level cursors
+    // Reset all level cursors and adj-list offsets so stale pointers
+    // from a previous source's traversal can't be reused (#193).
     for (int lv = 0; lv < (int)adj_col_cursor_per_level.size(); lv++) {
         adj_col_cursor_per_level[lv] = 0;
         for (int ac = 0; ac < (int)cursor_per_lv_per_col[lv].size(); ac++) {
             cursor_per_lv_per_col[lv][ac] = 0;
+            offsets_per_lv_per_col[lv][ac] = {nullptr, nullptr};
         }
     }
 

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -1259,22 +1259,15 @@ TEST_CASE("REPLY_OF *1..3 honours dst label across depths",
                     "RETURN count(*)") == 771);
 }
 
-// Known-failing: a separate VarLen path-uniqueness defect makes the
-// no-label *1..3 form emit one extra row (1269 vs Neo4j's 1268).
-// `[!mayfail]` keeps the suite green; remove the tag manually when
-// the underlying defect (#193) is fixed.
 TEST_CASE("REPLY_OF *1..3 no-label total matches Neo4j",
-          "[ldbc][filter][varlen][issue36][!mayfail]") {
+          "[ldbc][filter][varlen][issue193]") {
     SKIP_IF_NO_DB();
     CHECK(qr->count("MATCH (c:Comment)-[:REPLY_OF*1..3]->(m) "
                     "RETURN count(*)") == 1268);
 }
 
-// Known-failing: same VarLen path-uniqueness defect breaks the
-// label-disjoint invariant at depth ≥ 3 (1269 vs 497 + 771 = 1268).
-// `[!mayfail]` keeps the suite green; remove when #193 is fixed.
 TEST_CASE("REPLY_OF *1..3 label partition is disjoint",
-          "[ldbc][filter][varlen][issue36][!mayfail]") {
+          "[ldbc][filter][varlen][issue193]") {
     SKIP_IF_NO_DB();
     auto both = qr->count("MATCH (c:Comment)-[:REPLY_OF*1..3]->(m) "
                           "RETURN count(*)");

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -1116,13 +1116,87 @@ TEST_CASE("MATCH after WITH p reuses the binding rather than reopening it",
     CHECK(r[0].int64_at(0) == 1);  // would be > 1 if p were freshly scanned
 }
 
-// Note: OPTIONAL MATCH that reintroduces a dropped name alongside other
-// new bindings (`OPTIONAL MATCH (f:Person)-[:R]->(t:Tag)` after a WITH
-// that drops f) is the spec-correct case where the planner must
-// materialise a cartesian product against prev_plan and then apply the
-// WHERE filter. Our converter currently rejects this shape and SEGVs
-// through ORCA cleanup (#136). The fix lives in the converter and is
-// tracked in #186; the test will land alongside that fix.
+// Anchor-less OPTIONAL MATCH (every endpoint freshly introduced) must
+// materialise a LEFT OUTER cartesian against prev_plan, not throw.
+// WHERE predicates referencing both sides become the LOJ ON condition;
+// the NULL-fill row is preserved when the subquery has no match.
+// Oracles Neo4j-verified on the SF0.003 mini fixture (#186).
+TEST_CASE("anchor-less OPTIONAL MATCH yields prev × subquery cardinality",
+          "[ldbc][filter][optmatch][issue186]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (x:Forum) WITH count(x) AS c "
+        "OPTIONAL MATCH (p:Person)-[:HAS_INTEREST]->(t:Tag) "
+        "RETURN c, count(*) AS n",
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 400);
+    CHECK(r[0].int64_at(1) == 1256);
+}
+
+TEST_CASE("anchor-less OPTIONAL MATCH absorbs WHERE into LOJ condition",
+          "[ldbc][filter][optmatch][issue186]") {
+    SKIP_IF_NO_DB();
+    // Forum.id and Person.id are disjoint, so the WHERE p.id IN fids
+    // condition rejects every subquery row; the single prev row
+    // survives with NULL-filled p, t and count(*) = 1.
+    auto r = qr->run(
+        "MATCH (x:Forum) WITH count(x) AS c, collect(x.id) AS fids "
+        "OPTIONAL MATCH (p:Person)-[:HAS_INTEREST]->(t:Tag) "
+        "WHERE p.id IN fids "
+        "RETURN c, count(*) AS n",
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 400);
+    CHECK(r[0].int64_at(1) == 1);
+}
+
+TEST_CASE("anchor-less OPTIONAL MATCH pushes sub-only WHERE into subquery",
+          "[ldbc][filter][optmatch][issue186]") {
+    SKIP_IF_NO_DB();
+    // WHERE references only subquery columns → Selection pushed onto
+    // the subquery (LOJ condition stays TRUE). 51 HAS_INTEREST edges
+    // sourced from the Hossein person.
+    auto r = qr->run(
+        "MATCH (x:Forum) WITH count(x) AS c "
+        "OPTIONAL MATCH (p:Person)-[:HAS_INTEREST]->(t:Tag) "
+        "WHERE p.firstName = 'Hossein' "
+        "RETURN c, count(*) AS n",
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 400);
+    CHECK(r[0].int64_at(1) == 51);
+}
+
+TEST_CASE("anchor-less OPTIONAL MATCH preserves prev row when subquery is empty",
+          "[ldbc][filter][optmatch][issue186]") {
+    SKIP_IF_NO_DB();
+    // Empty subquery → LEFT OUTER semantics fills the prev row with
+    // NULL columns rather than dropping it.
+    auto r = qr->run(
+        "MATCH (x:Forum) WITH count(x) AS c "
+        "OPTIONAL MATCH (p:Person {id: 99999999999999}) "
+        "RETURN c, count(*) AS n",
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 400);
+    CHECK(r[0].int64_at(1) == 1);
+}
+
+TEST_CASE("anchor-less node-only OPTIONAL MATCH yields prev × scan",
+          "[ldbc][filter][optmatch][issue186]") {
+    SKIP_IF_NO_DB();
+    // No edges in the OPTIONAL pattern — single node scan LOJ'd
+    // against prev. 50 Person × 1 prev row.
+    auto r = qr->run(
+        "MATCH (x:Forum) WITH count(x) AS c "
+        "OPTIONAL MATCH (p:Person) "
+        "RETURN c, count(p) AS n",
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 400);
+    CHECK(r[0].int64_at(1) == 50);
+}
 
 TEST_CASE("bare pattern comprehension throws a clean binder error",
           "[ldbc][filter][listcomp][issue17]") {

--- a/test/query/test_oss_regression.cpp
+++ b/test/query/test_oss_regression.cpp
@@ -193,3 +193,49 @@ TEST_CASE("OSS #68 vulnpkg vs affected pkg (Package self-join layer)",
     CHECK(r[1].str_at(0) == "log4j");
     CHECK(r[1].str_at(1) == "webapp");
 }
+
+// Double VarLen with both ends self-joined (#181). Two layered fixes:
+//
+//  (a) Operator: when ORCA prunes the path output (count(*)) the second
+//      VarLen's `inner_col_map` was empty, so `tgtColIdx = inner_col_map[0]`
+//      walked off the vector and SIGSEGVed in ExecuteNaiveInput.
+//
+//  (b) Converter: PlanRegularMatch processed edges in syntax order. When
+//      the first edge has both endpoints unbound (e.g. `(p1)-[r]->(v1)`)
+//      and a later edge joins onto a bound anchor (`(v1)-[*]->(vuln)`),
+//      the cartProd-merge in line 2076 inflated the fresh subtree against
+//      qg_plan. Neo4j on the imported OSS fixture returned 4 paths; we
+//      were emitting 36 (9× inflation). PlanOptionalMatch already had
+//      the edge-reorder; PlanRegularMatch now mirrors it.
+//
+// Oracles below are Neo4j-verified against the imported OSS fixture.
+
+TEST_CASE("OSS #181 double var-len count matches Neo4j",
+          "[oss][regression181]") {
+    SKIP_IF_NO_OSS_DB();
+    CHECK(qr->count(
+        "MATCH (c:CVE {id: 'CVE-2021-44228'})<-[:AFFECTED_BY]-(vuln:Version) "
+        "MATCH (p1:Package)-[:HAS_VERSION]->(v1:Version)"
+        "-[:DEPENDS_ON*1..3]->(vuln) "
+        "MATCH (p2:Package)-[:HAS_VERSION]->(v2:Version)"
+        "-[:DEPENDS_ON*1..3]->(vuln) "
+        "RETURN count(*)") == 4);
+}
+
+TEST_CASE("OSS #181 double var-len ordered pairs match Neo4j",
+          "[oss][regression181]") {
+    SKIP_IF_NO_OSS_DB();
+    auto r = qr->run(
+        "MATCH (c:CVE {id: 'CVE-2021-44228'})<-[:AFFECTED_BY]-(vuln:Version) "
+        "MATCH (p1:Package)-[:HAS_VERSION]->(v1:Version)"
+        "-[:DEPENDS_ON*1..3]->(vuln) "
+        "MATCH (p2:Package)-[:HAS_VERSION]->(v2:Version)"
+        "-[:DEPENDS_ON*1..3]->(vuln) "
+        "WHERE p1.name < p2.name "
+        "RETURN p1.name AS p1, p2.name AS p2 "
+        "ORDER BY p1 ASC, p2 ASC",
+        {qtest::ColType::STRING, qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == "awesome-lib");
+    CHECK(r[0].str_at(1) == "webapp");
+}


### PR DESCRIPTION
closes #181
related: #199, #200, #198 (filed during this investigation)

## Two layered failures

The OSS-fixture repro from #181 had two distinct issues stacked.

### 1. SIGSEGV in \`PhysicalVarlenAdjIdxJoin::ExecuteNaiveInput\`

When ORCA prunes the path output (\`RETURN count(*)\` makes \`_id\`/\`_sid\`/\`_tid\` all unused), the second var-len's \`inner_col_map\` arrives empty. \`state.tgtColIdx = inner_col_map[0]\` walks off the vector.

### 2. 9× cardinality inflation

\`PlanRegularMatch\` iterates edges in syntax order. When the first edge has both endpoints unbound and a later edge anchors onto a previously bound vertex, the \`!is_lhs_bound && !is_rhs_bound\` branch in the cartProd-merge at line ~2076 inflates the fresh subtree against \`qg_plan\`. The subsequent equi-join on the bound anchor sits above the cartProd, so ORCA never recovers the join order. Neo4j returned 4 rows; we returned 36.

## Fixes

- **Operator** (1): when \`inner_col_map\` is empty, leave \`tgtColIdx\` / \`edgeColIdx\` at \`-1\` and skip the writes in \`addNewPathToOutput\` / the chunk access in \`VarlengthExpand_internal\`. Path enumeration still produces \`num_found_paths\`, which is what ORCA needs.
- **Converter** (2): in \`PlanRegularMatch\`, reverse the edge order when the first edge's endpoints are both unbound and the last edge has a bound endpoint. Mirrors the equivalent reorder in \`PlanOptionalMatch\`. The chain then starts at the bound anchor and every step is equi-joined — no cartProd merge fires.

## Scope

This is a positional reorder (\`first vs last\`), not a topological one. Cases covered:

| Pattern | Behavior |
|---|---|
| 2 edges, middle bound | auto-OK (no reorder needed) |
| 3 edges, middle bound | OK (reverse triggers) |
| Anchored at one end | OK (no reorder needed) |
| 5+ edges, only middle bound | not covered — tracked in #200 |

A separate gap surfaced during testing: single-MATCH multi-edge path-isomorphism is not enforced (\`(p)-[r1]->(vuln)<-[r2]-(q)\` accepts \`r1 == r2\` when \`p == q\`). Tracked in #199.

While importing the OSS fixture into Neo4j for oracles I also noticed CI doesn't exercise schemaless property sets at all; tracked in #198.

## Test plan

New \`[regression181]\` tests in \`test_oss_regression.cpp\`, Neo4j-verified against the OSS fixture imported into Neo4j 5:

- [x] double var-len count = 4 (was crash → 36 wrong)
- [x] ordered pair: \`(awesome-lib, webapp)\` (single row)

Regression:
- [x] LDBC 606/606
- [x] TPCH 55/55
- [x] OSS 8/8
- [x] types 23/23
- [x] unittest 216/216
- [x] oss-supply-chain pytest 22/22