### PR TITLE
fix(#210): enforce same-variable constraint on self-loop edge pattern

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -2081,8 +2081,15 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                         (*subquery_corr_keys)[rhs_name] = {edge_name, rhs_edge_key};
                     }
                     hop_plan = lhs_plan;
-                } else if (is_lhs_bound && is_rhs_bound) {
-                    // Both bound: add filter edge.rhs_key = rhs.id
+                } else if ((is_lhs_bound && is_rhs_bound) ||
+                           lhs_name == rhs_name) {
+                    // Both bound, OR self-loop pattern (rhs same variable as
+                    // lhs): rhs is already present in lhs_plan (via A-join-R
+                    // or earlier). Add the equality filter edge.rhs_key =
+                    // rhs.id instead of scanning a fresh rhs node — that
+                    // fresh scan would otherwise drop the same-variable
+                    // identity constraint and return all matching edges
+                    // regardless of whether src == dst (#210).
                     hop_plan = lhs_plan;
                     CExpression *sel_expr = CUtils::PexprLogicalSelect(
                         mp_, lhs_plan->getPlanExpr(),

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -488,6 +488,25 @@ TEST_CASE("Self-loop pattern", "[ldbc][robustness]") {
         "MATCH (n:Person)-[:KNOWS]->(n) RETURN n.id", 0);
 }
 
+// #210 positive case: synthesize one self-KNOWS edge in the delta store,
+// confirm the same-variable constraint actually finds it. Within one
+// session the delta store returns a single match (Neo4j-correct). Across
+// sessions the bidirectional CSR replay double-counts the edge (#220),
+// but that path isn't exercised here.
+TEST_CASE("Self-loop pattern with synthesized edge",
+          "[ldbc][robustness]") {
+    SKIP_IF_NO_DB();
+    try {
+        qr->run("MATCH (a:Person {id: " LDBC_SAMPLE_PID_STR "}), "
+                "(b:Person {id: " LDBC_SAMPLE_PID_STR "}) "
+                "CREATE (a)-[:KNOWS]->(b)");
+    } catch (...) {}
+    auto r = qr->run("MATCH (n:Person)-[:KNOWS]->(n) RETURN n.id",
+                     {qtest::ColType::INT64});
+    qr->clearDelta();
+    CHECK(r.size() == 1);
+}
+
 // Anonymous endpoints are valid Cypher; ()-[r]->() returns all edge rows.
 TEST_CASE("Dangling edge", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -479,11 +479,10 @@ TEST_CASE("VarLen range backwards", "[ldbc][robustness]") {
 // 4. Invalid pattern structures
 // ============================================================
 
-// #210: same-variable on both ends of an edge should constrain src == dst.
-// Engine currently returns all KNOWS edges (88) instead of self-loops only
-// (0 on LDBC mini). Marked [!mayfail] until the same-binding constraint
-// is enforced for non-VarLen patterns.
-TEST_CASE("Self-loop pattern", "[ldbc][robustness][!mayfail]") {
+// #210: same-variable on both ends of an edge now constrains src == dst.
+// `(n)-[:KNOWS]->(n)` used to return all 88 KNOWS edges; now correctly
+// returns the 0 self-loops the LDBC mini fixture contains.
+TEST_CASE("Self-loop pattern", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
     EXPECT_RESULT_ROWS_EQ(
         "MATCH (n:Person)-[:KNOWS]->(n) RETURN n.id", 0);


### PR DESCRIPTION
## Summary
\`MATCH (n:Person)-[:KNOWS]->(n) RETURN n.id\` returned 88 rows (every KNOWS edge in LDBC mini) instead of 0 (the count of actual self-loops in the fixture). \`PlanRegularMatch\`'s R-join-B unbound-rhs branch built a fresh scan of the rhs node and joined \`edge._tid = fresh_n._id\` — the fresh scan was independent of the lhs scan, so the (a, b) pair was never constrained to a == b.

When \`lhs_name == rhs_name\`, rhs is conceptually the same node as lhs and is already present in lhs_plan after A-join-R. Route this case to the existing both-bound branch, which emits a Select filter \`edge.rhs_key = lhs.n.id\`. Since \`rhs_name == lhs_name\`, both lookups resolve to the same ColRef in lhs_plan's schema and the filter becomes the desired \`edge.tid = n.id\` identity check.

## Test plan
- [x] \`MATCH (n:Person)-[:KNOWS]->(n) RETURN n.id\` → 0 rows (matches Neo4j on the same fixture; was 88)
- [x] \`MATCH (a:Person {id:14})-[:KNOWS]->(a) RETURN a.id\` → 0 rows
- [x] \`MATCH (a:Person)-[:KNOWS]->(b:Person {id:16}) RETURN a.id, b.id\` — distinct endpoints unaffected
- [x] \`[ldbc]\` 606/606 (2204 pass + 3 skip — one more #87 wrong-result gone), \`[oss]\` 13/13, unittest 216/216, oss-supply-chain pytest 22/22

Stacks on #218.