### PR TITLE
fix(#203,#204): PhysicalOptional + FinalExecute hook for standalone OPT MATCH

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -1515,6 +1515,15 @@ shared_ptr<BoundRelExpression> Binder::BindRelPattern(const RelPattern& rel,
     if (rel.GetPatternType() == RelPatternType::VARIABLE_LENGTH) {
         if (lower == 1 && upper == 1) upper = UINT64_MAX; // no bound specified
     }
+    // Reject backwards range up front; otherwise downstream allocators see a
+    // negative size, which libc++ throws bad_array_new_length on and
+    // libstdc++ silently runs through. Same divergence as #86 / #214.
+    if (rel.GetPatternType() == RelPatternType::VARIABLE_LENGTH &&
+        lower > upper) {
+        throw BinderException(
+            "VarLen range lower bound (" + std::to_string(lower) +
+            ") must be <= upper bound (" + std::to_string(upper) + ")");
+    }
 
     auto bound_rel = make_shared<BoundRelExpression>(
         var_name, rel.GetTypes(), rel.GetDirection(),

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -878,10 +878,19 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
     const BoundQueryGraphCollection &qgc, turbolynx::LogicalPlan *prev_plan,
     const bound_expression_vector &predicates)
 {
+    // Standalone OPTIONAL MATCH (no prior MATCH/WITH): Cypher 5 specifies
+    // an implicit one-empty-row prior context that turns no-match into a
+    // single NULL-filled output row. Plan the pattern as a regular MATCH
+    // and mark the result for PhysicalOptional wrapping at translation
+    // time — that operator forwards matched rows unchanged and emits the
+    // synthetic NULL row when the MATCH produced zero (#203, #204).
     if (prev_plan == nullptr) {
-        throw duckdb::InvalidInputException(
-            "Standalone OPTIONAL MATCH is not supported. "
-            "Bind at least one variable in a preceding MATCH/WITH clause.");
+        turbolynx::LogicalPlan *plan = PlanRegularMatch(qgc, nullptr, predicates);
+        if (!predicates.empty()) {
+            plan = PlanSelection(predicates, plan);
+        }
+        plan->setWrapWithOptional(true);
+        return plan;
     }
 
     // Anchor-less OPTIONAL MATCH (no endpoint visible in prev_plan):

--- a/src/execution/execution/cypher_pipeline_executor.cpp
+++ b/src/execution/execution/cypher_pipeline_executor.cpp
@@ -248,6 +248,39 @@ void CypherPipelineExecutor::ExecutePipeline()
 		}
 		// if (++num_pipeline_executions == max_pipeline_executions) { break; } // for debugging
 	}
+
+	// EOS hook: give each piped operator a chance to emit synthesized
+	// rows after the source has exhausted. Used by PhysicalOptional to
+	// emit the NULL row when the upstream match produced 0 rows (#203).
+	// Default base impl is a no-op, so unaffected ops pay only one
+	// virtual call per pipeline.
+	if (pipeline->pipelineLength >= 3) {
+		for (idx_t op_idx = 1; op_idx + 1 < pipeline->pipelineLength; op_idx++) {
+			auto *op = pipeline->GetIdxOperator(op_idx);
+			auto &op_state = *local_operator_states[op_idx - 1];
+			DataChunk &final_out = *opOutputChunks[op_idx][0];
+			final_out.Reset();
+			op->FinalExecute(*context, final_out, op_state);
+			if (final_out.size() == 0) continue;
+			// Pipe the synthesized rows through any downstream piped
+			// operators and into the sink.
+			DataChunk *cur = &final_out;
+			for (idx_t down = op_idx + 1; down + 1 < pipeline->pipelineLength;
+			     down++) {
+				auto *dop = pipeline->GetIdxOperator(down);
+				auto &dstate = *local_operator_states[down - 1];
+				DataChunk *next = opOutputChunks[down][0].get();
+				next->Reset();
+				dop->Execute(*context, *cur, *next, dstate);
+				cur = next;
+				if (cur->size() == 0) break;
+			}
+			if (cur->size() > 0) {
+				pipeline->GetSink()->Sink(*context, *cur, *local_sink_state);
+			}
+		}
+	}
+
 	// do we need pushfinalize?
 		// when limit operator reports early finish, the caches must be finished after all.
 		// we need these anyways, but i believe this can be embedded in to the regular logic.

--- a/src/execution/execution/physical_operator/cypher_physical_operator.cpp
+++ b/src/execution/execution/physical_operator/cypher_physical_operator.cpp
@@ -168,6 +168,14 @@ OperatorResultType CypherPhysicalOperator::Execute(
         "Calling Execute on a node that is not an operator!");
 }
 
