### PR TITLE
feat(#184) PR-1.2: converter lowering for pattern comprehension

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -203,12 +203,19 @@ void Binder::ResolveRelTypes(const vector<string>& types,
 // the opposite endpoint should have.
 string Binder::InferNodeLabelFromEdge(const BoundNodeExpression& other_node,
                                        const RelPattern& rel) {
+    return InferNodeLabelFromEdgeTypes(other_node, rel.GetTypes(),
+                                        rel.GetDirection());
+}
+
+string Binder::InferNodeLabelFromEdgeTypes(const BoundNodeExpression& other_node,
+                                            const vector<string>& edge_types,
+                                            RelDirection /*direction*/) {
     auto* gcat = GetGraphCatalog();
     auto& catalog = context_->db->GetCatalog();
 
     // Resolve edge type to partitions (may be multiple for 1:N edge types)
     vector<uint64_t> edge_part_ids, edge_graphlet_ids;
-    ResolveRelTypes(rel.GetTypes(), edge_part_ids, edge_graphlet_ids);
+    ResolveRelTypes(edge_types, edge_part_ids, edge_graphlet_ids);
     if (edge_part_ids.empty()) return "";
 
     // Collect all possible opposite-side partition OIDs across all edge partitions.
@@ -2244,8 +2251,23 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
             } else {
                 vector<uint64_t> partition_ids, graphlet_ids;
                 vector<string>   labels;
-                if (!hop.end_label.empty()) {
-                    labels.push_back(hop.end_label);
+                string end_label = hop.end_label;
+                // Mirror BindPatternElement: if the end node has no label,
+                // infer from the edge type so PlanRegularMatch's
+                // primary_graphlet_node_scan finds a partition.
+                if (end_label.empty() && !hop.edge_type.empty()) {
+                    auto *prev_n = ctx.HasNode(prev_node_name)
+                                       ? ctx.GetNode(prev_node_name).get()
+                                       : inner_ctx.GetNode(prev_node_name).get();
+                    RelDirection rdir =
+                        (hop.direction == ExpandDirection::OUTGOING) ? RelDirection::RIGHT
+                            : (hop.direction == ExpandDirection::INCOMING) ? RelDirection::LEFT
+                                                                           : RelDirection::BOTH;
+                    end_label = InferNodeLabelFromEdgeTypes(
+                        *prev_n, { hop.edge_type }, rdir);
+                }
+                if (!end_label.empty()) {
+                    labels.push_back(end_label);
                     ResolveNodeLabels(labels, partition_ids, graphlet_ids);
                 }
                 end_node = make_shared<BoundNodeExpression>(
@@ -2322,20 +2344,7 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
             std::move(map_expr),
             GenExprName(expr));
         bound->SetInnerMatch(std::move(inner_match));
-
-        // #184 PR-1.1 stops here: the bound expression is fully constructed
-        // (validating outer-bound start + pattern-scoped vars + map/WHERE
-        // binding in the inner scope) but the converter still has no
-        // lowering for PATTERN_COMP. Throwing a BinderException keeps the
-        // exception inside the binder frame — propagating into ORCA's task
-        // would trigger #136 (unsafe cleanup after siglongjmp). PR-1.2
-        // removes this throw and wires the CScalarSubquery / LOJ /
-        // GbAgg(collect) lowering in the converter.
-        (void)bound;
-        throw BinderException(
-            "Pattern comprehension `[(...)-[:R]->(...) | expr]` was bound "
-            "successfully but the converter lowering is not yet wired "
-            "(#184 PR-1.1 — PR-1.2 enables the CScalarSubquery sub-plan).");
+        return bound;
     }
 
     // __reduce(init, 'acc', list, 'var', body)

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -2213,8 +2213,15 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
         // outer expression.
         BindContext inner_ctx(&ctx);
 
+        // Build the inner pattern as a BoundQueryGraphCollection — the same
+        // shape the converter's PlanRegularMatch consumes, with the start
+        // node marked outer-bound so it's not re-scanned.
+        auto inner_qg = make_unique<BoundQueryGraph>();
+        inner_qg->AddQueryNode(ctx.GetNode(start_var));
+
         vector<CypherBoundPatternHop> hops;
         hops.reserve(num_hops);
+        string prev_node_name = start_var;
         for (int32_t i = 0; i < num_hops; i++) {
             size_t base = 3 + static_cast<size_t>(i) * 4;
             CypherBoundPatternHop hop;
@@ -2225,22 +2232,23 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
                                                 : ExpandDirection::BOTH;
             hop.end_var   = cst_str(*raw_args[base + 2]);
             hop.end_label = cst_str(*raw_args[base + 3]);
-
-            // Register the end node so the comprehension's WHERE / map_expr
-            // can reference `.prop` on it. Anonymous end nodes get a
-            // generated anchor so their position in the chain is still
-            // representable for the converter.
             if (hop.end_var.empty()) {
                 hop.end_var = GenAnonVarName();
             }
-            if (!inner_ctx.HasNode(hop.end_var)) {
+
+            // End node — register in inner_ctx so map_expr / WHERE can read
+            // `.prop` off it, and add to the inner query graph.
+            shared_ptr<BoundNodeExpression> end_node;
+            if (inner_ctx.HasNode(hop.end_var)) {
+                end_node = inner_ctx.GetNode(hop.end_var);
+            } else {
                 vector<uint64_t> partition_ids, graphlet_ids;
                 vector<string>   labels;
                 if (!hop.end_label.empty()) {
                     labels.push_back(hop.end_label);
                     ResolveNodeLabels(labels, partition_ids, graphlet_ids);
                 }
-                auto end_node = make_shared<BoundNodeExpression>(
+                end_node = make_shared<BoundNodeExpression>(
                     hop.end_var, labels, partition_ids, graphlet_ids);
                 if (!partition_ids.empty()) {
                     auto *gcat    = GetGraphCatalog();
@@ -2249,14 +2257,58 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
                 }
                 inner_ctx.AddNode(hop.end_var, end_node);
             }
+            if (!inner_qg->ContainsNode(hop.end_var)) {
+                inner_qg->AddQueryNode(end_node);
+            }
+
+            // Edge — anonymous binding gets a generated name so the converter
+            // can address it.
+            string edge_var = hop.edge_var.empty() ? GenAnonVarName() : hop.edge_var;
+            vector<string> rel_types;
+            if (!hop.edge_type.empty()) rel_types.push_back(hop.edge_type);
+            vector<uint64_t> edge_partition_ids, edge_graphlet_ids;
+            if (!rel_types.empty()) {
+                ResolveRelTypes(rel_types, edge_partition_ids, edge_graphlet_ids);
+            }
+            RelDirection rel_dir = (hop.direction == ExpandDirection::OUTGOING)
+                                       ? RelDirection::RIGHT
+                                       : (hop.direction == ExpandDirection::INCOMING)
+                                             ? RelDirection::LEFT
+                                             : RelDirection::BOTH;
+            auto edge_expr = make_shared<BoundRelExpression>(
+                edge_var, rel_types, rel_dir,
+                edge_partition_ids, edge_graphlet_ids,
+                prev_node_name, hop.end_var,
+                /*lower*/ 1, /*upper*/ 1);
+            if (!edge_partition_ids.empty()) {
+                auto *gcat    = GetGraphCatalog();
+                auto &catalog = context_->db->GetCatalog();
+                PopulateRelProperties(*edge_expr, *context_, *gcat, catalog);
+            }
+            inner_qg->AddQueryRel(edge_expr);
+
+            prev_node_name = hop.end_var;
             hops.push_back(std::move(hop));
         }
+
+        // Wrap the inner pattern in a BoundMatchClause; the converter's
+        // PlanRegularMatch consumes this directly.
+        auto inner_qgc = make_unique<BoundQueryGraphCollection>();
+        inner_qgc->AddAndMergeIfConnected(std::move(inner_qg));
+        auto inner_match = make_unique<BoundMatchClause>(std::move(inner_qgc), /*is_optional*/ false);
 
         size_t map_idx = 3 + static_cast<size_t>(num_hops) * 4;
         auto map_expr  = BindExpression(*raw_args[map_idx], inner_ctx);
         shared_ptr<BoundExpression> where_expr;
         if (map_idx + 1 < raw_args.size()) {
             where_expr = BindExpression(*raw_args[map_idx + 1], inner_ctx);
+        }
+
+        // WHERE predicates inside the comprehension should be applied as a
+        // Selection on the inner pattern; attach them to the BoundMatchClause
+        // so PlanRegularMatch picks them up.
+        if (where_expr) {
+            inner_match->AddPredicate(where_expr);
         }
 
         LogicalType result_type = LogicalType::LIST(map_expr->GetDataType());
@@ -2269,6 +2321,7 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
             std::move(where_expr),
             std::move(map_expr),
             GenExprName(expr));
+        bound->SetInnerMatch(std::move(inner_match));
 
         // #184 PR-1.1 stops here: the bound expression is fully constructed
         // (validating outer-bound start + pattern-scoped vars + map/WHERE

--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -5,8 +5,11 @@
 
 #include "converter/cypher2orca_converter.hpp"
 #include "binder/expression/bound_exists_subquery_expression.hpp"
+#include "binder/expression/bound_pattern_comprehension_expression.hpp"
+#include "gpopt/operators/CScalarSubquery.h"
 #include "gpopt/operators/CScalarSubqueryExists.h"
 #include "gpopt/operators/CScalarSubqueryNotExists.h"
+#include "gpopt/operators/CLogicalGbAgg.h"
 #include "planner/value_ser_des.hpp"
 #include "catalog/catalog.hpp"
 #include "catalog/catalog_wrapper.hpp"
@@ -346,6 +349,9 @@ CExpression *Cypher2OrcaConverter::ConvertExpression(const BoundExpression &expr
         return ConvertCase(static_cast<const CypherBoundCaseExpression &>(expr), plan);
     case BoundExpressionType::EXISTENTIAL:
         return ConvertExistsSubquery(static_cast<const BoundExistsSubqueryExpression &>(expr), plan);
+    case BoundExpressionType::PATTERN_COMP:
+        return ConvertPatternComprehension(
+            static_cast<const CypherBoundPatternComprehensionExpression &>(expr), plan);
     default:
         D_ASSERT(false);
         return nullptr;
@@ -1531,6 +1537,149 @@ CExpression *Cypher2OrcaConverter::ConvertExistsSubquery(
         mp_, GPOS_NEW(mp_) gpopt::CScalarSubqueryExists(mp_), plan_expr);
 
     return exists_expr;
+}
+
+// ============================================================
+// ConvertPatternComprehension  ([ pattern [WHERE p] | expr ])
+// ============================================================
+// Lowering: CScalarSubquery(GbAgg(collect(map_expr)) ← LOJ-style inner pattern
+// with outer-bound start). ORCA's CSubqueryHandler decorrelates because the
+// inner GbAgg(group_by=∅) yields max-card 1.
+CExpression *Cypher2OrcaConverter::ConvertPatternComprehension(
+    const CypherBoundPatternComprehensionExpression &expr,
+    turbolynx::LogicalPlan *outer_plan)
+{
+    GPOS_ASSERT(outer_plan != nullptr);
+    GPOS_ASSERT(expr.HasInnerMatch());
+
+    const BoundMatchClause          *bound_match = expr.GetInnerMatch();
+    const BoundQueryGraphCollection *qgc         = bound_match->GetQueryGraphCollection();
+    const bound_expression_vector   &predicates  = bound_match->GetPredicates();
+    const string                    &start_var   = expr.GetStartVar();
+
+    // Outer-bound start: matches the BoundExistsSubqueryExpression pattern —
+    // PlanRegularMatch skips its scan and records the inner edge key used to
+    // join back to the outer node's _id.
+    // Mirror ConvertExistsSubquery: only include nodes the outer plan's
+    // schema actually knows so PlanRegularMatch skips their scans and
+    // records the correlation edge key.
+    vector<string> outer_bound_nodes;
+    if (outer_plan->getSchema()->isNodeBound(start_var)) {
+        outer_bound_nodes.push_back(start_var);
+    }
+    map<string, SubqueryCorrelation> corr_keys;
+    turbolynx::LogicalPlan *inner_plan = PlanRegularMatch(
+        *qgc, nullptr, /*predicates*/ {}, outer_bound_nodes, &corr_keys);
+
+    // Correlation predicate: outer.start._id = inner_edge._sid/_tid
+    CExpressionArray *corr_preds = GPOS_NEW(mp_) CExpressionArray(mp_);
+    CColRef *outer_id = outer_plan->getSchema()->getColRefOfKey(start_var, ID_KEY_ID);
+    auto it = corr_keys.find(start_var);
+    if (outer_id && it != corr_keys.end()) {
+        CColRef *inner_edge_col = inner_plan->getSchema()->getColRefOfKey(
+            it->second.edge_name, it->second.edge_key_id);
+        if (inner_edge_col) {
+            corr_preds->Append(CUtils::PexprScalarEqCmp(
+                mp_, CUtils::PexprScalarIdent(mp_, inner_edge_col),
+                     CUtils::PexprScalarIdent(mp_, outer_id)));
+        }
+    }
+
+    // Inner WHERE — register outer plan so refs to outer vars become outer
+    // refs ORCA can decorrelate.
+    if (!predicates.empty()) {
+        bool saved_reg = outer_plan_registered_;
+        turbolynx::LogicalPlan *saved_outer = outer_plan_;
+        outer_plan_registered_ = true;
+        outer_plan_ = outer_plan;
+        for (auto &p : predicates) {
+            corr_preds->Append(ConvertExpression(*p, inner_plan));
+        }
+        outer_plan_registered_ = saved_reg;
+        outer_plan_ = saved_outer;
+    }
+
+    if (corr_preds->Size() > 0) {
+        CExpression *corr_pred = (corr_preds->Size() == 1)
+            ? (*corr_preds)[0]
+            : CUtils::PexprScalarBoolOp(mp_, CScalarBoolOp::EboolopAnd, corr_preds);
+        if (corr_preds->Size() == 1) (*corr_preds)[0]->AddRef();
+        auto *inner_expr = inner_plan->getPlanExpr();
+        inner_expr->AddRef();
+        CExpression *select_expr = CUtils::PexprLogicalSelect(mp_, inner_expr, corr_pred);
+        inner_plan = GPOS_NEW(mp_) turbolynx::LogicalPlan(
+            select_expr, *inner_plan->getSchema());
+    } else {
+        corr_preds->Release();
+    }
+
+    // Convert map_expr against the inner plan with outer plan registered.
+    bool saved_reg = outer_plan_registered_;
+    turbolynx::LogicalPlan *saved_outer = outer_plan_;
+    outer_plan_registered_ = true;
+    outer_plan_ = outer_plan;
+    CExpression *map_orca = ConvertExpression(*expr.GetMapExpr(), inner_plan);
+    outer_plan_registered_ = saved_reg;
+    outer_plan_ = saved_outer;
+
+    // GbAgg(group_by=∅, collect(map_orca) → result_colref)
+    CColumnFactory *cf = COptCtxt::PoctxtFromTLS()->Pcf();
+
+    string collect_name = "collect";
+    LogicalType map_type = expr.GetMapExpr()->GetDataType();
+    vector<LogicalType> agg_arg_types = { map_type };
+    idx_t collect_func_id = context_->db->GetCatalogWrapper().GetAggFuncMdId(
+        *context_, collect_name, agg_arg_types);
+    CMDIdGPDB *collect_mdid = GPOS_NEW(mp_) CMDIdGPDB(IMDId::EmdidGeneral, collect_func_id, 0, 0);
+    collect_mdid->AddRef();
+    const IMDAggregate *collect_md = GetMDAccessor()->RetrieveAgg(collect_mdid);
+    // The catalog's collect signature has a generic LIST return type without
+    // child info, which GetTypeMod can't encode. Build the type_mod off the
+    // binder's already-concrete LIST<map_type>.
+    INT collect_type_mod = GetTypeMod(expr.GetDataType());
+
+    IMDId *collect_agg_mdid = collect_md->MDId(); collect_agg_mdid->AddRef();
+    CWStringConst *collect_wstr = GPOS_NEW(mp_) CWStringConst(
+        mp_, collect_md->Mdname().GetMDName()->GetBuffer());
+    CScalarAggFunc *collect_op = CUtils::PopAggFunc(
+        mp_, collect_agg_mdid, collect_type_mod, collect_wstr,
+        /*is_distinct*/ false, EaggfuncstageGlobal, /*fSplit*/ false,
+        /*pmdidResolvedReturnType*/ nullptr, EaggfunckindNormal);
+
+    // Result colref carrying the LIST value back to outer.
+    LogicalType list_type = expr.GetDataType();
+    OID list_oid = LOGICAL_TYPE_BASE_ID + (OID)list_type.id();
+    IMDId *list_mdid = GPOS_NEW(mp_) CMDIdGPDB(IMDId::EmdidGeneral, list_oid, 1, 0);
+    const std::wstring wres_name = L"_pc_result";
+    CWStringConst wres_wstr(wres_name.c_str());
+    CName wres_cname(&wres_wstr);
+    CColRef *result_colref = cf->PcrCreate(
+        GetMDAccessor()->RetrieveType(list_mdid), collect_type_mod, wres_cname);
+
+    CExpressionArray *collect_args = GPOS_NEW(mp_) CExpressionArray(mp_);
+    collect_args->Append(map_orca);
+    CExpression *collect_agg = GPOS_NEW(mp_) CExpression(
+        mp_, collect_op, CUtils::PexprAggFuncArgs(mp_, collect_args));
+
+    CExpressionArray *agg_elems = GPOS_NEW(mp_) CExpressionArray(mp_);
+    agg_elems->Append(GPOS_NEW(mp_) CExpression(
+        mp_, GPOS_NEW(mp_) CScalarProjectElement(mp_, result_colref), collect_agg));
+    CExpression *agg_proj_list = GPOS_NEW(mp_) CExpression(
+        mp_, GPOS_NEW(mp_) CScalarProjectList(mp_), agg_elems);
+
+    CColRefArray *grp_cols = GPOS_NEW(mp_) CColRefArray(mp_);  // empty grouping
+    auto *inner_expr2 = inner_plan->getPlanExpr();
+    inner_expr2->AddRef();
+    CExpression *gb_expr = GPOS_NEW(mp_) CExpression(
+        mp_, GPOS_NEW(mp_) CLogicalGbAgg(mp_, grp_cols, COperator::EgbaggtypeGlobal),
+        inner_expr2, agg_proj_list);
+
+    // Wrap in CScalarSubquery — single value (LIST) per outer row.
+    return GPOS_NEW(mp_) CExpression(
+        mp_, GPOS_NEW(mp_) gpopt::CScalarSubquery(
+            mp_, result_colref, /*fGeneratedByExist*/ false,
+            /*fGeneratedByQuantified*/ false),
+        gb_expr);
 }
 
 } // namespace turbolynx

--- a/src/include/binder/binder.hpp
+++ b/src/include/binder/binder.hpp
@@ -89,6 +89,9 @@ private:
     // Returns the inferred label string, or empty if inference fails.
     string InferNodeLabelFromEdge(const BoundNodeExpression& other_node,
                                   const RelPattern& rel);
+    string InferNodeLabelFromEdgeTypes(const BoundNodeExpression& other_node,
+                                       const vector<string>& edge_types,
+                                       RelDirection direction);
 
     // Look up property expression for a variable (node or rel)
     shared_ptr<BoundExpression> LookupPropertyOnNode(BoundNodeExpression& node,

--- a/src/include/binder/expression/bound_pattern_comprehension_expression.hpp
+++ b/src/include/binder/expression/bound_pattern_comprehension_expression.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "binder/expression/bound_expression.hpp"
+#include "binder/query/reading_clause/bound_match_clause.hpp"
 #include "common/typedef.hpp"
 
 namespace duckdb {
@@ -68,6 +69,14 @@ public:
     BoundExpression*                    GetMapExpr()        const { return map_expr.get(); }
     bool                                HasWhereExpr()      const { return where_expr != nullptr; }
 
+    // BoundMatchClause-shaped view of the inner pattern. The binder populates
+    // this so the converter can call PlanRegularMatch with the standard
+    // subquery_outer_nodes / corr_keys interface (matches the
+    // BoundExistsSubqueryExpression pattern).
+    void                       SetInnerMatch(unique_ptr<BoundMatchClause> m) { inner_match = std::move(m); }
+    const BoundMatchClause*    GetInnerMatch() const { return inner_match.get(); }
+    bool                       HasInnerMatch() const { return inner_match != nullptr; }
+
     shared_ptr<BoundExpression> Copy() const override {
         vector<CypherBoundPatternHop> copied_hops;
         copied_hops.reserve(hops.size());
@@ -88,16 +97,19 @@ public:
             map_expr   ? map_expr->Copy()   : nullptr,
             unique_name);
         copy->SetAlias(alias);
+        // inner_match is not deep-copied: it's only consumed by the converter
+        // along the same pass that built it, never re-bound after Copy().
         return copy;
     }
 
 private:
-    string                          start_var;
-    string                          start_label;
-    shared_ptr<BoundExpression>     start_predicate;
-    vector<CypherBoundPatternHop>   hops;
-    shared_ptr<BoundExpression>     where_expr;
-    shared_ptr<BoundExpression>     map_expr;
+    string                              start_var;
+    string                              start_label;
+    shared_ptr<BoundExpression>         start_predicate;
+    vector<CypherBoundPatternHop>       hops;
+    shared_ptr<BoundExpression>         where_expr;
+    shared_ptr<BoundExpression>         map_expr;
+    unique_ptr<BoundMatchClause>        inner_match;
 };
 
 } // namespace duckdb

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -90,6 +90,7 @@
 #include "binder/expression/bound_bool_expression.hpp"
 #include "binder/expression/bound_case_expression.hpp"
 #include "binder/expression/bound_null_expression.hpp"
+#include "binder/expression/bound_pattern_comprehension_expression.hpp"
 
 #include "common/enums/expression_type.hpp"
 #include "function/aggregate_function.hpp"
@@ -316,6 +317,9 @@ private:
                               turbolynx::LogicalPlan *plan);
     CExpression *ConvertExistsSubquery(const BoundExistsSubqueryExpression &expr,
                                         turbolynx::LogicalPlan *plan);
+    CExpression *ConvertPatternComprehension(
+        const CypherBoundPatternComprehensionExpression &expr,
+        turbolynx::LogicalPlan *outer_plan);
 
     // DuckDB expression for function type resolution
     // `plan` is optional — when supplied, VARIABLE expressions whose

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -1514,21 +1514,19 @@ TEST_CASE("anchor-less node-only OPTIONAL MATCH yields prev × scan",
     CHECK(r[0].int64_at(1) == 50);
 }
 
-TEST_CASE("bare pattern comprehension throws a clean binder error",
-          "[ldbc][filter][listcomp][issue17]") {
+TEST_CASE("bare pattern comprehension returns the projected friend list",
+          "[ldbc][filter][listcomp][patterncomp]") {
     SKIP_IF_NO_DB();
-    // Pre-fix: this query reached the converter, where `throw
-    // NotImplementedException` fired inside an ORCA frame and SIGSEGVed
-    // in CAutoMemoryPool teardown (sig=11). Post-fix: the binder rejects
-    // it cleanly.
+    // Replaces the earlier "throws a clean binder error" expectation that
+    // pinned the pre-#184 binder rejection (originally guarding against the
+    // pre-fix converter throw inside ORCA → SIGSEGV in CAutoMemoryPool
+    // teardown). #184 PR-1.2 wires the converter lowering, so the same form
+    // now returns a real LIST.
     auto q = std::string("MATCH (p:Person {id: ") + sample_person_id_str() +
              "}) RETURN [(p)-[:KNOWS]->(f) | f.firstName] AS friends";
-    bool caught = false;
-    std::string err;
-    try { qr->run(q.c_str()); }
-    catch (const std::exception &e) { caught = true; err = e.what(); }
-    REQUIRE(caught);
-    CHECK(err.find("Pattern comprehension") != std::string::npos);
+    auto r = qr->run(q.c_str(), {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(!r[0].is_null_at(0));
 }
 
 // Cypher zero-length variable-length paths: `*0..N` must emit the

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -2180,14 +2180,18 @@ TEST_CASE("identity list comp with WHERE true must keep binding",
         qr->run("RETURN [x IN [1,2,3] WHERE true | x] AS r"));
 }
 
-TEST_CASE("bare pattern comprehension must throw, not return placeholder",
-          "[ldbc][robustness][regression][patterncomp]") {
+TEST_CASE("bare pattern comprehension returns the projected friend list",
+          "[ldbc][robustness][patterncomp]") {
     SKIP_IF_NO_DB();
-    // Bug: converter returned a single-element [0.0] placeholder for
-    // `[(a)-[:R]->(b) | b.x]` outside the IC14 weighted-path collapse.
-    // SIGSEGV from the unsupported-comp path is caught by the signal
-    // shield (#79) and surfaces here as a runtime_error.
-    REQUIRE_THROWS(qr->run(
+    // Replaces the earlier "must throw" expectation that pinned the
+    // pre-#184 binder rejection. PR-1.2 wires the converter lowering
+    // (CScalarSubquery over GbAgg(collect)), so this form now returns a
+    // proper LIST result. Match shape only — the friend ordering and
+    // exact names depend on fixture.
+    auto r = qr->run(
         "MATCH (p:Person {id: " LDBC_SAMPLE_PID_STR "}) "
-        "RETURN [(p)-[:KNOWS]->(f) | f.firstName] AS friends"));
+        "RETURN [(p)-[:KNOWS]->(f) | f.firstName] AS friends",
+        {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(!r[0].is_null_at(0));
 }

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -2180,14 +2180,16 @@ TEST_CASE("identity list comp with WHERE true must keep binding",
         qr->run("RETURN [x IN [1,2,3] WHERE true | x] AS r"));
 }
 
-TEST_CASE("bare pattern comprehension returns the projected friend list",
+TEST_CASE("bare pattern comprehension returns a projected list (robustness)",
           "[ldbc][robustness][patterncomp]") {
     SKIP_IF_NO_DB();
     // Replaces the earlier "must throw" expectation that pinned the
     // pre-#184 binder rejection. PR-1.2 wires the converter lowering
     // (CScalarSubquery over GbAgg(collect)), so this form now returns a
     // proper LIST result. Match shape only — the friend ordering and
-    // exact names depend on fixture.
+    // exact names depend on fixture. The "(robustness)" suffix avoids a
+    // Catch2 duplicate-name conflict with the same-shaped filter-suite
+    // case in test_ldbc_filter.cpp.
     auto r = qr->run(
         "MATCH (p:Person {id: " LDBC_SAMPLE_PID_STR "}) "
         "RETURN [(p)-[:KNOWS]->(f) | f.firstName] AS friends",


### PR DESCRIPTION
## Summary

Wire `BoundPatternComprehensionExpression` through to ORCA via `CScalarSubquery` over `GbAgg(collect)` + correlated inner pattern. Continues #184 on top of PR230 / PR231.

Two stacked commits:

1. **PR-1.1.5** — binder builds `BoundMatchClause` (= `BoundQueryGraphCollection` + WHERE predicates) for the inner pattern. Mirrors `BoundExistsSubqueryExpression`.
2. **PR-1.2** — converter lowering for `PATTERN_COMP`:

   ```
   CScalarSubquery(result_colref)
     CLogicalGbAgg(group_by=∅, agg=collect(map_expr) → result_colref)
       CLogicalSelect(corr + inner WHERE preds)
         <inner pattern plan from PlanRegularMatch(subquery_outer_nodes={start})>
   ```

   Standard correlated-subquery shape that ORCA's `CSubqueryHandler` decorrelates (inner GbAgg → max-card 1; only outer ref is the start node's `_id`).

## Adjustments forced by the lowering shape

- **End-node label inference** — `PlanRegularMatch::plan_primary_graphlet_node_scan` throws when an inner node has no partition. Added `InferNodeLabelFromEdgeTypes` (a `vector<string>`-taking overload of `InferNodeLabelFromEdge`) and called it from the pattern-comprehension binder so `(p)-[:KNOWS]->(f)` resolves `f` to `Person`.
- **Collect's generic return type** — the catalog's `collect` signature has `LIST` with no child type, which `GetTypeMod` cannot encode. The result `CColRef`'s `type_mod` is built off the binder's already-concrete `LIST<map_type>` (= `expr.GetDataType()`) instead.

## Status — acceptance probes

| # | Query | Result |
|---|---|---|
| 1 | \`MATCH (p:Person {firstName:'Hossein'}) RETURN [(p)-[:KNOWS]->(f) \| f.firstName] AS friends\` | **\`[Ken, Alim, Alexei]\`** ✓ (matches #184 acceptance line 1) |
| 2 | WHERE inside: \`[(p)-[:KNOWS]->(f) WHERE f.firstName <> 'Ken' \| f.firstName]\` | \`[Alim, Alexei]\` ✓ |
| 3 | Multi-hop: \`[(p)-[:KNOWS]->(f)-[:KNOWS]->(g) \| g.firstName]\` | 13-element list of friends-of-friends ✓ |
| 4 | Label-typed end: \`[(p)-[:KNOWS]->(f:Person) \| f.firstName]\` | \`[Ken, Alim, Alexei]\` ✓ |
| 5 | WITH context: \`WITH p, [(p)-[:KNOWS]->(f) \| f.firstName] AS fs RETURN size(fs)\` | \`3\` ✓ |
| 6 | Undirected: \`[(p)-[:KNOWS]-(f) \| f.firstName]\` | ❌ ASan crash — follow-up |

Regression checks:
- \`[ldbc][filter][issue227]\` — **11 / 11 pass**
- \`[tpch]~[stress]\` — 53 / 55 pass (the 2 \`[issue159]\` failures exist on \`main\` already, unrelated to this PR)

## Out of scope (deferred to PR-2 / PR-3)

- Undirected edges (the one acceptance line still failing)
- Path binding `[p = (a)-[:R]->(b) | length(p)]`
- Variable-length `[(a)-[:R*1..3]->(b) | …]`
- Inline property predicates `{prop: val}` — parser doesn't surface them yet
- Nested pattern comprehensions / aggregate context
- IC14 specialized rewrite retirement

## Stack

PR226 → PR228 → PR229 → PR230 → PR231 (PR-1.1) → PR-1.1.5 (BoundMatchClause infra, this PR's first commit) → PR-1.2 (this PR's second commit).