### PR TITLE
fix(#199): enforce single-MATCH multi-edge relationship-isomorphism

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -35,6 +35,7 @@
 #include <limits>
 #include <cassert>
 #include <set>
+#include <unordered_set>
 
 using namespace gpopt;
 using namespace gpmd;
@@ -1512,6 +1513,18 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
             }
         }
 
+        // Cypher relationship-isomorphism: every -[]- in a single MATCH's
+        // pattern must bind a distinct edge. Emitted as `cur._id != prev._id`
+        // chained AND on R-join-B (#199). Edges with disjoint partition sets
+        // (e.g. `HAS_CREATOR` vs `LIKES`) can never bind to the same physical
+        // edge, so the predicate is restricted to partition-overlapping pairs.
+        // Each entry: (current-edge-_id ColRef, partition-id set).
+        struct PathIsoEdge {
+            CColRef *id_colref;
+            std::unordered_set<uint64_t> partition_ids;
+        };
+        std::vector<PathIsoEdge> path_iso_edges;
+
         if (!rels.empty()) {
             // Edge-based join loop
             for (auto &qedge : rels) {
@@ -2079,15 +2092,65 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                     } else {
                         rhs_plan = qg_plan;
                     }
+                    // Path-iso (#199): chain `cur._id != prev._id` against every
+                    // earlier edge in this query graph as a residual predicate
+                    // on R-join-B. Skipped for var-len (ExactIsoChecker covers
+                    // the internal-iso part inside a single var-len).
+                    CExpression *iso_pred = nullptr;
+                    if (!is_pathjoin && !path_iso_edges.empty()) {
+                        std::unordered_set<uint64_t> cur_parts(
+                            qedge->GetPartitionIDs().begin(),
+                            qedge->GetPartitionIDs().end());
+                        CColRef *cur_id =
+                            lhs_plan->getSchema()->getColRefOfKey(edge_name,
+                                                                  ID_KEY_ID);
+                        for (auto &prev : path_iso_edges) {
+                            bool overlap = false;
+                            for (auto p : prev.partition_ids) {
+                                if (cur_parts.count(p)) {
+                                    overlap = true;
+                                    break;
+                                }
+                            }
+                            if (!overlap) continue;
+                            CExpression *ne = CUtils::PexprScalarCmp(
+                                mp_, cur_id, prev.id_colref,
+                                IMDType::EcmptNEq);
+                            if (iso_pred == nullptr) {
+                                iso_pred = ne;
+                            } else {
+                                CExpressionArray *children =
+                                    GPOS_NEW(mp_) CExpressionArray(mp_);
+                                iso_pred->AddRef();
+                                children->Append(iso_pred);
+                                children->Append(ne);
+                                iso_pred = CUtils::PexprScalarBoolOp(
+                                    mp_, CScalarBoolOp::EboolopAnd, children);
+                            }
+                        }
+                    }
                     auto rb_join_type = gpopt::COperator::EOperatorId::EopLogicalInnerJoin;
                     CExpression *join_expr = ExprLogicalJoin(
                         lhs_plan->getPlanExpr(), rhs_plan->getPlanExpr(),
                         lhs_plan->getSchema()->getColRefOfKey(edge_name, rhs_edge_key),
                         rhs_plan->getSchema()->getColRefOfKey(rhs_name, ID_KEY_ID),
-                        rb_join_type, nullptr);
+                        rb_join_type, iso_pred);
                     lhs_plan->getSchema()->appendSchema(rhs_plan->getSchema());
                     lhs_plan->addBinaryParentOp(join_expr, rhs_plan);
                     hop_plan = lhs_plan;