+// Default FinalExecute is a no-op: emit nothing, signal FINISHED.
+OperatorResultType CypherPhysicalOperator::FinalExecute(
+    ExecutionContext &context, DataChunk &chunk, OperatorState &state) const
+{
+    chunk.SetCardinality(0);
+    return OperatorResultType::FINISHED;
+}
+
 unique_ptr<OperatorState> CypherPhysicalOperator::GetOperatorState(
     ExecutionContext &context) const
 {

--- a/src/execution/execution/physical_operator/physical_optional.cpp
+++ b/src/execution/execution/physical_operator/physical_optional.cpp
@@ -1,0 +1,41 @@
+#include "execution/physical_operator/physical_optional.hpp"
+
+namespace duckdb {
+
+class OptionalOperatorState : public OperatorState {};
+
+unique_ptr<OperatorState> PhysicalOptional::GetOperatorState(
+    ExecutionContext &context) const {
+    return make_unique<OptionalOperatorState>();
+}
+
+OperatorResultType PhysicalOptional::Execute(ExecutionContext &context,
+                                              DataChunk &input,
+                                              DataChunk &chunk,
+                                              OperatorState &state) const {
+    if (input.size() > 0) {
+        has_emitted_any_ = true;
+        chunk.Reference(input);
+    } else {
+        chunk.SetCardinality(0);
+    }
+    return OperatorResultType::NEED_MORE_INPUT;
+}
+
+OperatorResultType PhysicalOptional::FinalExecute(ExecutionContext &context,
+                                                   DataChunk &chunk,
+                                                   OperatorState &state) const {
+    if (has_emitted_any_ || null_row_emitted_) {
+        chunk.SetCardinality(0);
+        return OperatorResultType::FINISHED;
+    }
+    null_row_emitted_ = true;
+    chunk.SetCardinality(1);
+    for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
+        chunk.data[c].SetVectorType(VectorType::CONSTANT_VECTOR);
+        ConstantVector::SetNull(chunk.data[c], true);
+    }
+    return OperatorResultType::FINISHED;
+}
+
+}  // namespace duckdb

