### PR TITLE
fix(#211): reject negative / non-integer SKIP/LIMIT and throw on /0

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -1740,26 +1740,40 @@ unique_ptr<BoundProjectionBody> Binder::BindProjectionBody(
         body->SetOrderBy(std::move(order_items));
     }
 
-    // SKIP / LIMIT (literal integers only for now)
-    if (proj.HasSkip()) {
-        auto* skip_expr = proj.GetSkip();
-        if (skip_expr && skip_expr->GetExpressionClass() == ExpressionClass::CONSTANT) {
-            auto& cv = static_cast<const ConstantExpression&>(*skip_expr);
-            if (cv.value.type().id() == LogicalTypeId::INTEGER ||
-                cv.value.type().id() == LogicalTypeId::BIGINT) {
-                body->SetSkipNumber((uint64_t)cv.value.GetValue<int64_t>());
-            }
+    // SKIP / LIMIT (literal integers only for now). Reject non-integer
+    // and negative values up front — silently casting `-1` to UINT64_MAX
+    // or ignoring a string clause used to return the full result set
+    // (#211).
+    auto bind_skip_limit = [&](const char *clause_name,
+                                const ParsedExpression *expr) -> uint64_t {
+        if (expr == nullptr) {
+            throw BinderException(std::string(clause_name) +
+                                  " expression is null");
         }
+        if (expr->GetExpressionClass() != ExpressionClass::CONSTANT) {
+            throw BinderException(std::string(clause_name) +
+                                  " expects a non-negative integer literal");
+        }
+        auto &cv = static_cast<const ConstantExpression &>(*expr);
+        auto tid = cv.value.type().id();
+        if (tid != LogicalTypeId::INTEGER && tid != LogicalTypeId::BIGINT) {
+            throw BinderException(std::string(clause_name) +
+                                  " expects a non-negative integer, got " +
+                                  cv.value.type().ToString());
+        }
+        int64_t v = cv.value.GetValue<int64_t>();
+        if (v < 0) {
+            throw BinderException(std::string(clause_name) +
+                                  " must be non-negative, got " +
+                                  std::to_string(v));
+        }
+        return (uint64_t)v;
+    };
+    if (proj.HasSkip()) {
+        body->SetSkipNumber(bind_skip_limit("SKIP", proj.GetSkip()));
     }
     if (proj.HasLimit()) {
-        auto* lim_expr = proj.GetLimit();
-        if (lim_expr && lim_expr->GetExpressionClass() == ExpressionClass::CONSTANT) {
-            auto& cv = static_cast<const ConstantExpression&>(*lim_expr);
-            if (cv.value.type().id() == LogicalTypeId::INTEGER ||
-                cv.value.type().id() == LogicalTypeId::BIGINT) {
-                body->SetLimitNumber((uint64_t)cv.value.GetValue<int64_t>());
-            }
-        }
+        body->SetLimitNumber(bind_skip_limit("LIMIT", proj.GetLimit()));
     }
 
     return body;

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -759,15 +759,18 @@ struct BinaryZeroIsNullWrapper {
 	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
 	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
 		if (right == 0) {
-			mask.SetInvalid(idx);
-			return left;
+			// Cypher throws on integer divide-by-zero (matches Neo4j);
+			// silently returning NULL hid arithmetic bugs at the engine
+			// level (#211). The hugeint code path already throws, so this
+			// brings the smaller integer types into agreement.
+			throw OutOfRangeException("Division by zero");
 		} else {
 			return OP::template Operation<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(left, right);
 		}
 	}
 
 	static bool AddsNulls() {
-		return true;
+		return false;
 	}
 };
 

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -439,22 +439,21 @@ TEST_CASE("String compared to integer", "[ldbc][robustness]") {
         "MATCH (n:Person) WHERE n.firstName = 12345 RETURN n.id");
 }
 
-// #211: negative / non-integer LIMIT and integer divide-by-zero are
-// silently accepted instead of throwing. Marked [!mayfail] until the
-// binder/runtime validates these inputs.
-TEST_CASE("Negative LIMIT", "[ldbc][robustness][!mayfail]") {
+// #211: SKIP / LIMIT now reject non-integer and negative values at the
+// binder; integer divide-by-zero throws an Out of Range error at execute.
+TEST_CASE("Negative LIMIT", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
     EXPECT_BINDER_REJECT(
         "MATCH (n:Person) RETURN n.id LIMIT -1");
 }
 
-TEST_CASE("String LIMIT", "[ldbc][robustness][!mayfail]") {
+TEST_CASE("String LIMIT", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
     EXPECT_BINDER_REJECT(
         "MATCH (n:Person) RETURN n.id LIMIT 'abc'");
 }
 
-TEST_CASE("Division by zero", "[ldbc][robustness][!mayfail]") {
+TEST_CASE("Division by zero", "[ldbc][robustness]") {
     SKIP_IF_NO_DB();
     EXPECT_BINDER_REJECT(
         "MATCH (n:Person) RETURN n.id / 0");


### PR DESCRIPTION
## Summary
Three validation gaps surfaced by the #87 audit, all returning silent wrong results:
- \`LIMIT -1\`  → silently cast to UINT64_MAX, returned all rows
- \`LIMIT 'abc'\` → bind silently skipped, returned all rows
- \`n.id / 0\`  → division silently produced a NULL row

**SKIP / LIMIT**: centralize the check in a \`bind_skip_limit\` lambda. Throws \`BinderException\` for null exprs, non-CONSTANT operands (catches \`-1\` which the parser produces as \`-(1)\`), non-integer types, and negative values. Error messages name the offending value.

**Divide-by-zero**: the \`BinaryZeroIsNullWrapper\` for the small integer types (TINYINT…UBIGINT) used to return the LHS with a SetInvalid validity mask, so the result became NULL. The hugeint code path already throws \`Hugeint division by zero!\`; bring the smaller integers into line by throwing \`OutOfRangeException(\"Division by zero\")\` and flipping \`AddsNulls\` to \`false\`. Matches Neo4j's \`/ by zero\` semantics.

Drop \`[!mayfail]\` from all three #211 tests.

## Final #87 status
After this PR, every \`[!mayfail]\` tag introduced by the audit is gone:

| Issue | Description | Status |
|-------|-------------|--------|
| #203 | OPTIONAL MATCH standalone SEGV | merged |
| #204 | OPTIONAL MATCH unbound SEGV | merged |
| #205 | nested map literal access SEGV | merged |
| #206 | datetime non-numeric SEGV | merged |
| #207 | temporal access on non-temporal SEGV | merged |
| #208 | shortestPath self-anchor SEGV | merged |
| #209 | bare MATCH SEGV | merged |
| #210 | self-loop wrong cardinality | merged |
| #211 | LIMIT / divby0 validation gaps | **this PR** |

(#214 backwards VarLen range + #220 self-loop CSR dedup were filed and fixed along the way.)

## Test plan
- [x] \`LIMIT -1\`, \`LIMIT 'abc'\`, \`SKIP -5\` all throw \`BinderException\`
- [x] \`RETURN 10 / 2\` returns 5 (sanity)
- [x] \`RETURN n.id / 0\` throws \`OutOfRangeException: Division by zero\`
- [x] \`[ldbc]\` 606/606 (2208 pass + 0 skipped — every #87 tag gone)
- [x] \`[oss]\` 13/13, unittest 216/216, oss-supply-chain pytest 22/22

Stacks on #221.