### PR TITLE
fix(#205): split nested property chain at last dot, not first

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -1897,8 +1897,13 @@ shared_ptr<BoundExpression> Binder::BindPropertyExpression(const ParsedPropertyE
         return looked;
     }
     // Handle chained property: a.b.c → struct_extract(struct_extract(a,'b'),'c')
+    // Split at the LAST dot so the recursion strips one level at a time.
+    // Splitting at the FIRST dot would route deeper chains (m.a.b.c with
+    // prop=c → recurse var=m, prop="a.b") into the single-field map-access
+    // branch, treating "a.b" as one field name and dereferencing NULL on
+    // execute (#205).
     if (var.find('.') != string::npos) {
-        auto dot_pos = var.find('.');
+        auto dot_pos = var.rfind('.');
         string base = var.substr(0, dot_pos);
         string mid = var.substr(dot_pos + 1);
         ParsedPropertyExpression inner(base, mid);

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -935,13 +935,17 @@ TEST_CASE("ORDER BY computed expression", "[ldbc][robustness]") {
         "ORDER BY toInteger(pid) DESC LIMIT 3");
 }
 
-// #205: SIGSEGV on nested map literal access (2+ levels of .a.b.c).
-TEST_CASE("deeply chained property access", "[ldbc][robustness][!mayfail]") {
+// #205: BindPropertyExpression was splitting the dotted variable at the
+// first dot instead of the last, so 3+ level chains routed the deeper
+// remainder into the single-field map-access branch and dereferenced
+// NULL on execute. Now resolves correctly to nested struct_extract.
+TEST_CASE("deeply chained property access", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
-    EXPECT_NO_SEGV(
+    EXPECT_RESULT_ROWS_EQ(
         "MATCH (p:Person {id: " LDBC_SAMPLE_PID_STR "}) "
         "WITH {a: {b: {c: p.firstName}}} AS nested "
-        "RETURN nested.a.b.c");
+        "RETURN nested.a.b.c",
+        1);
 }
 
 TEST_CASE("WITH WHERE on aggregation result", "[ldbc][robustness]") {


### PR DESCRIPTION
## Summary
\`BindPropertyExpression\` used to split a dotted variable at the FIRST dot to recurse. For 3+ level chains like \`m.a.b.c\`, the recursion was \`(var=\"m\", prop=\"a.b\")\`, which has no dot in the var so it fell through to the single-field map-access branch and asked struct_extract to find a field literally named \`\"a.b\"\` on \`m\`. That returns NULL, and the outer struct_extract then dereferenced NULL at execute time → SEGV (#205). Two-level access happened to work because the first-dot split yielded the correct shape.

Split at the LAST dot instead, so each recursion peels exactly one level:

\`\`\`
m.a.b.c  →  SE(BindProp(m.a.b, b), c)
           →  SE(SE(BindProp(m.a, b), c), ...)
           →  SE(SE(SE(SE(m, a), b), c), ...)  -- well-formed nested STRUCT
\`\`\`

Verified 3-level and 4-level nested map access both return the expected value. Drop \`[!mayfail]\` from \`deeply chained property access\` and assert via \`EXPECT_RESULT_ROWS_EQ\`.

## Test plan
- [x] \`MATCH (p) WITH {a:{b:{c: p.firstName}}} AS m RETURN m.a.b.c\` → 1 row \"Hossein\" (was SEGV)
- [x] \`MATCH (p) WITH {a:{b:{c:{d: p.firstName}}}} AS m RETURN m.a.b.c.d\` → 1 row \"Hossein\"
- [x] \`[ldbc]\` 606/606 (2196 pass + 8 mayfail-skip, was 9 — one fewer outstanding bug)
- [x] \`[oss]\` 13/13, unittest 216/216, oss-supply-chain pytest 22/22

Stacks on #213.