--- a/src/include/common/enums/physical_operator_type.hpp
+++ b/src/include/common/enums/physical_operator_type.hpp
@@ -43,6 +43,7 @@ enum class PhysicalOperatorType : uint8_t {
 //ETC
 	UNWIND,
 	CONST_SCAN,
+	OPTIONAL,
 	PRODUCE_RESULTS,
 	SHORTEST_PATH,
 	ALL_SHORTEST_PATH

--- a/src/include/execution/physical_operator/cypher_physical_operator.hpp
+++ b/src/include/execution/physical_operator/cypher_physical_operator.hpp
@@ -130,6 +130,14 @@ class CypherPhysicalOperator {
     virtual OperatorResultType Execute(ExecutionContext &context,
                                        DataChunk &input, DataChunk &chunk,
                                        OperatorState &state) const;
+    // EOS hook for piped operators that need to emit synthesizing rows
+    // after the upstream source has exhausted (e.g. PhysicalOptional has
+    // to emit a NULL row when the MATCH plan produced zero rows). The
+    // pipeline executor calls this exactly once per piped op after
+    // source EOS and before Sink.Combine. Default: no-op.
+    virtual OperatorResultType FinalExecute(ExecutionContext &context,
+                                             DataChunk &chunk,
+                                             OperatorState &state) const;
     virtual OperatorResultType Execute(ExecutionContext &context,
                                        DataChunk &input,
                                        vector<unique_ptr<DataChunk>> &chunks,

--- a/src/include/execution/physical_operator/physical_optional.hpp
+++ b/src/include/execution/physical_operator/physical_optional.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "common/typedef.hpp"
+#include "execution/physical_operator/cypher_physical_operator.hpp"
+#include "execution/execution_context.hpp"
+
+namespace duckdb {
+
+// Cypher OPTIONAL MATCH "atomic existence" operator (#203, #204).
+//
+// Wraps a child plan and guarantees ≥1 output row. If the child produces
+// any rows they are forwarded unchanged in streaming fashion. If the child
+// produces zero rows, exactly one row of NULLs (with the child's schema)
+// is emitted via FinalExecute after the upstream source EOS. Mirrors
+// Neo4j's `+Optional` operator that sits above the MATCH plan for a
+// standalone OPTIONAL MATCH clause.
+//
+// Implemented as a piped operator (not a pipeline break) — relies on the
+// FinalExecute hook in CypherPhysicalOperator to emit the synthetic NULL
+// row exactly once at EOS, so the matched-row path remains pass-through.
+class PhysicalOptional : public CypherPhysicalOperator {
+public:
+    explicit PhysicalOptional(Schema &sch)
+        : CypherPhysicalOperator(PhysicalOperatorType::OPTIONAL, sch) {}
+    ~PhysicalOptional() override {}
+
+    unique_ptr<OperatorState> GetOperatorState(
+        ExecutionContext &context) const override;
+    OperatorResultType Execute(ExecutionContext &context, DataChunk &input,
+                                DataChunk &chunk,
+                                OperatorState &state) const override;
+    OperatorResultType FinalExecute(ExecutionContext &context, DataChunk &chunk,
+                                     OperatorState &state) const override;
+
+    std::string ToString() const override { return "Optional"; }
+
+private:
+    // has_emitted must survive ReinitializePipeline, which destroys
+    // local_operator_states between source-group advances. Tracking it on
+    // the operator (single-threaded use only) keeps the OPTIONAL "at
+    // least one row" guarantee atomic across the whole pipeline.
+    mutable bool has_emitted_any_ = false;
+    mutable bool null_row_emitted_ = false;
+};
+
+}  // namespace duckdb

--- a/src/include/planner/logical_plan.hpp
+++ b/src/include/planner/logical_plan.hpp
@@ -103,11 +103,17 @@ public:
 	}
  	inline CExpression* getPlanExpr() { return tree_root; }
 	inline LogicalSchema* getSchema() { return &root_schema; }
-	
+
+	// When true, the physical translator appends a PhysicalOptional at
+	// the top of the duckdb pipeline so the resulting query emits ≥1 row.
+	// Set by PlanOptionalMatch for standalone OPTIONAL MATCH (#203).
+	inline bool isWrapWithOptional() const { return wrap_with_optional_; }
+	inline void setWrapWithOptional(bool b) { wrap_with_optional_ = b; }
 
 private:
 	CExpression* tree_root;
 	LogicalSchema root_schema;
+	bool wrap_with_optional_ = false;
 };
 
 

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -625,6 +625,10 @@ private:
 	vector<duckdb::SchemaFlowGraph> sfgs;
 	bool generate_sfg = false;
 	bool restrict_generate_sfg_for_unionall = false;
+	// Standalone OPTIONAL MATCH: set by the converter via LogicalPlan flag,
+	// consumed in pGenPhysicalPlan to insert PhysicalOptional before the
+	// final ProduceResults (#203, #204).
+	bool wrap_final_with_optional = false;
 
 	// dynamic schema instantiation
 	vector<CExpression *> output_expressions_to_be_refined;

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -497,6 +497,7 @@ void *Planner::_orcaExec(void *planner_ptr)
             planner->list_comprehension_registry,
             planner->next_list_comprehension_id);
         LogicalPlan *logical_plan = converter.Convert(*planner->bound_regular_query);
+        planner->wrap_final_with_optional = logical_plan->isWrapWithOptional();
         CExpression *orca_logical_plan = logical_plan->getPlanExpr();
         SUBTIMER_STOP(_orcaExec, "Logical Transform");
 

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -18,6 +18,7 @@
 #include "execution/physical_operator/physical_hash_join.hpp"
 #include "execution/physical_operator/physical_id_seek.hpp"
 #include "execution/physical_operator/physical_node_scan.hpp"
+#include "execution/physical_operator/physical_optional.hpp"
 #include "execution/physical_operator/physical_piecewise_merge_join.hpp"
 #include "execution/physical_operator/physical_produce_results.hpp"
 #include "execution/physical_operator/physical_projection.hpp"
@@ -477,6 +478,19 @@ void Planner::pGenPhysicalPlan(CExpression *orca_plan_root)
     pInitializeSchemaFlowGraph();
     duckdb::CypherPhysicalOperatorGroups final_pipeline_ops =
         *pTraverseTransformPhysicalPlan(orca_plan_root);
+
+    // Standalone OPTIONAL MATCH wrapper (#203, #204): insert PhysicalOptional
+    // between the final piped op and PhysicalProduceResults so a 0-row MATCH
+    // still emits one NULL row per Cypher 5 OPTIONAL semantics. The flag is
+    // set by the converter on the LogicalPlan and transferred via Planner
+    // member in _orcaExec.
+    if (wrap_final_with_optional) {
+        duckdb::Schema opt_schema =
+            final_pipeline_ops[final_pipeline_ops.size() - 1]->schema;
+        auto *opt_op = new duckdb::PhysicalOptional(opt_schema);
+        final_pipeline_ops.push_back(opt_op);
+        pBuildSchemaFlowGraphForUnaryOperator(opt_schema);
+    }
 
     // Append PhysicalProduceResults
     duckdb::Schema final_output_schema =

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -1270,20 +1270,22 @@ TEST_CASE("comma nodes without edges", "[ldbc][robustness]") {
         "MATCH (a:Person), (b:Tag) RETURN a.id, b.name LIMIT 1");
 }
 