+                }
+                // Track this edge's _id + partition set for subsequent
+                // iterations (#199 iso predicate scope).
+                if (!is_pathjoin) {
+                    CColRef *eid =
+                        lhs_plan->getSchema()->getColRefOfKey(edge_name,
+                                                              ID_KEY_ID);
+                    if (eid != nullptr) {
+                        std::unordered_set<uint64_t> parts(
+                            qedge->GetPartitionIDs().begin(),
+                            qedge->GetPartitionIDs().end());
+                        path_iso_edges.push_back({eid, std::move(parts)});
+                    }
                 }
                 D_ASSERT(hop_plan != nullptr);
 

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -2288,19 +2288,23 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
         }
     }
     else if (filter_after_adj && !generate_seek) {
-        if (!is_adjidxjoin_into) {
-            D_ASSERT(false);
-            D_ASSERT(filter_expr != NULL);
-            adj_output_cols->AppendArray(outer_cols);
-            adj_output_cols->AppendArray(inner_cols);
-            adj_inner_cols->AppendArray(inner_cols);
-            pAppendFilterOnlyCols(filter_expr, idxscan_cols, inner_cols,
-                                adj_inner_cols);
-            pAppendFilterOnlyCols(filter_expr, idxscan_cols, inner_cols,
-                                adj_output_cols);
-        } else {
-            D_ASSERT(false);
+        // AdjIdxJoin + Filter (no IdSeek): the residual filter runs on the
+        // AdjIdxJoin's output, so every col it references must be in
+        // adj_output_colset. Line 2325 below rebuilds adj_output_cols from
+        // the colset, so populating only the array (as the legacy code did)
+        // gets overwritten — populate the colset directly. Triggered by the
+        // path-iso predicate in single-MATCH multi-edge patterns (#199).
+        D_ASSERT(filter_expr != NULL);
+        adj_output_colset->Include(outer_cols);
+        adj_output_colset->Include(inner_cols);
+        adj_inner_colset->Include(inner_cols);
+        CColRefArray *flt_cols = GPOS_NEW(mp) CColRefArray(mp);
+        pAppendFilterOnlyCols(filter_expr, idxscan_cols, inner_cols, flt_cols);
+        for (ULONG i = 0; i < flt_cols->Size(); i++) {
+            adj_inner_colset->Include((*flt_cols)[i]);
+            adj_output_colset->Include((*flt_cols)[i]);
         }
+        flt_cols->Release();
     }
     else if (!filter_after_adj && generate_seek) {
         adj_output_colset->Include(output_cols_copy);

--- a/test/query/test_oss_regression.cpp
+++ b/test/query/test_oss_regression.cpp
@@ -239,3 +239,94 @@ TEST_CASE("OSS #181 double var-len ordered pairs match Neo4j",
     CHECK(r[0].str_at(0) == "awesome-lib");
     CHECK(r[0].str_at(1) == "webapp");
 }
+
+// Cypher relationship-isomorphism: edges of the same query graph must bind
+// distinct relationships. The single inbound HAS_VERSION to each Version
+// fixes r1 == r2 when both endpoints are Package, so Neo4j returns 0 rows.
+TEST_CASE("OSS #199 single-MATCH multi-edge enforces edge-iso",
+          "[oss][regression199]") {
+    SKIP_IF_NO_OSS_DB();
+    CHECK(qr->count(
+        "MATCH (c:CVE {id: 'CVE-2021-44228'})<-[:AFFECTED_BY]-(vuln:Version) "
+        "MATCH (p:Package)-[:HAS_VERSION]->(vuln)"
+        "<-[:HAS_VERSION]-(q:Package) "
+        "RETURN count(*)") == 0);
+}
+
+TEST_CASE("OSS #199 single-MATCH multi-edge enforces edge-iso (projected)",
+          "[oss][regression199]") {
+    SKIP_IF_NO_OSS_DB();
+    auto r = qr->run(
+        "MATCH (c:CVE {id: 'CVE-2021-44228'})<-[:AFFECTED_BY]-(vuln:Version) "
+        "MATCH (p:Package)-[:HAS_VERSION]->(vuln)"
+        "<-[:HAS_VERSION]-(q:Package) "
+        "RETURN p.name AS p, q.name AS q",
+        {qtest::ColType::STRING, qtest::ColType::STRING});
+    CHECK(r.size() == 0);
+}
+
+// Three-edge same-type chain: exercises the AND-chain across multiple
+// prior edges. Each Version has exactly one inbound HAS_VERSION, so r1==r2
+// is forced; iso rejects every row.
+TEST_CASE("OSS #199 three-edge HAS_VERSION enforces transitive iso",
+          "[oss][regression199]") {
+    SKIP_IF_NO_OSS_DB();
+    CHECK(qr->count(
+        "MATCH (p:Package)-[:HAS_VERSION]->(v:Version)"
+        "<-[:HAS_VERSION]-(q:Package)-[:HAS_VERSION]->(v2:Version) "
+        "RETURN count(*)") == 0);
+}
+
+// Control for the two cases above: Cypher iso applies only within a single
+// MATCH's query graph. Splitting the pattern into separate MATCHes bypasses
+// iso, so the same pattern returns a non-zero count. Neo4j oracles:
+//   2-edge split → 1, 3-edge split → 12. The 0-vs-N gap proves the new
+//   iso predicate is what's rejecting rows above, not a join misfire.
+TEST_CASE("OSS #199 split-MATCH control matches Neo4j non-iso count",
+          "[oss][regression199]") {
+    SKIP_IF_NO_OSS_DB();
+    CHECK(qr->count(
+        "MATCH (c:CVE {id: 'CVE-2021-44228'})<-[:AFFECTED_BY]-(vuln:Version) "
+        "MATCH (p:Package)-[:HAS_VERSION]->(vuln) "
+        "MATCH (q:Package)-[:HAS_VERSION]->(vuln) "
+        "RETURN count(*)") == 1);
+    CHECK(qr->count(
+        "MATCH (p:Package)-[:HAS_VERSION]->(v:Version) "
+        "MATCH (q:Package)-[:HAS_VERSION]->(v) "
+        "MATCH (q)-[:HAS_VERSION]->(v2:Version) "
+        "RETURN count(*)") == 12);
+}
+
+// a-b-a sequence (HAS_VERSION, DEPENDS_ON, HAS_VERSION). The partition-
+// overlap filter must SKIP iso between HV and DEPENDS_ON (cross-type) and
+// only enforce r1 != r3 between the two HV edges. Both HV edges connect
+// distinct (package, version) pairs so iso passes; cardinality must
+// match Neo4j (= 4).
+TEST_CASE("OSS #199 mixed-type sequence skips cross-type iso",
+          "[oss][regression199]") {
+    SKIP_IF_NO_OSS_DB();
+    auto r = qr->run(
+        "MATCH (p1:Package)-[:HAS_VERSION]->(v1:Version)"
+        "<-[:DEPENDS_ON]-(v2:Version)<-[:HAS_VERSION]-(p2:Package) "
+        "RETURN p1.name AS p1, v1.uid AS v1, v2.uid AS v2, p2.name AS p2 "
+        "ORDER BY p1, p2",
+        {qtest::ColType::STRING, qtest::ColType::UINT64,
+         qtest::ColType::UINT64, qtest::ColType::STRING});
+    REQUIRE(r.size() == 4);
+    CHECK(r[0].str_at(0) == "awesome-lib");
+    CHECK(r[0].int64_at(1) == 7);
+    CHECK(r[0].int64_at(2) == 8);
+    CHECK(r[0].str_at(3) == "webapp");
+    CHECK(r[1].str_at(0) == "lodash");
+    CHECK(r[1].int64_at(1) == 4);
+    CHECK(r[1].int64_at(2) == 8);
+    CHECK(r[1].str_at(3) == "webapp");
+    CHECK(r[2].str_at(0) == "lodashx");
+    CHECK(r[2].int64_at(1) == 6);
+    CHECK(r[2].int64_at(2) == 7);
+    CHECK(r[2].str_at(3) == "awesome-lib");
+    CHECK(r[3].str_at(0) == "log4j");
+    CHECK(r[3].int64_at(1) == 1);
+    CHECK(r[3].int64_at(2) == 7);
+    CHECK(r[3].str_at(3) == "awesome-lib");
+}


### PR DESCRIPTION
## Summary
- Converter emits `cur._id != prev._id` between sibling edges of the same single-MATCH query graph, filtered to partition-overlapping pairs so cross-type patterns (LDBC IC7's `HAS_CREATOR`+`LIKES`) are not falsely iso-checked.
- Translator's `pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin` had a previously-unreachable branch (`D_ASSERT(false)`) that populated only the col-array; the rebuild at the end of column setup wiped it. Switched to populating `adj_output_colset` directly so the residual filter resolves correctly.

## Why this is the right shape
Two paths were considered. Path-iso could have lived inside `PhysicalAdjIdxJoin` / `PhysicalIdSeek` as per-operator state (mirroring the var-len `ExactIsoChecker`), but that approach would require every new traversal operator to plumb iso state through the converter. Fixing the translator's residual-filter scope is a one-time fix for what is actually a more general translator bug — any future ORCA residual referencing ancestor cols would have hit the same dead branch. The single-MATCH multi-edge path is the first thing to exercise it.

The plan keeps `AdjIdxJoin → IdSeek` for the affected hop and adds one extra `PhysicalFilter` after the AdjIdxJoin emitting the iso-checked edge — confirmed via duckdb `PipeExec` trace on the reproducer.

## Test plan
- [x] 5 new `[oss][regression199]` cases: 2-edge / projected / 3-edge AND-chain / a-b-a mixed-type / split-MATCH control. All oracles Neo4j 5 verified on the OSS fixture.
- [x] Split-MATCH control returns 1 and 12 (Neo4j-matched), proving the zero-result tests are reduced by iso predicate, not by a silent join misfire.
- [x] `[oss]` 13/13 (150 assertions), `[ldbc]` 606/606 (2184 assertions), unittest 216/216 (870 assertions) all green.
- [x] LDBC IC7 (`HAS_CREATOR`+`LIKES` 2-edge cross-type) confirms the partition-overlap filter correctly skips cross-type iso.
- [x] `applications/oss-supply-chain` pytest 22/22.

Stacks on #201.