### PR TITLE
fix(#208): reject self-anchored shortestPath except the trivial *0..0

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -1175,6 +1175,32 @@ unique_ptr<BoundQueryGraph> Binder::BindPatternElement(const PatternElement& pe,
     } else if (pe.GetPathType() == PatternPathType::ALL_SHORTEST) {
         qg->SetPathType(BoundQueryGraph::PathType::ALL_SHORTEST);
     }
+    // shortestPath / allShortestPaths with both endpoints bound to the
+    // same variable: PlanShortestPath assumes distinct src/dst CColRefs
+    // and dereferences NULL when they collide. Only `*0..0` has clean
+    // semantics (the trivial zero-hop self-path, useful for constructing
+    // an empty path for `relationships()` / `length()` tests). Anything
+    // wider — `*0..N`, `*1..N`, `*` — either misleadingly short-circuits
+    // to the trivial 0-hop result (hiding the intended self-cycle search)
+    // or crashes outright. Neo4j rejects all self-anchored shortestPath
+    // by default (`forbid_shortestpath_common_nodes`); we relax that one
+    // case (#208).
+    if ((qg->GetPathType() == BoundQueryGraph::PathType::SHORTEST ||
+         qg->GetPathType() == BoundQueryGraph::PathType::ALL_SHORTEST) &&
+        !qg->GetQueryRels().empty()) {
+        const auto &rel0 = qg->GetQueryRels().front();
+        bool is_zero_only = rel0->GetLowerBound() == 0 &&
+                            rel0->GetUpperBound() == 0;
+        if (rel0->GetSrcNodeName() == rel0->GetDstNodeName() &&
+            !is_zero_only) {
+            throw BinderException(
+                "shortestPath / allShortestPaths between a node and "
+                "itself is only supported for the trivial `*0..0` "
+                "zero-hop form. For self-cycle search, rewrite as a "
+                "variable-length pattern (e.g. `(a)-[:R*]-(a)`) and "
+                "pick the shortest with ORDER BY length(path) LIMIT 1.");
+        }
+    }
     if (pe.HasPathName()) {
         qg->SetPathName(pe.GetPathName());
     }

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -810,11 +810,13 @@ TEST_CASE("shortestPath comma pattern", "[ldbc][robustness]") {
         "RETURN length(path)");
 }
 
-// #208: SIGSEGV when both endpoints of shortestPath bind to the same
-// variable. Marked [!mayfail] until the converter handles src == dst.
-TEST_CASE("shortestPath self", "[ldbc][robustness][!mayfail]") {
+// #208: self-anchored shortestPath / allShortestPaths is rejected at
+// the binder. Matches Neo4j's default behavior (which throws under
+// forbid_shortestpath_common_nodes) and prevents the converter from
+// dereferencing the colliding src/dst CColRef.
+TEST_CASE("shortestPath self", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
-    EXPECT_NO_SEGV(
+    EXPECT_BINDER_REJECT(
         "MATCH (a:Person {id: " LDBC_SAMPLE_PID_STR "}) "
         "MATCH path = shortestPath((a)-[:KNOWS*]-(a)) "
         "RETURN length(path)");


### PR DESCRIPTION
## Summary
\`shortestPath((a)-[:KNOWS*]-(a))\` segfaulted because PlanShortestPath assumes distinct src/dst CColRefs and dereferenced NULL when they collided.

Neo4j rejects every self-anchored shortestPath by default (\`forbid_shortestpath_common_nodes\`). Our engine actually handles all \`*0..N\` forms without crashing because the trivial zero-hop self-match short-circuits before the dangerous traversal path — but that creates a misleading UX: the user usually means \"find the shortest self-cycle of length 1..N\" and gets a length-0 result that silently hides the intent.

The one form with clean, unambiguous semantics is **\`*0..0\`** — the trivial zero-hop path, which is also the only Cypher syntax for constructing an empty path. test_ldbc_filter's \`relationships(path) returns empty list for zero-hop path\` test depends on it.

Reject every self-anchored shortestPath / allShortestPaths at the binder unless \`lower == upper == 0\`. Error message points the user to the VarLen + \`ORDER BY length(path) LIMIT 1\` rewrite.

## Test plan
- [x] \`shortestPath((a)-[:KNOWS*]-(a))\` → clean BinderException (was SEGV)
- [x] \`shortestPath((a)-[:KNOWS*0..3]-(a))\` → BinderException (formerly misleadingly returned length=0)
- [x] \`allShortestPaths((p)-[:KNOWS*0..0]-(p))\` → still returns 1 length-0 row (existing test_ldbc_filter case)
- [x] \`shortestPath((a:Person {id:14})-[:KNOWS*]-(b:Person {id:16}))\` (distinct endpoints) still works
- [x] \`[ldbc]\` 606/606 (2202 pass + 5 skip — one more #87 SEGV gone), \`[oss]\` 13/13, unittest 216/216, oss-supply-chain pytest 22/22

Stacks on #216.