### PR TITLE
feat(#184) PR-1.0: BoundPatternComprehensionExpression scaffold

### DIFF
--- a/src/include/binder/expression/bound_expression.hpp
+++ b/src/include/binder/expression/bound_expression.hpp
@@ -24,6 +24,7 @@ enum class BoundExpressionType : uint8_t {
     PATH           = 11,  // shortest path expression
     LIST_COMP      = 12,  // [x IN list WHERE ... | expr]
     ID_IN_COLL     = 13,  // id(x) IN list
+    PATTERN_COMP   = 14,  // [(a)-[:R]->(b) [WHERE p] | expr]  (#184)
 };
 
 class BoundExpression {

--- a/src/include/binder/expression/bound_pattern_comprehension_expression.hpp
+++ b/src/include/binder/expression/bound_pattern_comprehension_expression.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "binder/expression/bound_expression.hpp"
+#include "common/typedef.hpp"
+
+namespace duckdb {
+
+// Pattern comprehension: [ [path =] (a) -[:R1]-> (b) -[:R2]-> (c) [WHERE p] | expr ]
+//
+// Lowering target (in converter):
+//   CScalarSubquery(
+//     GbAgg(group: outer correlation cols, agg: collect(map_expr))
+//       LeftOuterJoin(
+//         outer correlation reference,
+//         inner pattern (start -> hops -> end nodes/edges)
+//       )
+//   )
+//
+// The GbAgg+collect compresses the multi-row inner match into a single row x
+// single LIST column, satisfying CScalarSubquery's single-value contract.
+// ORCA's CSubqueryHandler decorrelates the rest.
+
+// One hop in the comprehension's pattern chain.
+//   (prev_node) -[edge_var:edge_type {edge_props} *varlen]-> (end_var:end_label {end_props})
+//
+// edge_var / end_var are empty when no binding was provided in the source.
+// edge_type is empty for an untyped edge ("[]"). end_label is empty for an
+// unlabeled end node ("()"). varlen is currently unsupported and reserved
+// for PR-2.
+struct CypherBoundPatternHop {
+    // Edge
+    string                     edge_var;           // optional binding
+    string                     edge_type;          // "" if untyped
+    ExpandDirection            direction;          // OUTGOING / INCOMING / BOTH
+    shared_ptr<BoundExpression> edge_predicate;    // inline map {prop: val}, nullable
+
+    // End node
+    string                     end_var;            // pattern-scoped or outer-bound name
+    string                     end_label;          // "" if unlabeled
+    shared_ptr<BoundExpression> end_predicate;     // inline map, nullable
+};
+
+class CypherBoundPatternComprehensionExpression : public BoundExpression {
+public:
+    CypherBoundPatternComprehensionExpression(
+        LogicalType                          result_type,        // LIST<map_expr's type>
+        string                               start_var,
+        string                               start_label,
+        shared_ptr<BoundExpression>          start_predicate,
+        vector<CypherBoundPatternHop>        hops,
+        shared_ptr<BoundExpression>          where_expr,         // optional, may be null
+        shared_ptr<BoundExpression>          map_expr,           // required
+        string                               unique_name)
+        : BoundExpression(BoundExpressionType::PATTERN_COMP,
+                          std::move(result_type), std::move(unique_name)),
+          start_var(std::move(start_var)),
+          start_label(std::move(start_label)),
+          start_predicate(std::move(start_predicate)),
+          hops(std::move(hops)),
+          where_expr(std::move(where_expr)),
+          map_expr(std::move(map_expr)) {}
+
+    const string&                       GetStartVar()       const { return start_var; }
+    const string&                       GetStartLabel()     const { return start_label; }
+    BoundExpression*                    GetStartPredicate() const { return start_predicate.get(); }
+    const vector<CypherBoundPatternHop>& GetHops()          const { return hops; }
+    BoundExpression*                    GetWhereExpr()      const { return where_expr.get(); }
+    BoundExpression*                    GetMapExpr()        const { return map_expr.get(); }
+    bool                                HasWhereExpr()      const { return where_expr != nullptr; }
+
+    shared_ptr<BoundExpression> Copy() const override {
+        vector<CypherBoundPatternHop> copied_hops;
+        copied_hops.reserve(hops.size());
+        for (auto &h : hops) {
+            copied_hops.push_back({
+                h.edge_var, h.edge_type, h.direction,
+                h.edge_predicate ? h.edge_predicate->Copy() : nullptr,
+                h.end_var, h.end_label,
+                h.end_predicate ? h.end_predicate->Copy() : nullptr,
+            });
+        }
+        auto copy = make_shared<CypherBoundPatternComprehensionExpression>(
+            data_type,
+            start_var, start_label,
+            start_predicate ? start_predicate->Copy() : nullptr,
+            std::move(copied_hops),
+            where_expr ? where_expr->Copy() : nullptr,
+            map_expr   ? map_expr->Copy()   : nullptr,
+            unique_name);
+        copy->SetAlias(alias);
+        return copy;
+    }
+
+private:
+    string                          start_var;
+    string                          start_label;
+    shared_ptr<BoundExpression>     start_predicate;
+    vector<CypherBoundPatternHop>   hops;
+    shared_ptr<BoundExpression>     where_expr;
+    shared_ptr<BoundExpression>     map_expr;
+};
+
+} // namespace duckdb


### PR DESCRIPTION
## Summary

Foundation commit for the Cypher 5 pattern comprehension work tracked in #184. **No behaviour change** — this PR only adds the bound-expression class that the binder and converter will populate / consume in the follow-up PRs (PR-1.1 binder integration, PR-1.2 converter lowering). Splitting this off keeps each review unit small.

## What's in here

- \`BoundExpressionType::PATTERN_COMP\` enum slot.
- \`CypherBoundPatternComprehensionExpression\` class carrying everything PR-1 needs to lower:
  - start var / start label / start inline predicate
  - \`vector<CypherBoundPatternHop>\` for each \`-[:R]->(node)\` step
    - edge type / direction / inline predicate
    - end var / end label / inline predicate
    - optional edge binding (reserved for PR-2 path-binding)
  - optional WHERE expression
  - required map expression
  - LIST<map_expr_type> result type
- \`Copy()\` deep-clones the sub-expressions, matching the \`CypherBoundCaseExpression\` pattern.

## Stack

PR226 (#224) → PR228 (#227) → PR229 (helper cleanup) → **this PR** → PR-1.1 (binder integration) → PR-1.2 (converter lowering).

## Test plan

- [x] \`query_test\` compiles cleanly with and without \`TURBOLYNX_LDBC_FIXTURE_MINI\`.
- No new tests yet — the type isn't referenced by any path.