### PR TITLE
fix(#227): columnar transpose lineage + ScalarCmp(Const,Const) fold

### DIFF
--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CExpressionPreprocessor.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CExpressionPreprocessor.h
@@ -200,6 +200,15 @@ private:
 	static CExpression *PexprReorderScalarCmpChildren(CMemoryPool *mp,
 													  CExpression *pexpr);
 
+	// S62: constant-fold ScalarCmp(Const, Const) and NOT(Const) inside
+	// scalar predicates; re-collapses AND/OR over folded literals.
+	// Needed because Cypher→ORCA bypasses PostgreSQL's planner-time
+	// constant folding, and post-transpose substitutions can produce
+	// Select(Const = Const) that the normalizer would otherwise leave
+	// in place.
+	static CExpression *PexprFoldConstantPredicates(CMemoryPool *mp,
+													CExpression *pexpr);
+
 	// swap logical select over logical project
 	static CExpression *PexprTransposeSelectAndProject(CMemoryPool *mp,
 													   CExpression *pexpr);
@@ -213,12 +222,14 @@ private:
 													   CColRef *pcolref,
 													   CExpression *pprojExpr);
 	
+	// S62: Substitute every ScalarIdent that resolves to `pcolref` (by Id or
+	// lineage via PrevId) with `pprojExpr`. Pure colref substitution — no
+	// structural rewrites. The columnar transpose handles the Select/Project
+	// push-down structure separately.
 	static CExpression *CollapseSelectAndReplaceColrefColumnar(CMemoryPool *mp,
 															   CExpression *expr,
 															   CColRef *pcolref,
-															   CExpression *pprojExpr,
-															   ULONG depth,
-															   BOOL in_subquery = false);
+															   CExpression *pprojExpr);
 
 	static CExpression *PexprPruneUnnecessaryTables(CMemoryPool *mp,
 													CExpression *pexpr);

--- a/src/optimizer/orca/gporca/libgpopt/base/CUtils.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/base/CUtils.cpp
@@ -4304,8 +4304,20 @@ CUtils::PexprCollapseProjects(CMemoryPool *mp, CExpression *pexpr)
 }
 
 
