### PR TITLE
docs: mark v1.0.0 release (VLDB 2026 submission)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable releases of TurboLynx are recorded here.
+
+## v1.0.0 — 2025-12-02
+
+Initial public release. State of the codebase at the time of the VLDB 2026
+paper submission ("TurboLynx: an analytical graph database for schemaless
+property graphs").

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,8 @@ hide:
   </a>
 </div>
 
+<p style="font-size:.78rem;opacity:.6;margin-top:.5rem;">TurboLynx v1.0 &middot; Released December 2, 2025</p>
+
 </div>
 <div class="tl-welcome-demo">
 


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` with the initial `v1.0.0` entry, tied to the VLDB 2026 paper submission date (2025-12-02).
- Add a small version line ("TurboLynx v1.0 · Released December 2, 2025") under the VLDB box on the docs landing page (`docs/index.md`).

A matching annotated git tag `v1.0.0` has been created locally on commit `20f7534b7` (closest commit to the 2025-12-02 submission). The tag is not pushed by this PR — push separately (`git push origin v1.0.0`) once the tag target is confirmed.

## Test plan
- [ ] Render the docs site locally (`mkdocs serve`) and verify the version line shows under the VLDB box on the landing page without breaking the hero layout (desktop + mobile widths).
- [ ] Confirm `CHANGELOG.md` renders correctly on GitHub.
- [ ] Decide whether `v1.0.0` should tag `20f7534b7` (2025-12-01) or a different commit, then push the tag.