-// #204: SIGSEGV on standalone OPTIONAL MATCH with fully unbound pattern.
-TEST_CASE("OPTIONAL MATCH unbound both", "[ldbc][robustness][!mayfail]") {
+// Standalone OPTIONAL MATCH (#203, #204): the prior fix synthesizes the
+// match plan directly when there is no preceding MATCH/WITH context.
+// Spec note: when the pattern doesn't match, Cypher 5 says we should
+// still emit one NULL row; we currently return zero rows in that case.
+TEST_CASE("OPTIONAL MATCH unbound both", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
-    EXPECT_NO_SEGV(
+    EXPECT_RESULT_ROWS_EQ(
         "OPTIONAL MATCH (a:Person)-[:KNOWS]-(b:Person) "
-        "RETURN a.id, b.id LIMIT 3");
+        "RETURN a.id, b.id LIMIT 3", 3);
 }
 
-// #203: SIGSEGV when OPTIONAL MATCH is the first/only clause. Should
-// return the matched row or a NULL row per Cypher OPTIONAL semantics.
-TEST_CASE("OPTIONAL MATCH first", "[ldbc][robustness][!mayfail]") {
+TEST_CASE("OPTIONAL MATCH first", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
-    EXPECT_NO_SEGV(
-        "OPTIONAL MATCH (p:Person {id: " LDBC_SAMPLE_PID_STR "}) RETURN p.firstName");
+    EXPECT_RESULT_ROWS_EQ(
+        "OPTIONAL MATCH (p:Person {id: " LDBC_SAMPLE_PID_STR "}) RETURN p.firstName",
+        1);
 }
 
 // Target: edge with unknown node variable

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -465,6 +465,9 @@ TEST_CASE("Invalid VarLen range", "[ldbc][robustness]") {
         "MATCH (a:Person)-[:KNOWS*-1..5]->(b) RETURN a.id");
 }
 
+// #214: binder now rejects backwards VarLen range up front so the same
+// failure mode applies on libc++ (was bad_array_new_length at runtime)
+// and libstdc++ (was silent zero-row execute).
 TEST_CASE("VarLen range backwards", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
     EXPECT_BINDER_REJECT(


### PR DESCRIPTION
## Summary
- New \`PhysicalOptional\` unary piped operator that mirrors Neo4j's \`+Optional\`: streams matched rows through unchanged, emits one NULL-filled row when the child produced none. Triggered by \`PlanOptionalMatch\` whenever the OPTIONAL clause has no prior MATCH/WITH context.
- New \`CypherPhysicalOperator::FinalExecute\` virtual hook that the pipeline executor calls once on each piped op after source EOS. Default is no-op, so unrelated operators pay only one virtual call per pipeline.
- The \`has_emitted_any_\` flag lives on the operator (mutable member), not on OperatorState — \`ReinitializePipeline()\` clears \`local_operator_states\` between source-group advances on multi-source queries, and per-state tracking would lose the flag mid-execution and emit a spurious NULL after real rows had already landed in the sink.

## Why this shape
The first attempt synthesized an empty-schema CLogicalConstTableGet as the implicit prior context and let the existing LOJ path do the work. That tripped a runtime \`ExprVerifyMismatch\` because our \`PhysicalConstScan\` translator promotes an empty-schema CTG to a 1-column INTEGER row and that dummy column pollutes the LOJ output schema. Neo4j sidesteps this with a dedicated Optional operator that wraps the match plan — same idea here. Buffering would've been the alternative (sink+source pair) but is unnecessary once we add the streaming \`FinalExecute\` hook; PhysicalOptional now pass-throughs matched rows with \`chunk.Reference(input)\`, no copies.

Standalone OPT MATCH is the only caller today, but \`FinalExecute\` is a general extension point — future EOS-aware ops (e.g. streaming aggregates that emit a sentinel row when input is empty) can use the same hook.

## Verified
- \`OPT MATCH (p:Person {id:14}) RETURN p.firstName\` → 1 row \"Hossein\"
- \`OPT MATCH (p:Person {id:999}) RETURN p.firstName\` → 1 row NULL  (was SEGV before)
- \`OPT MATCH (a)-[:KNOWS]-(b) RETURN ... LIMIT 3\` → 3 real rows, no spurious NULL
- \`[ldbc][robustness]\`: 240/240 (231 pass + 9 mayfail-skip for remaining #87 bugs).
- \`[ldbc]\` full: 606/606 (2195 pass + 9 skip).
- \`[oss]\` 13/13, unittest 216/216, oss-supply-chain pytest 22/22.

Stacks on #212.