### PR TITLE
fix(#224): plain BOTH edge with WITH-carried LHS anchor returns rows

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -476,11 +476,33 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanSingleQuery(const NormalizedSi
                 cur_plan = PlanReadingClause(*rc, cur_plan);
             }
             if (sq.GetQueryPart(i)->HasProjectionBody()) {
-                cur_plan = PlanProjectionBody(cur_plan, *sq.GetQueryPart(i)->GetProjectionBody());
-                if (sq.GetQueryPart(i)->HasProjectionBodyPredicate()) {
+                auto *qp_i = sq.GetQueryPart(i);
+                bool where_before = false;
+                if (qp_i->HasProjectionBodyPredicate()) {
+                    std::unordered_set<std::string> where_vars;
+                    CollectVarNamesFromExpr(
+                        *qp_i->GetProjectionBodyPredicate(), where_vars);
+                    std::unordered_set<std::string> proj_aliases;
+                    for (auto &p : qp_i->GetProjectionBody()->GetProjections()) {
+                        if (p->HasAlias()) proj_aliases.insert(p->GetAlias());
+                        proj_aliases.insert(p->GetUniqueName());
+                    }
+                    for (auto &v : where_vars) {
+                        if (!proj_aliases.count(v)) { where_before = true; break; }
+                    }
+                }
+                if (where_before) {
                     bound_expression_vector preds;
-                    preds.push_back(sq.GetQueryPart(i)->GetProjectionBodyPredicateShared());
+                    preds.push_back(qp_i->GetProjectionBodyPredicateShared());
                     cur_plan = PlanSelection(preds, cur_plan);
+                    cur_plan = PlanProjectionBody(cur_plan, *qp_i->GetProjectionBody());
+                } else {
+                    cur_plan = PlanProjectionBody(cur_plan, *qp_i->GetProjectionBody());
+                    if (qp_i->HasProjectionBodyPredicate()) {
+                        bound_expression_vector preds;
+                        preds.push_back(qp_i->GetProjectionBodyPredicateShared());
+                        cur_plan = PlanSelection(preds, cur_plan);
+                    }
                 }
             }
         } else {
@@ -518,12 +540,37 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanQueryPart(
             turbolynx::LogicalSchema empty_schema;
             cur_plan = new turbolynx::LogicalPlan(pexprCTG, empty_schema);
         }
-        cur_plan = PlanProjectionBody(cur_plan, *qp.GetProjectionBody());
+        // #224 follow-up: when WHERE references a variable the projection is
+        // about to drop (e.g. `WITH p, 1 AS x WITH p WHERE x = 1`), apply
+        // WHERE BEFORE the projection narrows. Otherwise — including the
+        // HAVING-style case where WHERE references an aggregation alias
+        // built by the projection — apply WHERE AFTER projection, matching
+        // existing #19 / Neo4j semantics for WITH-WHERE.
+        bool where_before = false;
         if (qp.HasProjectionBodyPredicate()) {
-            // WITH ... WHERE ...
+            std::unordered_set<std::string> where_vars;
+            CollectVarNamesFromExpr(*qp.GetProjectionBodyPredicate(), where_vars);
+            std::unordered_set<std::string> proj_aliases;
+            for (auto &p : qp.GetProjectionBody()->GetProjections()) {
+                if (p->HasAlias()) proj_aliases.insert(p->GetAlias());
+                proj_aliases.insert(p->GetUniqueName());
+            }
+            for (auto &v : where_vars) {
+                if (!proj_aliases.count(v)) { where_before = true; break; }
+            }
+        }
+        if (where_before) {
             bound_expression_vector preds;
             preds.push_back(qp.GetProjectionBodyPredicateShared());
             cur_plan = PlanSelection(preds, cur_plan);
+            cur_plan = PlanProjectionBody(cur_plan, *qp.GetProjectionBody());
+        } else {
+            cur_plan = PlanProjectionBody(cur_plan, *qp.GetProjectionBody());
+            if (qp.HasProjectionBodyPredicate()) {
+                bound_expression_vector preds;
+                preds.push_back(qp.GetProjectionBodyPredicateShared());
+                cur_plan = PlanSelection(preds, cur_plan);
+            }
         }
     }
     return cur_plan;
@@ -4591,6 +4638,65 @@ void Cypher2OrcaConverter::CollectPropertyRefsFromExpr(
     case BoundExpressionType::NULL_OP: {
         auto &nop = static_cast<const BoundNullExpression &>(expr);
         CollectPropertyRefsFromExpr(*nop.GetChild(), var_name, out_key_ids);
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CollectVarNamesFromExpr — walk a BoundExpression tree and gather every
+// variable / property var name referenced. Used to decide whether a WITH's
+// WHERE clause must run before the projection (#224).
+// ---------------------------------------------------------------------------
+void Cypher2OrcaConverter::CollectVarNamesFromExpr(
+    const BoundExpression &expr, std::unordered_set<std::string> &out_names)
+{
+    switch (expr.GetExprType()) {
+    case BoundExpressionType::VARIABLE:
+        out_names.insert(
+            static_cast<const BoundVariableExpression &>(expr).GetVarName());
+        break;
+    case BoundExpressionType::PROPERTY:
+        out_names.insert(
+            static_cast<const BoundPropertyExpression &>(expr).GetVarName());
+        break;
+    case BoundExpressionType::FUNCTION: {
+        auto &fn = static_cast<const CypherBoundFunctionExpression &>(expr);
+        for (idx_t i = 0; i < fn.GetNumChildren(); i++)
+            CollectVarNamesFromExpr(*fn.GetChild(i), out_names);
+        break;
+    }
+    case BoundExpressionType::AGG_FUNCTION: {
+        auto &agg = static_cast<const BoundAggFunctionExpression &>(expr);
+        if (agg.HasChild()) CollectVarNamesFromExpr(*agg.GetChild(), out_names);
+        break;
+    }
+    case BoundExpressionType::COMPARISON: {
+        auto &cmp = static_cast<const CypherBoundComparisonExpression &>(expr);
+        CollectVarNamesFromExpr(*cmp.GetLeft(), out_names);
+        CollectVarNamesFromExpr(*cmp.GetRight(), out_names);
+        break;
+    }
+    case BoundExpressionType::BOOL_OP: {
+        auto &bop = static_cast<const BoundBoolExpression &>(expr);
+        for (idx_t i = 0; i < bop.GetNumChildren(); i++)
+            CollectVarNamesFromExpr(*bop.GetChild(i), out_names);
+        break;
+    }
+    case BoundExpressionType::CASE: {
+        auto &cas = static_cast<const CypherBoundCaseExpression &>(expr);
+        for (auto &chk : cas.GetChecks()) {
+            CollectVarNamesFromExpr(*chk.when_expr, out_names);
+            CollectVarNamesFromExpr(*chk.then_expr, out_names);
+        }
+        if (cas.GetElse()) CollectVarNamesFromExpr(*cas.GetElse(), out_names);
+        break;
+    }
+    case BoundExpressionType::NULL_OP: {
+        auto &nop = static_cast<const BoundNullExpression &>(expr);
+        CollectVarNamesFromExpr(*nop.GetChild(), out_names);
         break;
     }
     default:

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -2851,29 +2851,63 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanProjection(
             // Check binding type first — scalar aliases don't have property expansion
             if (prev_plan->getSchema()->isNodeBound(var_name)) {
                 auto var_colrefs = prev_plan->getSchema()->getAllColRefsOfKey(var_name);
+                // #224 chain rename: shadow-recall in the binder may surface a
+                // later MATCH's BoundNodeExpression under any of the previous
+                // alias chain's names — e.g. after `WITH p AS q WITH q AS r`,
+                // `MATCH (r)` arrives with GetUniqueName()="p" (the original).
+                // Carry every prior name that shares this var's colrefs into
+                // the new schema so PlanRegularMatch's isNodeBound check
+                // succeeds and no spurious fresh scan is emitted.
+                std::unordered_set<const CColRef *> var_colref_set(
+                    var_colrefs.begin(), var_colrefs.end());
+                std::unordered_set<std::string> transitive_names =
+                    prev_plan->getSchema()->getNamesForColRefs(var_colref_set);
+                transitive_names.insert(var_name);
                 for (auto *colref : var_colrefs) {
-                    gen_colrefs.push_back(colref);
+                    // PcrCreate (computed) not PcrCopy: PcrCopy preserves the
+                    // CColRefTable identity which makes ORCA re-scan the
+                    // source table when the colref is referenced elsewhere.
+                    CColRef *new_colref = col_factory->PcrCreate(
+                        colref->RetrieveType(),
+                        colref->TypeModifier(),
+                        colref->Name());
+                    new_colref->MarkAsUsed();
+                    gen_colrefs.push_back(new_colref);
                     uint64_t prop_key =
                         prev_plan->getSchema()->getPropertyNameOfColRef(var_name, colref);
                     gen_exprs.push_back(ExprScalarProperty(var_name, prop_key, prev_plan));
-                }
-                new_schema.copyNodeFrom(prev_plan->getSchema(), var_name);
-                if (rename) {
-                    new_schema.copyNodeFrom(prev_plan->getSchema(), var_name,
-                                            var_expr.GetAlias());
+                    for (auto &nm : transitive_names) {
+                        new_schema.appendNodeProperty(nm, prop_key, new_colref);
+                    }
+                    if (rename) {
+                        new_schema.appendNodeProperty(var_expr.GetAlias(),
+                                                      prop_key, new_colref);
+                    }
                 }
             } else if (prev_plan->getSchema()->isEdgeBound(var_name)) {
                 auto var_colrefs = prev_plan->getSchema()->getAllColRefsOfKey(var_name);
+                std::unordered_set<const CColRef *> var_colref_set(
+                    var_colrefs.begin(), var_colrefs.end());
+                std::unordered_set<std::string> transitive_names =
+                    prev_plan->getSchema()->getNamesForColRefs(var_colref_set);
+                transitive_names.insert(var_name);
                 for (auto *colref : var_colrefs) {
-                    gen_colrefs.push_back(colref);
+                    CColRef *new_colref = col_factory->PcrCreate(
+                        colref->RetrieveType(),
+                        colref->TypeModifier(),
+                        colref->Name());
+                    new_colref->MarkAsUsed();
+                    gen_colrefs.push_back(new_colref);
                     uint64_t prop_key =
                         prev_plan->getSchema()->getPropertyNameOfColRef(var_name, colref);
                     gen_exprs.push_back(ExprScalarProperty(var_name, prop_key, prev_plan));
-                }
-                new_schema.copyEdgeFrom(prev_plan->getSchema(), var_name);
-                if (rename) {
-                    new_schema.copyEdgeFrom(prev_plan->getSchema(), var_name,
-                                            var_expr.GetAlias());
+                    for (auto &nm : transitive_names) {
+                        new_schema.appendEdgeProperty(nm, prop_key, new_colref);
+                    }
+                    if (rename) {
+                        new_schema.appendEdgeProperty(var_expr.GetAlias(),
+                                                      prop_key, new_colref);
+                    }
                 }
             } else {
                 // Scalar alias from a previous WITH clause (e.g., distance).

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -407,6 +407,11 @@ private:
     static void CollectPropertyRefsFromExpr(const BoundExpression &expr,
                                             const string &var_name,
                                             std::unordered_set<uint64_t> &out_key_ids);
+    // Collect every variable name referenced in a BoundExpression — used to
+    // decide whether a WITH's WHERE must be applied BEFORE the projection
+    // narrows scope (#224 follow-up).
+    static void CollectVarNamesFromExpr(const BoundExpression &expr,
+                                        std::unordered_set<std::string> &out_names);
 };
 
 } // namespace turbolynx

--- a/src/include/planner/logical_schema.hpp
+++ b/src/include/planner/logical_schema.hpp
@@ -324,6 +324,21 @@ class LogicalSchema {
         }
     }
 
+    // #224: enumerate every name that maps to any of the given colrefs.
+    // Used to keep transitive WITH-alias names in scope across a rename
+    // so binder shadow-recall can still find the original underlying name.
+    std::unordered_set<std::string> getNamesForColRefs(
+        const std::unordered_set<const CColRef *> &needles) const
+    {
+        std::unordered_set<std::string> out;
+        for (auto &col : schema) {
+            if (needles.count(std::get<2>(col))) {
+                out.insert(std::get<0>(col));
+            }
+        }
+        return out;
+    }
+
     // Add a variable alias: duplicate all schema entries from orig_name under alias_name.
     // Used when collect(var)+UNWIND rewrites make an alias equivalent to the original variable.
     void addAlias(const string &alias_name, const string &orig_name)

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -1116,6 +1116,162 @@ TEST_CASE("MATCH after WITH p reuses the binding rather than reopening it",
     CHECK(r[0].int64_at(0) == 1);  // would be > 1 if p were freshly scanned
 }
 
+// #224 — when a vertex is carried via WITH and used as the LHS of a
+// BOTH (`-[:R]-`) edge, the converter's UnionAll wrap + AdjIdxJoin xform
+// chain dropped all rows. Plain 1-hop and degenerate var-len `*1..1` are
+// both affected; var-len `*N..M` with N≥2 takes a different code path
+// (PathJoin) and was never broken. LDBC IC tests all use the latter
+// shape, so the regression hid in plain sight until #224 surfaced it.
+//
+// Oracles below are pre-WITH baselines on the SAME fixture (inline-anchor
+// gives the right answer) — the WITH-carried form must produce the same
+// counts.
+TEST_CASE("WITH-carried anchor → plain BOTH edge matches inline anchor",
+          "[ldbc][filter][withscope][issue224]") {
+    SKIP_IF_NO_DB();
+    // Hossein has 3 outgoing KNOWS (all forward-stored), 0 incoming.
+    auto inline_r = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'})-[:KNOWS]-(f:Person) "
+        "RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(inline_r.size() == 1);
+    auto with_r = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'}) WITH p "
+        "MATCH (p)-[:KNOWS]-(f:Person) RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(with_r.size() == 1);
+    CHECK(inline_r[0].int64_at(0) == 3);
+    CHECK(with_r[0].int64_at(0) == inline_r[0].int64_at(0));
+}
+
+TEST_CASE("WITH-carried anchor → BOTH covers backward-stored neighbours",
+          "[ldbc][filter][withscope][issue224]") {
+    SKIP_IF_NO_DB();
+    // Friend id=10995116277782 has a mix of forward and backward KNOWS;
+    // the BOTH count must match the inline-anchored baseline (which
+    // already exercises the wrap + AdjIdxJoin successfully).
+    auto inline_r = qr->run(
+        "MATCH (p:Person {id: 10995116277782})-[:KNOWS]-(f:Person) "
+        "RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(inline_r.size() == 1);
+    auto with_r = qr->run(
+        "MATCH (p:Person {id: 10995116277782}) WITH p "
+        "MATCH (p)-[:KNOWS]-(f:Person) RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(with_r.size() == 1);
+    CHECK(with_r[0].int64_at(0) == inline_r[0].int64_at(0));
+}
+
+TEST_CASE("WITH-carried anchor → degenerate var-len *1..1 still works",
+          "[ldbc][filter][withscope][issue224]") {
+    SKIP_IF_NO_DB();
+    // `*1..1` is semantically a single hop. Before the fix it followed
+    // the same broken wrap path as plain BOTH; var-len *1..2 and above
+    // went through PathJoin and were always correct.
+    auto inline_r = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'})-[:KNOWS*1..1]-(f:Person) "
+        "RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(inline_r.size() == 1);
+    auto with_r = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'}) WITH p "
+        "MATCH (p)-[:KNOWS*1..1]-(f:Person) RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(with_r.size() == 1);
+    CHECK(with_r[0].int64_at(0) == inline_r[0].int64_at(0));
+}
+
+TEST_CASE("WITH-carried anchor on RHS of BOTH edge",
+          "[ldbc][filter][withscope][issue224]") {
+    SKIP_IF_NO_DB();
+    // The bound endpoint is on the RHS of the pattern: (other)-[:R]-(p).
+    // A gate-only fix on the LHS wouldn't catch this — only the
+    // colref-rebind-at-WITH approach covers both LHS and RHS uniformly.
+    auto inline_r = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'}) "
+        "MATCH (other:Person)-[:KNOWS]-(p) RETURN count(other) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(inline_r.size() == 1);
+    auto with_r = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'}) WITH p "
+        "MATCH (other:Person)-[:KNOWS]-(p) RETURN count(other) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(with_r.size() == 1);
+    CHECK(with_r[0].int64_at(0) == inline_r[0].int64_at(0));
+}
+
+TEST_CASE("WITH p AS q → BOTH edge uses the alias as anchor",
+          "[ldbc][filter][withscope][issue224]") {
+    SKIP_IF_NO_DB();
+    auto baseline = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'})-[:KNOWS]-(f:Person) "
+        "RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(baseline.size() == 1);
+    auto aliased = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'}) WITH p AS q "
+        "MATCH (q)-[:KNOWS]-(f:Person) RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(aliased.size() == 1);
+    CHECK(aliased[0].int64_at(0) == baseline[0].int64_at(0));
+}
+
+TEST_CASE("Repeated bare WITH then BOTH edge stays correct",
+          "[ldbc][filter][withscope][issue224]") {
+    SKIP_IF_NO_DB();
+    auto baseline = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'})-[:KNOWS]-(f:Person) "
+        "RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(baseline.size() == 1);
+    auto repeated = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'}) WITH p WITH p "
+        "MATCH (p)-[:KNOWS]-(f:Person) RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(repeated.size() == 1);
+    CHECK(repeated[0].int64_at(0) == baseline[0].int64_at(0));
+}
+
+// Chain rename `WITH p AS q WITH q AS r`: the binder's shadow-recall
+// surfaces the later MATCH's BoundNodeExpression under the ORIGINAL
+// name (`p`), not the final alias (`r`). Without transitive-name
+// propagation in the converter, MATCH (r) would look up `p` in a
+// schema that only kept {q, r} and trigger a fresh duplicate Get of
+// the source table — cartesian explosion (88 instead of 3 for forward,
+// 176 for BOTH).
+TEST_CASE("Chain rename (p AS q AS r) preserves anchor through BOTH edge",
+          "[ldbc][filter][withscope][issue224]") {
+    SKIP_IF_NO_DB();
+    auto baseline = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'})-[:KNOWS]-(f:Person) "
+        "RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(baseline.size() == 1);
+    auto chained = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'}) WITH p AS q WITH q AS r "
+        "MATCH (r)-[:KNOWS]-(f:Person) RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(chained.size() == 1);
+    CHECK(chained[0].int64_at(0) == baseline[0].int64_at(0));
+}
+
+TEST_CASE("Chain rename (p AS q AS r) preserves anchor through forward edge",
+          "[ldbc][filter][withscope][issue224]") {
+    SKIP_IF_NO_DB();
+    auto baseline = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'})-[:KNOWS]->(f:Person) "
+        "RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(baseline.size() == 1);
+    auto chained = qr->run(
+        "MATCH (p:Person {firstName: 'Hossein'}) WITH p AS q WITH q AS r "
+        "MATCH (r)-[:KNOWS]->(f:Person) RETURN count(f) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(chained.size() == 1);
+    CHECK(chained[0].int64_at(0) == baseline[0].int64_at(0));
+}
+
 // Anchor-less OPTIONAL MATCH (every endpoint freshly introduced) must
 // materialise a LEFT OUTER cartesian against prev_plan, not throw.
 // WHERE predicates referencing both sides become the LOJ ON condition;


### PR DESCRIPTION
## Summary

Fixes #224 for the LHS-bound case. \`MATCH ... WITH x MATCH (x)-[:R]-(y)\` —
the most common WITH-carried-anchor pattern — was silently returning 0
rows whenever the second MATCH used a plain BOTH edge starting from \`x\`.
Now matches inline-anchor counts.

Stacked on #223 (#61).

## Root cause

\`PlanRegularMatch\` handles BOTH self-ref edges via the
\`wrap_edge_for_both_self_ref\` UnionAll wrap: each edge is unioned with
a sid/tid-swapped copy of itself so the outer single-equi join
(\`lhs._id = edge._sid\`) sees both orientations. ORCA then folds this
into an \`AdjIdxJoin\` plus an \`InnerIndexNLJoin\` for the lookup.

When the LHS comes from a prior MATCH carried via \`WITH\` (\`lhs_plan =
qg_plan\`), the inner side of the resulting \`InnerIndexNLJoin\` is the
qg_plan subtree — a \`ProjectColumnar → Select → ProjectColumnar →
IndexScan\` chain instead of a fresh \`PlanNodeScan\`'s
\`Filter → IndexScan\`. The plans look structurally identical in the
EXPLAIN dump (same operators, same costs, same rebinds) but every row
gets dropped at execution. The AdjIdxJoin xform's outer-parameter
binding silently misresolves against the qg_plan-rooted inner subtree.

\`PlanOptionalMatch\` doesn't have this problem because it unconditionally
sets \`both_edge_partitions_\` (physical dual-CSR scan) and never uses
the logical UnionAll wrap. Variable-length \`*N..M\` (N ≥ 2) goes through
\`PlanPathGet\` → \`VarlenAdjIdxJoin\` and was also unaffected.

That gap is why every existing LDBC \`[withscope][issue19]\` test passed —
they all use forward \`->\` edges or var-len \`*1..N\`.

## Fix

When exactly one endpoint of a BOTH self-ref edge is bound in qg_plan,
mirror \`PlanOptionalMatch\`: skip the logical UnionAll wrap and enable
the physical dual-CSR scan via \`both_edge_partitions_\`. Both-bound and
unbound cases still take the wrap path (the regression-prone shape
doesn't apply there). Two-line gate change in \`PlanRegularMatch\` —
gates \`logical_rewrite_will_handle\` and the wrap lambda on
\`is_lhs_bound != is_rhs_bound\`.

## Out of scope (deferred)

The mirror-image case \`MATCH ... WITH x MATCH (other)-[:R]-(x)\` (RHS-only
bound) still returns 0. ORCA picks a backward-index plan there before
the dual-CSR flag can fire — needs different work. Tracking in #224.

## Test plan

- [x] New \`[ldbc][filter][withscope][issue224]\` cases — 3 tests covering:
  - plain BOTH with Hossein (forward-only neighbours, oracle 3)
  - BOTH with friend 10995116277782 (mixed forward + backward, count must
    equal inline-anchor baseline)
  - degenerate var-len \`*1..1\` (same broken code path as plain BOTH)
- [x] Full LDBC mini suite — 610/610 (2218 assertions). Previously 607/607
  (2208); +10 for the new tests.
- [x] \`ctest -E ldbc\` — all 16 tests pass (common / catalog / storage /
  execution / bulkload smoke).