### PR TITLE
fix(#220): skip backward AdjListDelta insert for self-loop edges

### DIFF
--- a/src/storage/wal.cpp
+++ b/src/storage/wal.cpp
@@ -331,7 +331,13 @@ void LogAndApplyInsertEdge(WALWriter* wal, DeltaStore& ds,
     // Write-ahead: durable record first, then in-memory apply.
     if (wal) wal->LogInsertEdge(edge_partition_id, src_vid, dst_vid, edge_id);
     ds.GetAdjListDelta(edge_partition_id).InsertEdge(src_vid, dst_vid, edge_id);
-    ds.GetAdjListDelta(edge_partition_id).InsertEdge(dst_vid, src_vid, edge_id);
+    // Backward index entry keeps `(b)-[]->(a)` queries reachable for
+    // undirected edges. For a self-loop (src == dst) it would land in
+    // the same adj list with the same (dst, eid), causing the scanner
+    // to emit the same physical edge twice (#220).
+    if (src_vid != dst_vid) {
+        ds.GetAdjListDelta(edge_partition_id).InsertEdge(dst_vid, src_vid, edge_id);
+    }
 }
 
 void WALWriter::LogCheckpointBegin() {
@@ -698,7 +704,10 @@ idx_t WALReader::Replay(const std::string &db_path, DeltaStore &ds,
                 uint64_t dst = MsReadU64(ms);
                 uint64_t eid = MsReadU64(ms);
                 ds.GetAdjListDelta(epid).InsertEdge(src, dst, eid);
-                ds.GetAdjListDelta(epid).InsertEdge(dst, src, eid);
+                // Same self-loop dedup as LogAndApplyInsertEdge (#220).
+                if (src != dst) {
+                    ds.GetAdjListDelta(epid).InsertEdge(dst, src, eid);
+                }
                 // Restore global edge counter so future allocations don't
                 // collide with IDs already on disk (supports both legacy and
                 // synthetic edge-ID formats).


### PR DESCRIPTION
## Summary
\`LogAndApplyInsertEdge\` (live CREATE) and the WAL replay path both insert each new edge into the forward (src→dst) and backward (dst→src) adjacency indexes so undirected queries reach the edge from either end. For a self-loop (src == dst), both inserts land in the same adj list with the same (dst, eid) entry — \`AdjListDelta::InsertEdge\` is \`push_back\` with no dedup — so the scanner emits the same physical edge twice. A Person 14 self-KNOWS query returns 2 rows in TurboLynx where Neo4j returns 1.

Discovered while writing the positive test for #210. The same-variable constraint from #210 (\`edge.tid = lhs.n.id\`) correctly identifies that a self-loop edge matches; the double-insert at the storage layer is what makes it match twice.

Skip the backward insert when \`src == dst\` at both call sites (live and replay).

## Test plan
- [x] Cross-session: \`CREATE (a {id:14})-[:KNOWS]->(a)\` in one shell, then \`MATCH (n)-[r:KNOWS]->(n) RETURN n.id, r._id\` in another → 1 row, single \`_id\`.
- [x] Same-session inline test (added in #219) — unchanged, still 1 row.
- [x] Non-self-loop CREATE still indexed both ways: \`CREATE (a)-[:KNOWS]->(b)\` followed by \`MATCH (b)<-[]-(a) RETURN b\` still works.
- [x] \`[ldbc]\` 606/606 (2205 pass + 3 skip), \`[oss]\` 13/13, unittest 216/216, oss-supply-chain pytest 22/22.

Stacks on #219.