### PR TITLE
fix(#206,#207): reject ill-typed temporal / field access at binder

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -1930,6 +1930,19 @@ shared_ptr<BoundExpression> Binder::BindPropertyExpression(const ParsedPropertyE
                     "date_part", LogicalType::BIGINT, std::move(dp_args), var + "." + prop);
             }
         }
+        // Reject field access on primitives up front. Without this, the
+        // engine builds struct_extract(VARCHAR, "month") and crashes during
+        // downstream type resolution because struct_extract dereferences
+        // a NULL STRUCT child (#207).
+        if (inner_type.id() != LogicalTypeId::STRUCT &&
+            inner_type.id() != LogicalTypeId::ANY &&
+            inner_type.id() != LogicalTypeId::SQLNULL) {
+            throw BinderException(
+                "Cannot access field '" + prop + "' on " +
+                inner_type.ToString() +
+                ". Property '." + prop + "' requires STRUCT/map or " +
+                "DATE/TIMESTAMP, got " + inner_type.ToString());
+        }
         auto field_name = make_shared<BoundLiteralExpression>(Value(prop), "_field_" + prop);
         bound_expression_vector args;
         args.push_back(std::move(inner_bound));
@@ -2600,7 +2613,19 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
                             // DATE/TIMESTAMP: pass through — date_part handles these directly
                             return bound_arg;
                         }
-                        // BIGINT: epoch millis → epoch_ms(expr) → TIMESTAMP
+                        // Numeric (epoch ms): wrap in epoch_ms → TIMESTAMP.
+                        // Reject other types up front; otherwise epoch_ms is
+                        // built over an incompatible scalar and crashes
+                        // during downstream type resolution (#206).
+                        if (arg_type.id() != LogicalTypeId::BIGINT &&
+                            arg_type.id() != LogicalTypeId::INTEGER &&
+                            arg_type.id() != LogicalTypeId::UBIGINT &&
+                            arg_type.id() != LogicalTypeId::UINTEGER &&
+                            arg_type.id() != LogicalTypeId::ANY) {
+                            throw BinderException(
+                                "datetime({epochMillis: ...}) expects INTEGER, "
+                                "got " + arg_type.ToString());
+                        }
                         bound_expression_vector args;
                         args.push_back(std::move(bound_arg));
                         return make_shared<CypherBoundFunctionExpression>(

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -835,21 +835,21 @@ TEST_CASE("NOT pattern expression in WHERE", "[ldbc][robustness]") {
         "RETURN b.id LIMIT 5");
 }
 
-// #206: SIGSEGV when datetime({epochMillis: STRING_PROP}) is bound. The
-// binder should reject the type mismatch with a catchable error.
-TEST_CASE("datetime on non-date property", "[ldbc][robustness][!mayfail]") {
+// #206: datetime({epochMillis: STRING_PROP}) now rejected at the binder
+// with a clear type-mismatch message instead of segfaulting at execute.
+TEST_CASE("datetime on non-date property", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
-    EXPECT_NO_SEGV(
+    EXPECT_BINDER_REJECT(
         "MATCH (p:Person {id: " LDBC_SAMPLE_PID_STR "}) "
         "WITH datetime({epochMillis: p.firstName}) AS d "
         "RETURN d.month");
 }
 
-// #207: SIGSEGV when .month is accessed on a non-temporal property. Type
-// check should reject this at bind time.
-TEST_CASE("temporal property on non-temporal", "[ldbc][robustness][!mayfail]") {
+// #207: chained-property field access on a primitive (e.g. VARCHAR.month)
+// is now rejected at the binder instead of segfaulting in struct_extract.
+TEST_CASE("temporal property on non-temporal", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
-    EXPECT_NO_SEGV(
+    EXPECT_BINDER_REJECT(
         "MATCH (p:Person {id: " LDBC_SAMPLE_PID_STR "}) "
         "RETURN p.firstName.month");
 }


### PR DESCRIPTION
## Summary
- **#206**: \`datetime({epochMillis: STRING_PROP})\` segfaulted because the binder wrapped a VARCHAR in \`epoch_ms\` and ORCA failed during type resolution. Add a type guard in the datetime constructor branch — INTEGER/BIGINT pass through, anything else throws \`BinderException\` with the offending type named.
- **#207**: chained-property access on a primitive like \`p.firstName.month\` segfaulted in \`struct_extract(VARCHAR, \"month\")\`. Reject up front in the chained-property branch when \`inner_type\` is not STRUCT/ANY/SQLNULL — DATE/TIMESTAMP is already handled by the temporal shortcut.

Both tests drop \`[!mayfail]\` and switch from \`EXPECT_NO_SEGV\` to \`EXPECT_BINDER_REJECT\`.

## Test plan
- [x] \`datetime({epochMillis: p.firstName})\` → \"Binder Error: datetime({epochMillis: ...}) expects INTEGER, got VARCHAR\"
- [x] \`p.firstName.month\` → \"Binder Error: Cannot access field 'month' on VARCHAR.\"
- [x] \`datetime({epochMillis: p.birthday})\` still works (returns month=3 for Person 14)
- [x] Map literal access \`m.a.b.c\` (from #205) still works on STRUCT
- [x] \`[ldbc]\` 606/606 (2200 pass + 6 skip), \`[oss]\` 13/13, unittest 216/216, oss-supply-chain pytest 22/22

Stacks on #215.