### PR TITLE
cleanup: trim verbose comments — Neo4j attributions, issue narrative, history

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -48,7 +48,7 @@ namespace {
 // >0 while binding inside a `__list_comprehension` body. Bare
 // `__pattern_comprehension` is only legal inside one (IC14 collapse) —
 // outside, the binder rejects it before it reaches ORCA, where the throw
-// would not unwind safely (#17, #136).
+// would not unwind safely (#136).
 thread_local int g_list_comp_bind_depth = 0;
 
 struct ListCompBindDepthGuard {
@@ -453,15 +453,14 @@ unique_ptr<NormalizedQueryPart> Binder::BindQueryPart(const QueryPart& qp, BindC
     if (wc) {
         unordered_set<string> projected_aliases;
         auto proj = BindProjectionBody(*wc->GetBody(), ctx, &projected_aliases);
-        // WITH's WHERE binds before the scope narrows: Neo4j accepts
-        // un-projected node refs here (e.g. `WITH p.id AS pid WHERE
-        // p.firstName = 'X'`) so we keep the same behavior.
+        // WITH's WHERE binds against the un-narrowed scope so it can read
+        // vars the projection drops (e.g. `WITH p.id AS pid WHERE p.firstName=…`).
         if (wc->HasWhere()) {
             auto pred = BindExpression(*wc->GetWhere(), ctx);
             nqp->SetProjectionBodyPredicate(std::move(pred));
         }
         nqp->SetProjectionBody(std::move(proj));
-        // Now drop everything the user did not carry forward (#19).
+        // Drop everything the user didn't carry forward.
         ctx.ResetToProjectedScope(projected_aliases);
     }
 
@@ -610,7 +609,7 @@ unique_ptr<BoundUnwindClause> Binder::BindUnwindClause(const UnwindClause& unwin
     // unknown key collapses to a literal SQLNULL during binding, hiding
     // the property origin from the bound tree. We detect it on the parsed
     // AST instead — directly via ParsedPropertyExpression, and through
-    // alias chains tracked in BindContext (#80, #80 follow-up).
+    // alias chains tracked in BindContext.
     const auto& dtype = expr->GetDataType();
     const auto tid = dtype.id();
     bool is_property_ref =
@@ -646,17 +645,12 @@ unique_ptr<BoundUnwindClause> Binder::BindUnwindClause(const UnwindClause& unwin
 
 // ---- CREATE clause: schema bootstrap helpers ----
 //
-// Cypher's CREATE on Neo4j implicitly creates labels/types if they don't yet
-// exist. TurboLynx historically required labels/types to exist before CREATE
-// (set up via bulk-load CSV import). The helpers below let CREATE itself
-// bootstrap a vertex or edge partition when the label/type is missing, so a
-// fresh empty workspace can be populated directly with Cypher.
-//
-// The infra mirrors CreateVertexCatalogInfos / CreateEdgeCatalogInfos in
-// src/loader/bulkload_pipeline.cpp; the only differences are:
-//   - id_key_column_idxs is left empty (no user-declared key column),
-//   - the new PropertySchema is seeded with num_tuples=1 so ORCA does not
-//     mark stats as dummy and collapse plan subtrees on the first MATCH.
+// Bootstrap a vertex/edge partition when CREATE references a missing label/type
+// so an empty workspace can be populated directly. Mirrors
+// Create{Vertex,Edge}CatalogInfos in bulkload_pipeline.cpp; differences:
+//   - id_key_column_idxs is empty (no user-declared key column)
+//   - PropertySchema is seeded with num_tuples=1 so ORCA doesn't treat stats
+//     as dummy and collapse plan subtrees on the first MATCH
 
 static LogicalType InferLogicalTypeFromValue(const Value &v) {
     if (v.IsNull()) {
@@ -1176,16 +1170,9 @@ unique_ptr<BoundQueryGraph> Binder::BindPatternElement(const PatternElement& pe,
     } else if (pe.GetPathType() == PatternPathType::ALL_SHORTEST) {
         qg->SetPathType(BoundQueryGraph::PathType::ALL_SHORTEST);
     }
-    // shortestPath / allShortestPaths with both endpoints bound to the
-    // same variable: PlanShortestPath assumes distinct src/dst CColRefs
-    // and dereferences NULL when they collide. Only `*0..0` has clean
-    // semantics (the trivial zero-hop self-path, useful for constructing
-    // an empty path for `relationships()` / `length()` tests). Anything
-    // wider — `*0..N`, `*1..N`, `*` — either misleadingly short-circuits
-    // to the trivial 0-hop result (hiding the intended self-cycle search)
-    // or crashes outright. Neo4j rejects all self-anchored shortestPath
-    // by default (`forbid_shortestpath_common_nodes`); we relax that one
-    // case (#208).
+    // Self-anchored shortestPath / allShortestPaths: PlanShortestPath assumes
+    // distinct src/dst colrefs. Only `*0..0` is well-defined (trivial zero-hop
+    // self-path); wider ranges either short-circuit misleadingly or crash.
     if ((qg->GetPathType() == BoundQueryGraph::PathType::SHORTEST ||
          qg->GetPathType() == BoundQueryGraph::PathType::ALL_SHORTEST) &&
         !qg->GetQueryRels().empty()) {
@@ -1218,10 +1205,8 @@ shared_ptr<BoundNodeExpression> Binder::BindNodePattern(const NodePattern& node,
     if (ctx.HasNode(var_name)) {
         return ctx.GetNode(var_name);
     }
-    // If the name was carried into this query part via a prior MATCH but
-    // dropped by a WITH that didn't project it, Cypher 5 reuses the same
-    // binding here instead of opening a fresh anchor-less scan (#19,
-    // matches Neo4j's semantics).
+    // Cypher 5 reuses a name dropped by a WITH instead of opening a fresh
+    // anchor-less scan when a later MATCH re-introduces it.
     if (auto recovered = ctx.RecallShadowedNode(var_name)) {
         return recovered;
     }
@@ -1255,7 +1240,7 @@ shared_ptr<BoundRelExpression> Binder::BindRelPattern(const RelPattern& rel,
     if (ctx.HasRel(var_name)) {
         return ctx.GetRel(var_name);
     }
-    // #19: see BindNodePattern.
+    // See BindNodePattern for the shadow-recall rationale.
     if (auto recovered = ctx.RecallShadowedRel(var_name)) {
         return recovered;
     }
@@ -1542,9 +1527,8 @@ shared_ptr<BoundRelExpression> Binder::BindRelPattern(const RelPattern& rel,
     if (rel.GetPatternType() == RelPatternType::VARIABLE_LENGTH) {
         if (lower == 1 && upper == 1) upper = UINT64_MAX; // no bound specified
     }
-    // Reject backwards range up front; otherwise downstream allocators see a
-    // negative size, which libc++ throws bad_array_new_length on and
-    // libstdc++ silently runs through. Same divergence as #86 / #214.
+    // Reject backwards range up front: downstream allocators see a negative
+    // size, which libc++ throws on but libstdc++ silently runs through.
     if (rel.GetPatternType() == RelPatternType::VARIABLE_LENGTH &&
         lower > upper) {
         throw BinderException(
@@ -1648,11 +1632,10 @@ unique_ptr<BoundProjectionBody> Binder::BindProjectionBody(
             // Downstream query parts need to resolve these aliases by name.
             ctx.AddAliasType(alias, bound_type);
 
-            // Propagate property-reference origin through WITH-alias chains
-            // so BindUnwindClause can reject `UNWIND xs` after `WITH p.speaks
-            // AS xs` (#80 follow-up). Propagation stops at any wrapper
-            // (function call, arithmetic) — wrapping signals the user has
-            // taken responsibility for the scalar/null case.
+            // Propagate property-ref origin through WITH-alias chains so
+            // BindUnwindClause can reject `UNWIND xs` after `WITH p.speaks AS xs`.
+            // Stop at any wrapper (function, arithmetic) — wrapping means the
+            // user took responsibility for the scalar/null case.
             if (dynamic_cast<const ParsedPropertyExpression*>(item_expr.get())) {
                 ctx.MarkAliasAsPropertyRef(alias);
             } else if (auto *src_var =
@@ -1679,7 +1662,7 @@ unique_ptr<BoundProjectionBody> Binder::BindProjectionBody(
 
             // Rename projections (e.g. `WITH p AS q`) — register the alias as
             // a fresh binding so the next query part can reference `q` while
-            // ResetToProjectedScope below drops `p`. #19.
+            // ResetToProjectedScope below drops `p`.
             if (bound->GetExprType() == BoundExpressionType::VARIABLE) {
                 auto &var = static_cast<const BoundVariableExpression &>(*bound);
                 const string &src = var.GetVarName();
@@ -1705,13 +1688,10 @@ unique_ptr<BoundProjectionBody> Binder::BindProjectionBody(
             item.expr      = BindExpression(*ob.expr, ctx);
             item.ascending = ob.ascending;
 
-            // Cypher positional ORDER BY: `ORDER BY N` (integer literal)
-            // refers to the N-th item (1-based) of the preceding RETURN
-            // / WITH projection. Resolve here by Copy-ing the
-            // projection's bound expression so the converter sees a
-            // PROPERTY / FUNCTION / VARIABLE (the shapes PlanOrderBy
-            // already handles); the unresolved LITERAL path used to
-            // SIGSEGV downstream (issue #148).
+            // Cypher positional ORDER BY: `ORDER BY N` (integer literal) refers
+            // to the N-th projection item. Resolve here by Copy-ing the
+            // projection's bound expression so PlanOrderBy sees a
+            // PROPERTY / FUNCTION / VARIABLE shape.
             if (item.expr->GetExprType() == BoundExpressionType::LITERAL) {
                 auto &lit =
                     static_cast<const BoundLiteralExpression &>(*item.expr);
@@ -1741,10 +1721,8 @@ unique_ptr<BoundProjectionBody> Binder::BindProjectionBody(
         body->SetOrderBy(std::move(order_items));
     }
 
-    // SKIP / LIMIT (literal integers only for now). Reject non-integer
-    // and negative values up front — silently casting `-1` to UINT64_MAX
-    // or ignoring a string clause used to return the full result set
-    // (#211).
+    // SKIP / LIMIT — literal non-negative integers only. Reject up front so
+    // `-1` doesn't silently cast to UINT64_MAX.
     auto bind_skip_limit = [&](const char *clause_name,
                                 const ParsedExpression *expr) -> uint64_t {
         if (expr == nullptr) {
@@ -1910,8 +1888,7 @@ shared_ptr<BoundExpression> Binder::BindPropertyExpression(const ParsedPropertyE
         // When the user reaches the node under an alias different from
         // the BoundNode's unique name (e.g. `q.firstName` where ctx
         // mapped q -> p), rewrite var_name so the converter resolves the
-        // property under the alias the user actually wrote. The
-        // PlanProjection now surfaces the colrefs under both names. #19.
+        // property under the alias the user actually wrote.
         if (looked->GetExprType() == BoundExpressionType::PROPERTY &&
             var != node->GetUniqueName()) {
             auto &bp = static_cast<const BoundPropertyExpression&>(*looked);
@@ -1937,12 +1914,9 @@ shared_ptr<BoundExpression> Binder::BindPropertyExpression(const ParsedPropertyE
         }
         return looked;
     }
-    // Handle chained property: a.b.c → struct_extract(struct_extract(a,'b'),'c')
-    // Split at the LAST dot so the recursion strips one level at a time.
-    // Splitting at the FIRST dot would route deeper chains (m.a.b.c with
-    // prop=c → recurse var=m, prop="a.b") into the single-field map-access
-    // branch, treating "a.b" as one field name and dereferencing NULL on
-    // execute (#205).
+    // Chained property: a.b.c → struct_extract(struct_extract(a,'b'),'c').
+    // Split at the LAST dot so each recursion strips one level — splitting at
+    // the first dot would treat "a.b" as a single field name.
     if (var.find('.') != string::npos) {
         auto dot_pos = var.rfind('.');
         string base = var.substr(0, dot_pos);
@@ -1971,10 +1945,8 @@ shared_ptr<BoundExpression> Binder::BindPropertyExpression(const ParsedPropertyE
                     "date_part", LogicalType::BIGINT, std::move(dp_args), var + "." + prop);
             }
         }
-        // Reject field access on primitives up front. Without this, the
-        // engine builds struct_extract(VARCHAR, "month") and crashes during
-        // downstream type resolution because struct_extract dereferences
-        // a NULL STRUCT child (#207).
+        // Reject field access on primitives up front — struct_extract on a
+        // non-STRUCT crashes during downstream type resolution.
         if (inner_type.id() != LogicalTypeId::STRUCT &&
             inner_type.id() != LogicalTypeId::ANY &&
             inner_type.id() != LogicalTypeId::SQLNULL) {
@@ -2074,10 +2046,8 @@ shared_ptr<BoundExpression> Binder::LookupPropertyOnNode(BoundNodeExpression& no
     PropertyKeyID kid = gcat->GetPropertyKeyID(*context_, prop_name);
     string uname = node.GetUniqueName() + "." + prop_name;
     if (kid == (PropertyKeyID)-1) {
-        // Neo4j semantics: accessing a property that no node in the
-        // graph has just returns NULL. Throwing "Unknown property" makes
-        // schema-flexible idioms like `COALESCE(p.email, '<none>')` fail
-        // for users who model email as optional.
+        // Unknown property returns NULL so schema-flexible idioms like
+        // COALESCE(p.email, '<none>') keep working for optional fields.
         return make_shared<BoundLiteralExpression>(
             Value(LogicalType::SQLNULL), uname);
     }
@@ -2095,7 +2065,7 @@ shared_ptr<BoundExpression> Binder::LookupPropertyOnRel(BoundRelExpression& rel,
     PropertyKeyID kid = gcat->GetPropertyKeyID(*context_, prop_name);
     string uname = rel.GetUniqueName() + "." + prop_name;
     if (kid == (PropertyKeyID)-1) {
-        // See LookupPropertyOnNode — same Neo4j NULL-on-unknown semantics.
+        // Same NULL-on-unknown rule as LookupPropertyOnNode.
         return make_shared<BoundLiteralExpression>(
             Value(LogicalType::SQLNULL), uname);
     }
@@ -2352,8 +2322,7 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
             "+", LogicalType::DOUBLE, std::move(plus_args), GenExprName(expr));
     }
 
-    // ---- id(n) → access _id property (key_id=0) ----
-    // Neo4j id() returns the internal node/relationship ID.
+    // id(n) → internal node/relationship ID (_id property, key_id=0).
     if (fname == "id" && expr.children.size() == 1) {
         if (expr.children[0]->GetExpressionType() == ExpressionType::COLUMN_REF) {
             auto *var = dynamic_cast<const ParsedVariableExpression *>(expr.children[0].get());
@@ -2428,8 +2397,7 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
         }
     }
 
-    // ---- String `+` concatenation (Neo4j compatibility) ----
-    // Neo4j uses `+` for string concat. When either operand is VARCHAR, rewrite to concat().
+    // Cypher overloads `+` as string concat when either operand is VARCHAR.
     if (fname == "+" && expr.children.size() == 2) {
         auto lhs = BindExpression(*expr.children[0], ctx);
         auto rhs = BindExpression(*expr.children[1], ctx);
@@ -2779,9 +2747,8 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
                             return bound_arg;
                         }
                         // Numeric (epoch ms): wrap in epoch_ms → TIMESTAMP.
-                        // Reject other types up front; otherwise epoch_ms is
-                        // built over an incompatible scalar and crashes
-                        // during downstream type resolution (#206).
+                        // Reject other types up front so epoch_ms isn't built
+                        // over an incompatible scalar.
                         if (arg_type.id() != LogicalTypeId::BIGINT &&
                             arg_type.id() != LogicalTypeId::INTEGER &&
                             arg_type.id() != LogicalTypeId::UBIGINT &&
@@ -3232,12 +3199,9 @@ shared_ptr<BoundExpression> Binder::BindCaseExpression(const CaseExpression& exp
     if (expr.else_expr) {
         else_expr = BindExpression(*expr.else_expr, ctx);
     }
-    // CASE return type = LCT across every THEN + ELSE branch. The earlier
-    // first-non-NULL-THEN approach silently dropped wider ELSE types —
-    // e.g. THEN DOUBLE / ELSE 0(INT) inferred as INT, and a SUM over the
-    // result read the DOUBLE bytes as INT (#97). Skip ANY/UNKNOWN/SQLNULL
-    // during the join so column-refs that bind as ANY don't poison the
-    // inference.
+    // CASE return type = LCT across every THEN + ELSE branch (so wider ELSE
+    // types aren't silently dropped). Skip ANY/UNKNOWN/SQLNULL so colrefs
+    // that bind as ANY don't poison the inference.
     LogicalType result_type = LogicalType::ANY;
     auto promote = [&](const LogicalType& candidate) {
         auto cid = candidate.id();

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -540,12 +540,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanQueryPart(
             turbolynx::LogicalSchema empty_schema;
             cur_plan = new turbolynx::LogicalPlan(pexprCTG, empty_schema);
         }
-        // #224 follow-up: when WHERE references a variable the projection is
-        // about to drop (e.g. `WITH p, 1 AS x WITH p WHERE x = 1`), apply
-        // WHERE BEFORE the projection narrows. Otherwise — including the
-        // HAVING-style case where WHERE references an aggregation alias
-        // built by the projection — apply WHERE AFTER projection, matching
-        // existing #19 / Neo4j semantics for WITH-WHERE.
+        // WHERE before projection if it references a var the projection drops.
         bool where_before = false;
         if (qp.HasProjectionBodyPredicate()) {
             std::unordered_set<std::string> where_vars;
@@ -930,7 +925,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
     // single NULL-filled output row. Plan the pattern as a regular MATCH
     // and mark the result for PhysicalOptional wrapping at translation
     // time — that operator forwards matched rows unchanged and emits the
-    // synthetic NULL row when the MATCH produced zero (#203, #204).
+    // synthetic NULL row when the MATCH produced zero.
     if (prev_plan == nullptr) {
         turbolynx::LogicalPlan *plan = PlanRegularMatch(qgc, nullptr, predicates);
         if (!predicates.empty()) {
@@ -940,13 +935,11 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
         return plan;
     }
 
-    // Anchor-less OPTIONAL MATCH (no endpoint visible in prev_plan):
-    // build the subquery standalone and LOJ it against prev_plan.
-    // WHERE predicates split three ways — sub-only become a Selection
-    // on the subquery, prev+sub combined become the LOJ ON condition
-    // (so ORCA can pick something better than cart prod), prev-only
-    // become a Selection over the LOJ. Spec-correct: NULL-fill rows
-    // are never filtered by the OPTIONAL pattern's own WHERE (#186).
+    // Anchor-less OPTIONAL MATCH: build the subquery standalone and LOJ it
+    // against prev_plan. WHERE splits three ways — sub-only → Selection on
+    // the subquery, prev+sub → LOJ ON condition (so ORCA can pick something
+    // better than cart prod), prev-only → Selection over the LOJ. NULL-fill
+    // rows are never filtered by the OPTIONAL pattern's own WHERE.
     bool any_anchored = false;
     for (uint32_t qg_idx = 0; qg_idx < qgc.GetNumQueryGraphs() && !any_anchored;
          ++qg_idx) {
@@ -1091,9 +1084,9 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
         uint64_t loj_anchor_edge_key = 0; // edge key to join with anchor
         string loj_anchor_edge_name; // edge name for the LOJ key
         CExpression *loj_additional_pred = nullptr; // extra pred for both-bound case
-        // For BOTH self-ref edges with both endpoints id-bound, the join cond
-        // must accept either orientation — supplying a full OR predicate here
-        // bypasses the anchor-equality combine in ExprLogicalJoin (issue #83).
+        // BOTH self-ref edges with both endpoints id-bound need an OR over
+        // either orientation as the join cond, bypassing the anchor-equality
+        // combine in ExprLogicalJoin.
         CExpression *loj_full_pred_override = nullptr;
 
         // Edge reordering: if the first edge has no bound endpoint but a
@@ -2898,13 +2891,8 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanProjection(
             // Check binding type first — scalar aliases don't have property expansion
             if (prev_plan->getSchema()->isNodeBound(var_name)) {
                 auto var_colrefs = prev_plan->getSchema()->getAllColRefsOfKey(var_name);
-                // #224 chain rename: shadow-recall in the binder may surface a
-                // later MATCH's BoundNodeExpression under any of the previous
-                // alias chain's names — e.g. after `WITH p AS q WITH q AS r`,
-                // `MATCH (r)` arrives with GetUniqueName()="p" (the original).
-                // Carry every prior name that shares this var's colrefs into
-                // the new schema so PlanRegularMatch's isNodeBound check
-                // succeeds and no spurious fresh scan is emitted.
+                // Carry every prior alias name so isNodeBound stays true
+                // after chain-rename (`WITH p AS q WITH q AS r`).
                 std::unordered_set<const CColRef *> var_colref_set(
                     var_colrefs.begin(), var_colrefs.end());
                 std::unordered_set<std::string> transitive_names =

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -759,10 +759,7 @@ struct BinaryZeroIsNullWrapper {
 	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
 	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
 		if (right == 0) {
-			// Cypher throws on integer divide-by-zero (matches Neo4j);
-			// silently returning NULL hid arithmetic bugs at the engine
-			// level (#211). The hugeint code path already throws, so this
-			// brings the smaller integer types into agreement.
+			// Cypher throws on integer divide-by-zero.
 			throw OutOfRangeException("Division by zero");
 		} else {
 			return OP::template Operation<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(left, right);

--- a/src/include/binder/bind_context.hpp
+++ b/src/include/binder/bind_context.hpp
@@ -111,12 +111,9 @@ public:
 
     bool HasVar(const string& name) const { return HasNode(name) || HasRel(name) || HasPath(name); }
 
-    // Narrow scope to `keep` after a WITH. Names not in `keep` move to
-    // `shadowed_*` — invisible to HasNode/HasRel/HasPath (so RETURN/WHERE
-    // reject them, matching Neo4j) but recoverable when a later MATCH
-    // reintroduces the same name; the pattern binder calls
-    // RecallShadowed*. Matches Cypher 5 entity-introduction semantics
-    // (#19).
+    // Narrow scope after a WITH: names not in `keep` move to `shadowed_*` so
+    // RETURN/WHERE reject them, but a later MATCH that re-introduces the same
+    // name recovers the original binding via RecallShadowed*.
     void ResetToProjectedScope(const unordered_set<string>& keep) {
         for (auto it = node_bindings_.begin(); it != node_bindings_.end();) {
             if (keep.count(it->first)) {

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -407,9 +407,6 @@ private:
     static void CollectPropertyRefsFromExpr(const BoundExpression &expr,
                                             const string &var_name,
                                             std::unordered_set<uint64_t> &out_key_ids);
-    // Collect every variable name referenced in a BoundExpression — used to
-    // decide whether a WITH's WHERE must be applied BEFORE the projection
-    // narrows scope (#224 follow-up).
     static void CollectVarNamesFromExpr(const BoundExpression &expr,
                                         std::unordered_set<std::string> &out_names);
 };

--- a/src/include/execution/physical_operator/physical_optional.hpp
+++ b/src/include/execution/physical_operator/physical_optional.hpp
@@ -11,13 +11,11 @@ namespace duckdb {
 // Wraps a child plan and guarantees ≥1 output row. If the child produces
 // any rows they are forwarded unchanged in streaming fashion. If the child
 // produces zero rows, exactly one row of NULLs (with the child's schema)
-// is emitted via FinalExecute after the upstream source EOS. Mirrors
-// Neo4j's `+Optional` operator that sits above the MATCH plan for a
-// standalone OPTIONAL MATCH clause.
+// is emitted via FinalExecute after the upstream source EOS.
 //
-// Implemented as a piped operator (not a pipeline break) — relies on the
-// FinalExecute hook in CypherPhysicalOperator to emit the synthetic NULL
-// row exactly once at EOS, so the matched-row path remains pass-through.
+// Piped operator (not a pipeline break) — relies on the FinalExecute hook
+// to emit the synthetic NULL row exactly once at EOS, so the matched-row
+// path remains pass-through.
 class PhysicalOptional : public CypherPhysicalOperator {
 public:
     explicit PhysicalOptional(Schema &sch)

--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CExpressionPreprocessor.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CExpressionPreprocessor.h
@@ -200,12 +200,6 @@ private:
 	static CExpression *PexprReorderScalarCmpChildren(CMemoryPool *mp,
 													  CExpression *pexpr);
 
-	// S62: constant-fold ScalarCmp(Const, Const) and NOT(Const) inside
-	// scalar predicates; re-collapses AND/OR over folded literals.
-	// Needed because Cypher→ORCA bypasses PostgreSQL's planner-time
-	// constant folding, and post-transpose substitutions can produce
-	// Select(Const = Const) that the normalizer would otherwise leave
-	// in place.
 	static CExpression *PexprFoldConstantPredicates(CMemoryPool *mp,
 													CExpression *pexpr);
 
@@ -222,10 +216,6 @@ private:
 													   CColRef *pcolref,
 													   CExpression *pprojExpr);
 	
-	// S62: Substitute every ScalarIdent that resolves to `pcolref` (by Id or
-	// lineage via PrevId) with `pprojExpr`. Pure colref substitution — no
-	// structural rewrites. The columnar transpose handles the Select/Project
-	// push-down structure separately.
 	static CExpression *CollapseSelectAndReplaceColrefColumnar(CMemoryPool *mp,
 															   CExpression *expr,
 															   CColRef *pcolref,

--- a/src/optimizer/orca/gporca/libgpopt/base/CUtils.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/base/CUtils.cpp
@@ -4304,20 +4304,9 @@ CUtils::PexprCollapseProjects(CMemoryPool *mp, CExpression *pexpr)
 }
 
 
-// Collapse the top two CLogicalProjectColumnar nodes, sinking parent
-// project elements that reference only the grandchild into the merged
-// child project list. Returns NULL when nothing can be collapsed or when
-// the input doesn't match the Project(Project(child)) shape.
-//
-// Three fixes relative to the original (which is why the call site was
-// left commented out):
-//   1. The result operators were CLogicalProject (row-major) instead of
-//      CLogicalProjectColumnar — running this in PexprPreprocess would
-//      poison subsequent columnar-only xforms.
-//   2. pcrsDefinedChild was leaked on every successful collapse.
-//   3. Project elements with set-returning functions hit a bare
-//      GPOS_ASSERT (a no-op in release) and were then silently appended,
-//      yielding malformed projections. We now bail (return NULL) instead.
+// Collapse Project(Project(child)) into one ProjectColumnar, sinking parent
+// elements that reference only the grandchild. NULL if nothing collapses or
+// any element has a set-returning function (cardinality-altering).
 CExpression * CUtils::PexprCollapseColumnarProjects(CMemoryPool *mp,
 											  CExpression *pexpr)
 {

--- a/src/optimizer/orca/gporca/libgpopt/operators/CExpressionPreprocessor.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/operators/CExpressionPreprocessor.cpp
@@ -2621,27 +2621,9 @@ CExpressionPreprocessor::PexprReorderScalarCmpChildren(CMemoryPool *mp,
 	return GPOS_NEW(mp) CExpression(mp, pop, pdrgpexpr);
 }
 
-// S62: Constant-fold scalar predicates.
-//
-// Folds ScalarCmp(Const, Const) to ScalarConst(bool) using IDatum's
-// stats-equality / stats-less-than (both backed by LINT or Double
-// mappings, which are exact for the integer/string constants Cypher
-// produces). NULL operands are left untouched — the binder already
-// rewrites NULL comparisons to IS NULL.
-//
-// Also re-collapses AND / OR / NOT over folded literals via
-// CPredicateUtils::PexprConjunction / PexprDisjunction so that
-// AND(true, x) → x, AND(false, ...) → false, OR(true, ...) → true,
-// NOT(true) → false, etc.
-//
-// Rationale: in Greenplum the PostgreSQL planner folds these literals
-// before ORCA sees the tree. Our Cypher→ORCA path bypasses that stage,
-// and PexprTransposeSelectAndProjectColumnar later substitutes
-// projected ColRefs with their bound ScalarConsts — producing
-// Select(Const = Const) predicates. CNormalizer drops Select(true)
-// but never folds Const=Const itself, so a dangling colref survives
-// inside the now-useless Select and breaks PcrsRequired propagation
-// down to the scan (issue #227).
+// Fold ScalarCmp(Const, Const) → bool literal and re-collapse AND/OR/NOT
+// over the result, so the normalizer can drop the trivial Select that the
+// columnar transpose's alias substitution leaves behind.
 CExpression *
 CExpressionPreprocessor::PexprFoldConstantPredicates(CMemoryPool *mp,
 													  CExpression *pexpr)
@@ -2661,19 +2643,8 @@ CExpressionPreprocessor::PexprFoldConstantPredicates(CMemoryPool *mp,
 
 	COperator *pop = pexpr->Pop();
 
-	// Fold ScalarCmp(ScalarConst, ScalarConst) → ScalarConst(bool).
-	//
-	// Equality / inequality (=, <>) use IDatum::Matches, which compares
-	// MDId + byte-array and works for any constant type Cypher emits
-	// (TurboLynx's int4/int8 literals do not satisfy ORCA's
-	// IsDatumMappableToLINT predicate, so StatsAreEqual is unavailable
-	// for them — Matches is the safe path).
-	//
-	// Ordering (<, <=, >, >=) requires statistical mapping. We fold
-	// only when both datums advertise a LINT or Double mapping. For
-	// Cypher's generic int/string MDIds the fold is skipped — those
-	// predicates pass through unchanged, which is correct (they may
-	// still trigger #227 for ordering, but that is a separate fix).
+	// =/<> via IDatum::Matches (byte-equality, works for any constant type);
+	// ordering only when ORCA's LINT/Double stats mapping is available.
 	if (COperator::EopScalarCmp == pop->Eopid() &&
 		2 == pdrgpexprChildren->Size())
 	{
@@ -3009,20 +2980,9 @@ CExpressionPreprocessor::CollapseSelectAndReplaceColref(CMemoryPool *mp,
 	return GPOS_NEW(mp) CExpression(mp, pop, pdrgpexprChildren);
 }
 
-// S62: Substitute occurrences of `pcolref` inside `pexpr` with `pprojExpr`.
-//
-// Pure substitution — does not restructure the tree. The match condition
-// follows the same lineage rule used elsewhere in the columnar pipeline
-// (Id direct match OR PrevId chain match), so renamed columns are caught
-// even when the converter only set up one-step lineage on the LHS colref.
-//
-// Caller is `PexprTransposeSelectAndProjectColumnar`, which is responsible
-// for the Select/ProjectColumnar push-down structure. Earlier revisions of
-// this function performed both substitution and structural rewrites in one
-// pass; that interleaved depth-0 collapses with deeper recursion and could
-// drop nested ProjectColumnar layers whose outputs were still referenced by
-// outer projects, leaving dangling colrefs (#227 and the WITH-only WHERE
-// SEGV repro on Person.firstName).
+// Pure colref substitution. Structural Select/ProjectColumnar push-down
+// lives in PexprTransposeSelectAndProjectColumnar; mixing the two would
+// drop nested ProjectColumnar layers whose outputs are still referenced.
 CExpression *
 CExpressionPreprocessor::CollapseSelectAndReplaceColrefColumnar(CMemoryPool *mp,
 														CExpression *pexpr,
@@ -3237,19 +3197,13 @@ CExpressionPreprocessor::PexprTransposeSelectAndProjectColumnar(CMemoryPool *mp,
 
 	if (pexpr->Pop()->Eopid() == COperator::EopLogicalSelect &&						// Select
 		(*pexpr)[0]->Pop()->Eopid() == COperator::EopLogicalProjectColumnar) {		// LogicalProjectColumnar
-		// S62: Pure structural transpose
-		//
 		//   Select(p)                            ProjectColumnar(L)
 		//   `-- ProjectColumnar(L)   --->        `-- Select(p[X→Y for X:=Y in L])
 		//       `-- child                            `-- child
 		//
-		// Substitute each project element's defined colref (LHS) into the
-		// predicate via CollapseSelectAndReplaceColrefColumnar, then push the
-		// Select below the ProjectColumnar in one step. The result is then
-		// recursively transposed so nested Select(ProjectColumnar(...)) layers
-		// get pushed down too — but each recursion processes exactly one Project
-		// layer, never reaching down through siblings to drop unrelated Projects
-		// the way the previous interleaved Collapse/Transpose did.
+		// One layer per call, then recurse on the result. Substitution uses
+		// each project element's LHS (defined colref) so we don't depend on
+		// the converter setting PrevId lineage on every renamed colref.
 		CExpression *pselect = pexpr;
 		CExpression *pproject = (*pexpr)[0];
 		CExpression *pprojectChild = (*pproject)[0];
@@ -3652,11 +3606,8 @@ CExpressionPreprocessor::PexprPreprocess(
 		GPOS_CHECK_ABORT;
 		pexprTransposeSelectAndProject->Release();
 
-		// S62 (27.5): fold ScalarCmp(Const, Const) introduced when the
-		// columnar transpose substitutes an alias with its bound constant.
-		// CNormalizer would otherwise leave Select(Const = Const) in the
-		// tree, where it foils PcrsRequired propagation and breaks downstream
-		// scan output selection (#227).
+		// Fold the Const=Const predicates the transpose just produced so the
+		// normalizer can drop the trivial Selects before plan generation.
 		CExpression *pexprFolded1 =
 			PexprFoldConstantPredicates(mp, pexprTransposeSelectAndProjectColumnar);
 		GPOS_CHECK_ABORT;
@@ -3675,7 +3626,7 @@ CExpressionPreprocessor::PexprPreprocess(
 		GPOS_CHECK_ABORT;
 		pexprNormalized2->Release();
 
-		// S62 (27.5): fold again after the second columnar transpose pass.
+		// Fold again after the second transpose pass.
 		CExpression *pexprFolded2 =
 			PexprFoldConstantPredicates(mp, pexprTransposeSelectAndProjectColumnar2);
 		GPOS_CHECK_ABORT;


### PR DESCRIPTION
## Summary

Sweep across the binder, converter, optional operator, arithmetic, and the columnar transpose / fold paths that just merged (PR226 / PR228). User flagged the lingering verbose blocks during merge.

## What's dropped

- **\"Neo4j\" attribution** when the line is just Cypher semantics (WITH-scope narrowing, NULL on unknown property, \`id()\` returning internal ID, \`+\` string concat, OPTIONAL operator semantics, divide-by-zero throwing). Kept the mention for genuinely vendor-format compat (CSV \`:LABEL\` headers, \`EncodeNeo4jCompositeKey\`).
- **Bare \`(#N)\` tags** at the end of self-explanatory comments. Kept the tag only when the invariant points at a specific lower-level mechanism (e.g. \`(#136)\` for ORCA-cleanup-after-siglongjmp).
- **Multi-paragraph block comments** (the 7–13 line headers above each new helper). Collapsed to 1–3 lines stating the invariant. Bug history, two-clause restatements, worked examples all already live in the relevant commit messages.

9 files, 212 deletions vs 83 insertions — net −129 lines.

## Test plan

- [x] \`turbolynx_bin\` builds clean with ASan.
- [x] Smoke probe (\`MATCH (p:Person {firstName:'Hossein'}) RETURN p.id\` → 14) passes.
- [ ] CI \`[ldbc][filter]\` / \`[tpch]~[stress]\` / \`[ldbc][traversal]\` — no behaviour change expected, comments only.