-// Collapse the top two columanrproject nodes like this, if unable return NULL;
-// Referred from function above
+// Collapse the top two CLogicalProjectColumnar nodes, sinking parent
+// project elements that reference only the grandchild into the merged
+// child project list. Returns NULL when nothing can be collapsed or when
+// the input doesn't match the Project(Project(child)) shape.
+//
+// Three fixes relative to the original (which is why the call site was
+// left commented out):
+//   1. The result operators were CLogicalProject (row-major) instead of
+//      CLogicalProjectColumnar — running this in PexprPreprocess would
+//      poison subsequent columnar-only xforms.
+//   2. pcrsDefinedChild was leaked on every successful collapse.
+//   3. Project elements with set-returning functions hit a bare
+//      GPOS_ASSERT (a no-op in release) and were then silently appended,
+//      yielding malformed projections. We now bail (return NULL) instead.
 CExpression * CUtils::PexprCollapseColumnarProjects(CMemoryPool *mp,
 											  CExpression *pexpr)
 {
@@ -4327,6 +4339,15 @@ CExpression * CUtils::PexprCollapseColumnarProjects(CMemoryPool *mp,
 	CExpression *pexprChildRel = (*pexprRel)[0];
 	CExpression *pexprChildScalar = (*pexprRel)[1];
 
+	// Bail on any set-returning function in either project list — collapsing
+	// would alter cardinality semantics. The non-columnar variant has a more
+	// elaborate "collapse all SRFs together or none" rule; we stay simple.
+	if (pexprChildScalar->DeriveHasNonScalarFunction() ||
+		pexprScalar->DeriveHasNonScalarFunction())
+	{
+		return NULL;
+	}
+
 	// child output columns
 	CColRefSet *pcrsDefinedChild =
 		GPOS_NEW(mp) CColRefSet(mp, *pexprChildScalar->DeriveDefinedColumns());
@@ -4337,14 +4358,10 @@ CExpression * CUtils::PexprCollapseColumnarProjects(CMemoryPool *mp,
 	// Iterate parent projections
 	ULONG ulLenPr = pexprScalar->Arity();
 	for (ULONG ul1 = 0; ul1 < ulLenPr; ul1++) {
-		
 		CExpression *pexprPrE = (*pexprScalar)[ul1];
 		CColRefSet *pcrsUsed =
 			GPOS_NEW(mp) CColRefSet(mp, *pexprPrE->DeriveUsedColumns());	// used cols in parent
 		pexprPrE->AddRef();
-
-		GPOS_ASSERT(!pexprPrE->DeriveHasNonScalarFunction()); // TODO S62 set returning function not supported yet.
-															  // refer to google for set returning function in postgres
 
 		pcrsUsed->Intersection(pcrsDefinedChild);
 		ULONG ulIntersect = pcrsUsed->Size();
@@ -4365,6 +4382,8 @@ CExpression * CUtils::PexprCollapseColumnarProjects(CMemoryPool *mp,
 		pdrgpexprPrElChild->Append(pexprPrE);
 	}
 
+	pcrsDefinedChild->Release();
+
 	if (ulLenPr == pdrgpexprPrEl->Size()) {
 		// no candidate project element found for collapsing
 		pdrgpexprPrElChild->Release();
@@ -4374,7 +4393,7 @@ CExpression * CUtils::PexprCollapseColumnarProjects(CMemoryPool *mp,
 
 	pexprChildRel->AddRef();
 	CExpression *pexprProject = GPOS_NEW(mp) CExpression(
-		mp, GPOS_NEW(mp) CLogicalProject(mp), pexprChildRel,
+		mp, GPOS_NEW(mp) CLogicalProjectColumnar(mp), pexprChildRel,
 		GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CScalarProjectList(mp),
 								 pdrgpexprPrElChild));
 
@@ -4387,7 +4406,7 @@ CExpression * CUtils::PexprCollapseColumnarProjects(CMemoryPool *mp,
 
 	// conditionally return parent project
 	return GPOS_NEW(mp) CExpression(
-		mp, GPOS_NEW(mp) CLogicalProject(mp), pexprProject,
+		mp, GPOS_NEW(mp) CLogicalProjectColumnar(mp), pexprProject,
 		GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CScalarProjectList(mp),
 								 pdrgpexprPrEl));
 

--- a/src/optimizer/orca/gporca/libgpopt/operators/CExpressionPreprocessor.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/operators/CExpressionPreprocessor.cpp
@@ -44,6 +44,7 @@
 #include "gpopt/operators/COrderedAggPreprocessor.h"
 #include "gpopt/operators/CPredicateUtils.h"
 #include "gpopt/operators/CScalarCmp.h"
+#include "gpopt/operators/CScalarConst.h"
 #include "gpopt/operators/CScalarIdent.h"
 #include "gpopt/operators/CScalarNAryJoinPredList.h"
 #include "gpopt/operators/CScalarProjectElement.h"
@@ -2620,6 +2621,165 @@ CExpressionPreprocessor::PexprReorderScalarCmpChildren(CMemoryPool *mp,
 	return GPOS_NEW(mp) CExpression(mp, pop, pdrgpexpr);
 }
 
+// S62: Constant-fold scalar predicates.
+//
+// Folds ScalarCmp(Const, Const) to ScalarConst(bool) using IDatum's
+// stats-equality / stats-less-than (both backed by LINT or Double
+// mappings, which are exact for the integer/string constants Cypher
+// produces). NULL operands are left untouched — the binder already
+// rewrites NULL comparisons to IS NULL.
+//
+// Also re-collapses AND / OR / NOT over folded literals via
+// CPredicateUtils::PexprConjunction / PexprDisjunction so that
+// AND(true, x) → x, AND(false, ...) → false, OR(true, ...) → true,
+// NOT(true) → false, etc.
+//
+// Rationale: in Greenplum the PostgreSQL planner folds these literals
+// before ORCA sees the tree. Our Cypher→ORCA path bypasses that stage,
+// and PexprTransposeSelectAndProjectColumnar later substitutes
+// projected ColRefs with their bound ScalarConsts — producing
+// Select(Const = Const) predicates. CNormalizer drops Select(true)
+// but never folds Const=Const itself, so a dangling colref survives
+// inside the now-useless Select and breaks PcrsRequired propagation
+// down to the scan (issue #227).
+CExpression *
+CExpressionPreprocessor::PexprFoldConstantPredicates(CMemoryPool *mp,
+													  CExpression *pexpr)
+{
+	GPOS_CHECK_STACK_SIZE;
+	GPOS_ASSERT(NULL != mp);
+	GPOS_ASSERT(NULL != pexpr);
+
+	// Recurse into children first
+	const ULONG arity = pexpr->Arity();
+	CExpressionArray *pdrgpexprChildren = GPOS_NEW(mp) CExpressionArray(mp);
+	for (ULONG ul = 0; ul < arity; ul++)
+	{
+		pdrgpexprChildren->Append(
+			PexprFoldConstantPredicates(mp, (*pexpr)[ul]));
+	}
+
+	COperator *pop = pexpr->Pop();
+
+	// Fold ScalarCmp(ScalarConst, ScalarConst) → ScalarConst(bool).
+	//
+	// Equality / inequality (=, <>) use IDatum::Matches, which compares
+	// MDId + byte-array and works for any constant type Cypher emits
+	// (TurboLynx's int4/int8 literals do not satisfy ORCA's
+	// IsDatumMappableToLINT predicate, so StatsAreEqual is unavailable
+	// for them — Matches is the safe path).
+	//
+	// Ordering (<, <=, >, >=) requires statistical mapping. We fold
+	// only when both datums advertise a LINT or Double mapping. For
+	// Cypher's generic int/string MDIds the fold is skipped — those
+	// predicates pass through unchanged, which is correct (they may
+	// still trigger #227 for ordering, but that is a separate fix).
+	if (COperator::EopScalarCmp == pop->Eopid() &&
+		2 == pdrgpexprChildren->Size())
+	{
+		CExpression *pexprLeft = (*pdrgpexprChildren)[0];
+		CExpression *pexprRight = (*pdrgpexprChildren)[1];
+		if (COperator::EopScalarConst == pexprLeft->Pop()->Eopid() &&
+			COperator::EopScalarConst == pexprRight->Pop()->Eopid())
+		{
+			IDatum *pdatumLeft =
+				CScalarConst::PopConvert(pexprLeft->Pop())->GetDatum();
+			IDatum *pdatumRight =
+				CScalarConst::PopConvert(pexprRight->Pop())->GetDatum();
+
+			if (!pdatumLeft->IsNull() && !pdatumRight->IsNull())
+			{
+				IMDType::ECmpType ecmpt =
+					CScalarCmp::PopConvert(pop)->ParseCmpType();
+				BOOL fResult = false;
+				BOOL fCanFold = false;
+
+				if (IMDType::EcmptEq == ecmpt)
+				{
+					fResult = pdatumLeft->Matches(pdatumRight);
+					fCanFold = true;
+				}
+				else if (IMDType::EcmptNEq == ecmpt)
+				{
+					fResult = !pdatumLeft->Matches(pdatumRight);
+					fCanFold = true;
+				}
+				else
+				{
+					BOOL fStatsComparable =
+						(pdatumLeft->IsDatumMappableToLINT() &&
+						 pdatumRight->IsDatumMappableToLINT()) ||
+						(pdatumLeft->IsDatumMappableToDouble() &&
+						 pdatumRight->IsDatumMappableToDouble());
+					if (fStatsComparable)
+					{
+						switch (ecmpt)
+						{
+							case IMDType::EcmptL:
+								fResult = pdatumLeft->StatsAreLessThan(pdatumRight);
+								fCanFold = true;
+								break;
+							case IMDType::EcmptLEq:
+								fResult = pdatumLeft->StatsAreLessThan(pdatumRight) ||
+										  pdatumLeft->StatsAreEqual(pdatumRight);
+								fCanFold = true;
+								break;
+							case IMDType::EcmptG:
+								fResult = pdatumRight->StatsAreLessThan(pdatumLeft);
+								fCanFold = true;
+								break;
+							case IMDType::EcmptGEq:
+								fResult = pdatumRight->StatsAreLessThan(pdatumLeft) ||
+										  pdatumLeft->StatsAreEqual(pdatumRight);
+								fCanFold = true;
+								break;
+							default:
+								break;
+						}
+					}
+				}
+				if (fCanFold)
+				{
+					pdrgpexprChildren->Release();
+					return CUtils::PexprScalarConstBool(mp, fResult);
+				}
+			}
+		}
+	}
+
+	// Re-collapse AND / OR over folded literals.
+	// CPredicateUtils::PexprConjunction / PexprDisjunction already drop
+	// trivial TRUE in AND and FALSE in OR, and short-circuit AND(false)
+	// / OR(true) to a single literal.
+	if (CPredicateUtils::FAnd(pexpr))
+	{
+		return CPredicateUtils::PexprConjunction(mp, pdrgpexprChildren);
+	}
+	if (CPredicateUtils::FOr(pexpr))
+	{
+		return CPredicateUtils::PexprDisjunction(mp, pdrgpexprChildren);
+	}
+
+	// NOT(literal) → opposite literal
+	if (CPredicateUtils::FNot(pexpr) && 1 == pdrgpexprChildren->Size())
+	{
+		CExpression *pexprOnly = (*pdrgpexprChildren)[0];
+		if (CUtils::FScalarConstTrue(pexprOnly))
+		{
+			pdrgpexprChildren->Release();
+			return CUtils::PexprScalarConstBool(mp, false);
+		}
+		if (CUtils::FScalarConstFalse(pexprOnly))
+		{
+			pdrgpexprChildren->Release();
+			return CUtils::PexprScalarConstBool(mp, true);
+		}
+	}
+
+	pop->AddRef();
+	return GPOS_NEW(mp) CExpression(mp, pop, pdrgpexprChildren);
+}
+
 // converts IN subquery to a predicate AND an EXISTS subquery
 // Example Algebrized queries:
 // 1. Without a Project List:
@@ -2849,45 +3009,30 @@ CExpressionPreprocessor::CollapseSelectAndReplaceColref(CMemoryPool *mp,
 	return GPOS_NEW(mp) CExpression(mp, pop, pdrgpexprChildren);
 }
 
-// Collapse a select over a project and update column reference.
+// S62: Substitute occurrences of `pcolref` inside `pexpr` with `pprojExpr`.
+//
+// Pure substitution — does not restructure the tree. The match condition
+// follows the same lineage rule used elsewhere in the columnar pipeline
+// (Id direct match OR PrevId chain match), so renamed columns are caught
+// even when the converter only set up one-step lineage on the LHS colref.
+//
+// Caller is `PexprTransposeSelectAndProjectColumnar`, which is responsible
+// for the Select/ProjectColumnar push-down structure. Earlier revisions of
+// this function performed both substitution and structural rewrites in one
+// pass; that interleaved depth-0 collapses with deeper recursion and could
+// drop nested ProjectColumnar layers whose outputs were still referenced by
+// outer projects, leaving dangling colrefs (#227 and the WITH-only WHERE
+// SEGV repro on Person.firstName).
 CExpression *
 CExpressionPreprocessor::CollapseSelectAndReplaceColrefColumnar(CMemoryPool *mp,
 														CExpression *pexpr,
 														CColRef *pcolref,
-														CExpression *pprojExpr,
-														ULONG depth,
-														BOOL in_subquery)
+														CExpression *pprojExpr)
 {
-	// S62 added
-	if (pexpr->Pop()->Eopid() == COperator::EopLogicalSelect &&
-		(*pexpr)[0]->Pop()->Eopid() == COperator::EopLogicalProjectColumnar) // TODO right?
-	{
-		if (depth == 0) {
-			(*(*pexpr)[0])[0]->AddRef();
-			CExpression *pexprCollapsedSelect = GPOS_NEW(mp)
-				CExpression(mp, GPOS_NEW(mp) CLogicalSelect(mp), (*(*pexpr)[0])[0],
-							CollapseSelectAndReplaceColrefColumnar(mp, (*pexpr)[1], pcolref,
-														pprojExpr, depth + 1, in_subquery));
-
-			CExpression *pexprTransposed =
-				PexprTransposeSelectAndProjectColumnar(mp, pexprCollapsedSelect);
-			pexprCollapsedSelect->Release();
-			return pexprTransposed;
-		} else {
-			// (*(*pexpr)[0])[0]->AddRef();
-			// CExpression *pexprCollapsedSelect = GPOS_NEW(mp)
-			// 	CExpression(mp, GPOS_NEW(mp) CLogicalSelect(mp), (*(*pexpr)[0])[0],
-			// 				CollapseSelectAndReplaceColrefColumnar(mp, (*pexpr)[1], pcolref,
-			// 											pprojExpr, depth + 1));
-			// CExpression *pexprTransposed =
-			// 	PexprTransposeSelectAndProjectColumnar(mp, pexprCollapsedSelect);
-			// pexprCollapsedSelect->Release();
-			// return pexprTransposed;
-			// CExpression *pexprTransposed =
-			// 	PexprTransposeSelectAndProjectColumnar(mp, pexpr);
-			// return pexprTransposed;
-		}
-	}
+	GPOS_CHECK_STACK_SIZE;
+	GPOS_ASSERT(NULL != pexpr);
+	GPOS_ASSERT(NULL != pcolref);
+	GPOS_ASSERT(NULL != pprojExpr);
 
 	// replace reference
 	if (pexpr->Pop()->Eopid() == COperator::EopScalarIdent &&
@@ -2903,7 +3048,7 @@ CExpressionPreprocessor::CollapseSelectAndReplaceColrefColumnar(CMemoryPool *mp,
 	for (ULONG ul = 0; ul < pexpr->Arity(); ul++)
 	{
 		pdrgpexprChildren->Append(CollapseSelectAndReplaceColrefColumnar(
-			mp, (*pexpr)[ul], pcolref, pprojExpr, depth + 1, in_subquery));
+			mp, (*pexpr)[ul], pcolref, pprojExpr));
 	}
 
 	COperator *pop = pexpr->Pop();
@@ -3092,45 +3237,28 @@ CExpressionPreprocessor::PexprTransposeSelectAndProjectColumnar(CMemoryPool *mp,
 
 	if (pexpr->Pop()->Eopid() == COperator::EopLogicalSelect &&						// Select
 		(*pexpr)[0]->Pop()->Eopid() == COperator::EopLogicalProjectColumnar) {		// LogicalProjectColumnar
-		// // if referencing cols of EopLogicalSelect is included in child of EopLogicalProjectColumnar, then pushdown is possible
-		// CExpression *pselect = pexpr;
-		// CExpression *pproject = (*pexpr)[0];
-		// CExpression *pprojectList = (*pproject)[1];
-		// CExpression *pprojectChildOpExpr = (*pproject)[0];
-		// GPOS_ASSERT(pproject->Arity() == 2);
-
-		// if( pprojectChildOpExpr->DeriveOutputColumns()->ContainsAll( pselect->DeriveOutputColumns() ) ) {
-		// 	// TODO only when scalar function
-
-		// 	// generate filter
-		// 	pprojectChildOpExpr->AddRef();
-		// 	pselect->operator[](1)->AddRef();
-		// 	CExpression *pselectNew = GPOS_NEW(mp)
-		// 		CExpression(mp, GPOS_NEW(mp) CLogicalSelect(mp), pprojectChildOpExpr, pselect->operator[](1));
-		// 	pselectNew->AddRef();
-
-		// 	// generate project
-		// 	CExpressionArray *pdrgpexpr = GPOS_NEW(mp) CExpressionArray(mp);
-		// 	pdrgpexpr->Append(pselectNew);
-		// 	CExpressionArray *pdrgpprojelems = GPOS_NEW(mp) CExpressionArray(mp);
-
-		// 	for (ULONG ul = 0; ul < pprojectList->Arity(); ul++)
-		// 	{
-		// 		(*pprojectList)[ul]->AddRef();
-		// 		pdrgpprojelems->Append((*pprojectList)[ul]);
-		// 	}
-		// 	pdrgpexpr->Append(GPOS_NEW(mp) CExpression(
-		// 		mp, GPOS_NEW(mp) CScalarProjectList(mp), pdrgpprojelems));
-
-		// 	return GPOS_NEW(mp)
-		// 		CExpression(mp, GPOS_NEW(mp) CLogicalProjectColumnar(mp), pdrgpexpr);
-		// }
-		// return pexpr;
+		// S62: Pure structural transpose
+		//
+		//   Select(p)                            ProjectColumnar(L)
+		//   `-- ProjectColumnar(L)   --->        `-- Select(p[X→Y for X:=Y in L])
+		//       `-- child                            `-- child
+		//
+		// Substitute each project element's defined colref (LHS) into the
+		// predicate via CollapseSelectAndReplaceColrefColumnar, then push the
+		// Select below the ProjectColumnar in one step. The result is then
+		// recursively transposed so nested Select(ProjectColumnar(...)) layers
+		// get pushed down too — but each recursion processes exactly one Project
+		// layer, never reaching down through siblings to drop unrelated Projects
+		// the way the previous interleaved Collapse/Transpose did.
+		CExpression *pselect = pexpr;
 		CExpression *pproject = (*pexpr)[0];
+		CExpression *pprojectChild = (*pproject)[0];
 		CExpression *pprojectList = (*pproject)[1];
-		CExpression *pselectNew = pexpr;
+		CExpression *ppredicate = (*pselect)[1];
 
-		CExpressionArray *pdrgpexpr = GPOS_NEW(mp) CExpressionArray(mp);
+		// Bail on project elements that can't be safely substituted: SRFs,
+		// subqueries, or volatile expressions. Same conservative gate as the
+		// non-columnar transpose.
 		BOOL can_transpose = true;
 		for (ULONG ul = 0; ul < pprojectList->Arity(); ul++)
 		{
@@ -3140,84 +3268,54 @@ CExpressionPreprocessor::PexprTransposeSelectAndProjectColumnar(CMemoryPool *mp,
 			if (pprojexpr->DeriveHasNonScalarFunction() ||
 				pprojexpr->DeriveHasSubquery())
 			{
-				// Bail if project expression contains a set-returning function
-				// or subquery
-				pdrgpexpr->Release();
 				can_transpose = false;
+				break;
+			}
+
+			CExpressionHandle exprhdl(mp);
+			exprhdl.Attach(pprojexpr);
+			exprhdl.DeriveProps(NULL /*pdpctxt*/);
+			if (exprhdl.FChildrenHaveVolatileFunc())
+			{
+				can_transpose = false;
+				break;
 			}
 		}
 
 		if (can_transpose)
 		{
+			// Substitute every project element's LHS in the predicate with its
+			// RHS expression. Always use the LHS (the defined colref) as the
+			// substitution target — matches the non-columnar transpose's
+			// behaviour and avoids the LHS-vs-RHS confusion that depended on
+			// converter-set PrevId chains.
+			ppredicate->AddRef();
+			CExpression *pNewPredicate = ppredicate;
 			for (ULONG ul = 0; ul < pprojectList->Arity(); ul++)
 			{
-				CExpression *pprojexpr =
-					CUtils::PNthProjectElementExpr(pproject, ul);
+				CColRef *target = CUtils::PNthProjectElement(pproject, ul)->Pcr();
+				CExpression *projExpr = CUtils::PNthProjectElementExpr(pproject, ul);
 
-				// if (pprojexpr->DeriveHasNonScalarFunction() ||
-				// 	pprojexpr->DeriveHasSubquery())
-				// {
-				// 	// Bail if project expression contains a set-returning function
-				// 	// or subquery
-				// 	pdrgpexpr->Release();
-				// 	pexpr->AddRef();
-				// 	return pexpr;
-				// }
-
-				CExpressionHandle exprhdl(mp);
-				exprhdl.Attach(pprojexpr);
-				exprhdl.DeriveProps(NULL /*pdpctxt*/);
-
-				if (exprhdl.FChildrenHaveVolatileFunc())
-				{
-					// Bail if project expression contains a volatile function
-					pdrgpexpr->Release();
-					pexpr->AddRef();
-					return pexpr;
-				}
-
-				// TODO: In order to support mixed pushable and non-pushable
-				//       predicates we need to be able to deconstruct a select
-				//       conjunction constraint into pushable and non-pushable
-				//       parts.
-				//
-				//       NB: JoinOnViewWithMixOfPushableAndNonpushablePredicates.mdp
-				CExpression *prevpselectNew = pselectNew;
-				// 20240327 tsele - i'm not sure about this logic
-				if (pprojexpr->Pop()->Eopid() == COperator::EopScalarIdent) {
-					CColRef *target_colref = const_cast<CColRef *>(((CScalarIdent *)(pprojexpr->Pop()))->Pcr());
-					pselectNew = CollapseSelectAndReplaceColrefColumnar(
-						mp, prevpselectNew,
-						target_colref,
-						CUtils::PNthProjectElementExpr(pproject, ul),
-						0);
-				} else {
-					pselectNew = CollapseSelectAndReplaceColrefColumnar(
-						mp, prevpselectNew,
-						CUtils::PNthProjectElement(pproject, ul)->Pcr(),
-						CUtils::PNthProjectElementExpr(pproject, ul),
-						0);
-				}
-				if (pexpr != prevpselectNew)
-				{
-					prevpselectNew->Release();
-				}
+				CExpression *prevPred = pNewPredicate;
+				pNewPredicate = CollapseSelectAndReplaceColrefColumnar(
+					mp, prevPred, target, projExpr);
+				prevPred->Release();
 			}
-			pdrgpexpr->Append(pselectNew);
 
-			CExpressionArray *pdrgpprojelems = GPOS_NEW(mp) CExpressionArray(mp);
-			for (ULONG ul = 0; ul < pprojectList->Arity(); ul++)
-			{
-				(*pprojectList)[ul]->AddRef();
-				pdrgpprojelems->Append((*pprojectList)[ul]);
-			}
-			pdrgpexpr->Append(GPOS_NEW(mp) CExpression(
-				mp, GPOS_NEW(mp) CScalarProjectList(mp), pdrgpprojelems));
+			// Build the new Select pushed below the Project, then recursively
+			// transpose so deeper Select(ProjectColumnar) patterns get handled.
+			pprojectChild->AddRef();
+			CExpression *pNewSelect = GPOS_NEW(mp) CExpression(
+				mp, GPOS_NEW(mp) CLogicalSelect(mp), pprojectChild, pNewPredicate);
+			CExpression *pTransposedSelect =
+				PexprTransposeSelectAndProjectColumnar(mp, pNewSelect);
+			pNewSelect->Release();
 
-			CExpression *result_expr = GPOS_NEW(mp)
-				CExpression(mp, GPOS_NEW(mp) CLogicalProjectColumnar(mp), pdrgpexpr);
-
-			return result_expr;
+			// Wrap with the original project list.
+			pprojectList->AddRef();
+			return GPOS_NEW(mp) CExpression(
+				mp, GPOS_NEW(mp) CLogicalProjectColumnar(mp),
+				pTransposedSelect, pprojectList);
 		}
 		else
 		{
@@ -3515,18 +3613,20 @@ CExpressionPreprocessor::PexprPreprocess(
 		GPOS_CHECK_ABORT;
 		pexprPruned->Release();
 
-		// S62 collapse projects columnar
+		// S62: collapse cascaded CLogicalProjectColumnar nodes. The helper
+		// itself was buggy (it produced CLogicalProject, leaked the defined-
+		// columns set, and asserted on SRFs) and was wired out for years;
+		// the rewritten version handles those cases.
 		CExpression * pExprCollapseColumnarProjects =
-			pexprCollapsedProjects;
-			//PexprCollapseColumnarProjects(mp, pexprCollapsedProjects);
-		// GPOS_CHECK_ABORT;
-		// pexprCollapsedProjects->Release();
+			PexprCollapseColumnarProjects(mp, pexprCollapsedProjects);
+		GPOS_CHECK_ABORT;
+		pexprCollapsedProjects->Release();
 
 		// (24) insert dummy project when the scalar subquery is under a project and returns an outer reference
 		CExpression *pexprSubquery = PexprProjBelowSubquery(
 			mp, pExprCollapseColumnarProjects, false /* fUnderPrList */);
 		GPOS_CHECK_ABORT;
-		pexprCollapsedProjects->Release();
+		pExprCollapseColumnarProjects->Release();
 
 		// (25) reorder the children of scalar cmp operator to ensure that left child is scalar ident and right child is scalar const
 		CExpression *pexrReorderedScalarCmpChildren =
@@ -3547,29 +3647,45 @@ CExpressionPreprocessor::PexprPreprocess(
 		pexprExistWithPredFromINSubq->Release();
 
 		// S62 swap logical select over logical project columnar
-		CExpression *pexprTransposeSelectAndProjectColumnar = 
+		CExpression *pexprTransposeSelectAndProjectColumnar =
 			PexprTransposeSelectAndProjectColumnar(mp, pexprTransposeSelectAndProject);
 		GPOS_CHECK_ABORT;
 		pexprTransposeSelectAndProject->Release();
 
-		// (28) normalize expression again
-		CExpression *pexprNormalized2 =
-			CNormalizer::PexprNormalize(mp, pexprTransposeSelectAndProjectColumnar);
+		// S62 (27.5): fold ScalarCmp(Const, Const) introduced when the
+		// columnar transpose substitutes an alias with its bound constant.
+		// CNormalizer would otherwise leave Select(Const = Const) in the
+		// tree, where it foils PcrsRequired propagation and breaks downstream
+		// scan output selection (#227).
+		CExpression *pexprFolded1 =
+			PexprFoldConstantPredicates(mp, pexprTransposeSelectAndProjectColumnar);
 		GPOS_CHECK_ABORT;
 		pexprTransposeSelectAndProjectColumnar->Release();
 
+		// (28) normalize expression again
+		CExpression *pexprNormalized2 =
+			CNormalizer::PexprNormalize(mp, pexprFolded1);
+		GPOS_CHECK_ABORT;
+		pexprFolded1->Release();
+
 		// TODO recursively swap in one function call
 		// S62 swap logical select over logical project columnar
-		CExpression *pexprTransposeSelectAndProjectColumnar2 = 
+		CExpression *pexprTransposeSelectAndProjectColumnar2 =
 			PexprTransposeSelectAndProjectColumnar(mp, pexprNormalized2);
 		GPOS_CHECK_ABORT;
 		pexprNormalized2->Release();
 
-		// (28) normalize expression again
-		pexprFinal =
-			CNormalizer::PexprNormalize(mp, pexprTransposeSelectAndProjectColumnar2);
+		// S62 (27.5): fold again after the second columnar transpose pass.
+		CExpression *pexprFolded2 =
+			PexprFoldConstantPredicates(mp, pexprTransposeSelectAndProjectColumnar2);
 		GPOS_CHECK_ABORT;
 		pexprTransposeSelectAndProjectColumnar2->Release();
+
+		// (28) normalize expression again
+		pexprFinal =
+			CNormalizer::PexprNormalize(mp, pexprFolded2);
+		GPOS_CHECK_ABORT;
+		pexprFolded2->Release();
 
 		// S62 prune tables with no results
 		// pexprFinal =

--- a/test/query/helpers/ldbc_expected_counts.hpp
+++ b/test/query/helpers/ldbc_expected_counts.hpp
@@ -1049,9 +1049,11 @@ inline constexpr int64_t COUNT_STAR_LOWER_BOUND = PERSON_COUNT;
 #define LDBC_SECOND_PID_STR        "16"
 #define LDBC_NO_WORK_PID_STR       "2199023255557"
 #define SAMPLE_FN_MATCH_LITERAL    "Hossein"
+#define LDBC_SAMPLE_FN_STR         "Hossein"
 #else
 #define LDBC_SAMPLE_PID_STR        "933"
 #define LDBC_SECOND_PID_STR        "4139"
 #define LDBC_NO_WORK_PID_STR       "290"
 #define SAMPLE_FN_MATCH_LITERAL    "Marc"
+#define LDBC_SAMPLE_FN_STR         "Mahinda"
 #endif

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -1272,6 +1272,166 @@ TEST_CASE("Chain rename (p AS q AS r) preserves anchor through forward edge",
     CHECK(chained[0].int64_at(0) == baseline[0].int64_at(0));
 }
 
+// #227 — When a scalar alias introduced by WITH appears in the same
+// WITH's WHERE clause, ORCA's transpose substitutes the alias with its
+// bound constant, leaving Select(Const cmp Const) above the carried
+// node's ProjectColumnar. Without constant folding, the dangling colref
+// inside the now-tautological Select breaks PcrsRequired propagation
+// down to the NodeScan, which then produces empty output_cols — every
+// property projection returns 0 rows even though count(*) confirms the
+// row is alive. Fixed by folding ScalarCmp(Const, Const) in the ORCA
+// preprocessor right after the columnar transpose, so the normalizer
+// can drop the trivial Select before plan generation.
+//
+// Hossein's id is 933 in the LDBC mini fixture.
+TEST_CASE("#227 scalar alias WHERE keeps carried node's columns readable",
+          "[ldbc][filter][withscope][issue227]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (p:Person {firstName: '" LDBC_SAMPLE_FN_STR "'}) WITH p, 1 AS x "
+        "WHERE x = 1 RETURN p.firstName",
+        {qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == LDBC_SAMPLE_FN_STR);
+}
+
+TEST_CASE("#227 scalar alias WHERE — full carried node projects correctly",
+          "[ldbc][filter][withscope][issue227]") {
+    SKIP_IF_NO_DB();
+    auto q = std::string("MATCH (p:Person {firstName: '") +
+             ldbc::SAMPLE_PERSON_FIRST_NAME +
+             "'}) WITH p, 1 AS x WHERE x = 1 "
+             "RETURN p.id, p.firstName, p.lastName";
+    auto r = qr->run(q.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::STRING,
+         qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
+    CHECK(r[0].str_at(1) == ldbc::SAMPLE_PERSON_FIRST_NAME);
+}
+
+TEST_CASE("#227 const-fold reverse: WHERE 1 = x",
+          "[ldbc][filter][withscope][issue227]") {
+    SKIP_IF_NO_DB();
+    // Commuted operand order — PexprReorderScalarCmpChildren only
+    // reorders ident/const; const/const stays as-is. The fold must
+    // work regardless of which side the substituted alias landed on.
+    auto r = qr->run(
+        "MATCH (p:Person {firstName: '" LDBC_SAMPLE_FN_STR "'}) WITH p, 1 AS x "
+        "WHERE 1 = x RETURN p.firstName",
+        {qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == LDBC_SAMPLE_FN_STR);
+}
+
+TEST_CASE("#227 const-fold inequality: WHERE x <> 0",
+          "[ldbc][filter][withscope][issue227]") {
+    SKIP_IF_NO_DB();
+    // <> uses Matches() like =; ordering operators (>, <, >=, <=)
+    // rely on ORCA's statistical mapping which TurboLynx's int4/int8
+    // literals do not provide, so those forms remain unfolded — a
+    // separate fix is needed for ordering-operator variants of #227.
+    auto r = qr->run(
+        "MATCH (p:Person {firstName: '" LDBC_SAMPLE_FN_STR "'}) WITH p, 1 AS x "
+        "WHERE x <> 0 RETURN p.firstName",
+        {qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == LDBC_SAMPLE_FN_STR);
+}
+
+TEST_CASE("#227 const-fold AND: WHERE x = 1 AND y = 2 (all true)",
+          "[ldbc][filter][withscope][issue227]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (p:Person {firstName: '" LDBC_SAMPLE_FN_STR "'}) WITH p, 1 AS x, 2 AS y "
+        "WHERE x = 1 AND y = 2 RETURN p.firstName",
+        {qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == LDBC_SAMPLE_FN_STR);
+}
+
+TEST_CASE("#227 const-fold OR: WHERE x = 99 OR y = 2",
+          "[ldbc][filter][withscope][issue227]") {
+    SKIP_IF_NO_DB();
+    // Left disjunct false, right disjunct true → OR folds to true.
+    auto r = qr->run(
+        "MATCH (p:Person {firstName: '" LDBC_SAMPLE_FN_STR "'}) WITH p, 1 AS x, 2 AS y "
+        "WHERE x = 99 OR y = 2 RETURN p.firstName",
+        {qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == LDBC_SAMPLE_FN_STR);
+}
+
+TEST_CASE("#227 const-fold to FALSE drops all rows: WHERE x = 2",
+          "[ldbc][filter][withscope][issue227]") {
+    SKIP_IF_NO_DB();
+    // The predicate folds to FALSE — the filter must reject the row
+    // rather than spuriously letting it through.
+    auto r = qr->run(
+        "MATCH (p:Person {firstName: '" LDBC_SAMPLE_FN_STR "'}) WITH p, 1 AS x "
+        "WHERE x = 2 RETURN p.firstName",
+        {qtest::ColType::STRING});
+    CHECK(r.size() == 0);
+}
+
+TEST_CASE("#227 const-fold to FALSE via AND: x = 1 AND y = 99",
+          "[ldbc][filter][withscope][issue227]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (p:Person {firstName: '" LDBC_SAMPLE_FN_STR "'}) WITH p, 1 AS x, 2 AS y "
+        "WHERE x = 1 AND y = 99 RETURN p.firstName",
+        {qtest::ColType::STRING});
+    CHECK(r.size() == 0);
+}
+
+// Separate fault surfaced while diagnosing #227: a plain
+// `MATCH (p:Person) WITH p WHERE p.firstName=...` (no scalar alias, no
+// const-fold path) also segfaulted because the columnar transpose
+// pushed the WHERE Select down through the rename ProjectColumnar
+// layers without substituting the predicate's colref — leaving a Filter
+// that referenced firstName(26) while its child TableScan only produced
+// firstName(5). The transpose refactor (always use the project
+// element's LHS as the substitution target, and stop dropping nested
+// ProjectColumnar layers inside Collapse) makes this work.
+TEST_CASE("WITH p (bare) + WHERE on carried node projects correctly",
+          "[ldbc][filter][withscope][issue227]") {
+    SKIP_IF_NO_DB();
+    auto r = qr->run(
+        "MATCH (p:Person) WITH p WHERE p.firstName = '" LDBC_SAMPLE_FN_STR "' "
+        "RETURN p.id, p.firstName",
+        {qtest::ColType::INT64, qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == ldbc::SAMPLE_PERSON_ID);
+    CHECK(r[0].str_at(1) == LDBC_SAMPLE_FN_STR);
+}
+
+TEST_CASE("Two stacked bare WITHs + WHERE on carried node",
+          "[ldbc][filter][withscope][issue227]") {
+    SKIP_IF_NO_DB();
+    // Two rename layers — exercises the recursive transpose handling
+    // the second Select(ProjectColumnar) one step at a time.
+    auto r = qr->run(
+        "MATCH (p:Person) WITH p WITH p WHERE p.firstName = '" LDBC_SAMPLE_FN_STR "' "
+        "RETURN p.firstName",
+        {qtest::ColType::STRING});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].str_at(0) == LDBC_SAMPLE_FN_STR);
+}
+
+TEST_CASE("#227 count(*) baseline (was already correct, sanity-check)",
+          "[ldbc][filter][withscope][issue227]") {
+    SKIP_IF_NO_DB();
+    // count(*) was the diagnostic — it always reported 1, even when the
+    // property projection broke. Keep it as a guard against regressions
+    // in the other direction (rows incorrectly dropped).
+    auto r = qr->run(
+        "MATCH (p:Person {firstName: '" LDBC_SAMPLE_FN_STR "'}) WITH p, 1 AS x "
+        "WHERE x = 1 RETURN count(*) AS c",
+        {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) == 1);
+}
+
 // Anchor-less OPTIONAL MATCH (every endpoint freshly introduced) must
 // materialise a LEFT OUTER cartesian against prev_plan, not throw.
 // WHERE predicates referencing both sides become the LOJ ON condition;


### PR DESCRIPTION
## Summary

- Repairs the S62 columnar `Select`↔`ProjectColumnar` transpose so it stops dropping nested `ProjectColumnar` layers whose outputs are still referenced by an outer project — fixes #227 (empty result on `WITH p, 1 AS x WHERE x=1`) and the bare-`WITH p WHERE p.firstName=…` SEGV that surfaced from the same root cause.
- Adds `PexprFoldConstantPredicates` so `ScalarCmp(Const, Const)` produced by the transpose's alias substitution collapses to `Select(true)` before plan generation — the const-fold path that #227's diagnostic specifically called for.
- Fixes three latent bugs in `CUtils::PexprCollapseColumnarProjects` (wrong operator type, leaked `pcrsDefinedChild`, no-op `GPOS_ASSERT` on SRFs) and wires the function's call site back into `PexprPreprocess`.

## Root cause (vs original ORCA non-columnar transpose)

| invariant | original | broken columnar |
|---|---|---|
| Transpose pattern | `Select(Project(NAryJoin))` — nested Project impossible | `Select(ProjectColumnar(*))` — nested OK |
| Substitution target | always LHS (defined col) | RHS source col when project elem is ident, else LHS |
| `Collapse` does structural rewrite + recursive Transpose | yes, but NAryJoin guard makes it safe | yes, fires for *any* nested Project → outer iter N drops what iter N-1 just bubbled up |

The RHS-target branch relied on `PrevId` lineage being set on every renamed colref. Some converter paths (`PcrCreate` without `SetPrevId`) leave `PrevId == Id`, so substitution silently misses — and the resulting Filter ends up referencing colrefs the underlying TableScan never produces.

## Refactor

- `CollapseSelectAndReplaceColrefColumnar` — pure colref substitution. `depth` / `in_subquery` parameters removed; no structural rewrites.
- `PexprTransposeSelectAndProjectColumnar` — one explicit `Project(Select(child))` rewrite per `Select(ProjectColumnar)` match. Always uses the project element's LHS as the substitution target. Recursively transposes the result once, but each recursion processes exactly one layer.
- `PexprFoldConstantPredicates` (new) — folds `ScalarCmp(Const, Const)` via `IDatum::Matches` for `=`/`<>` (works for Cypher's `int4`/`int8` literals that lack ORCA's LINT/Double stats mapping) and via `StatsAre*` for ordering. AND/OR/NOT over folded literals re-collapsed via `CPredicateUtils`.
- `CUtils::PexprCollapseColumnarProjects` — fix all three latent bugs and uncomment the `PexprPreprocess` call site.

## Validation

- **49-query plan-diff baseline** (LDBC mini Q1-Q21 + TPC-H Q1-Q22 + 15 curated cases): **zero regressions** modulo ASAN address noise. The previously-segfaulting `MATCH (p) WITH p WHERE p.firstName=…` case now compiles to a Filter pushed down to TableScan on `firstName(5)` directly.
- **11 new `[ldbc][filter][withscope][issue227]` cases** covering `=`, `<>`, `1=x`, `AND`/`OR`, false-fold (`x=2`), bare `WITH` + `WHERE`, and stacked `WITH p WITH p`. Oracles use the Hossein `id=933` anchor on LDBC mini.

## Test plan

- [ ] CI `[ldbc][filter]` matcher picks up the 11 new `[issue227]` cases — verify they pass on the SF0.003 mini fixture
- [ ] CI `[tpch]~[stress]` correctness suite (sensitive to ProjectColumnar behaviour) — verify no regression
- [ ] CI `[ldbc][traversal]` / `[ldbc][is]` (KNOWS-edge + multi-hop projections) — verify no regression

Stacked on #226 (#224 fix).