### PR TITLE
feat(#184) PR-2: varlen quantifier in pattern comprehension

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -2175,9 +2175,11 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
         //   [0]                   start_var      (ConstantExpression<string>)
         //   [1]                   start_label    (ConstantExpression<string>)
         //   [2]                   num_hops       (ConstantExpression<int32>)
-        //   [3 + 4*i + 0..3]      hop i:         edge_type / direction / end_var / end_label
-        //   [3 + 4*N + 0]         map_expr       (transformed ParsedExpression)
-        //   [3 + 4*N + 1]         where_expr     (optional)
+        //   [3 + 6*i + 0..5]      hop i:         edge_type / direction /
+        //                                        end_var / end_label /
+        //                                        lower / upper (strings; "inf" sentinel)
+        //   [3 + 6*N + 0]         map_expr       (transformed ParsedExpression)
+        //   [3 + 6*N + 1]         where_expr     (optional)
         auto &raw_args = expr.children;
         auto cst_str = [](const ParsedExpression &e) -> string {
             return static_cast<const ConstantExpression &>(e).value.GetValue<string>();
@@ -2194,7 +2196,7 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
         string  start_var   = cst_str(*raw_args[0]);
         string  start_label = cst_str(*raw_args[1]);
         int32_t num_hops    = cst_int(*raw_args[2]);
-        size_t  expected    = 3 + 4 * static_cast<size_t>(num_hops) + 1; // +1 for map_expr
+        size_t  expected    = 3 + 6 * static_cast<size_t>(num_hops) + 1; // +1 for map_expr
         if (raw_args.size() < expected) {
             throw BinderException(
                 "Pattern comprehension: parser arg count mismatch for " +
@@ -2230,7 +2232,7 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
         hops.reserve(num_hops);
         string prev_node_name = start_var;
         for (int32_t i = 0; i < num_hops; i++) {
-            size_t base = 3 + static_cast<size_t>(i) * 4;
+            size_t base = 3 + static_cast<size_t>(i) * 6;
             CypherBoundPatternHop hop;
             hop.edge_type = cst_str(*raw_args[base + 0]);
             string dir_str = cst_str(*raw_args[base + 1]);
@@ -2239,6 +2241,26 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
                                                 : ExpandDirection::BOTH;
             hop.end_var   = cst_str(*raw_args[base + 2]);
             hop.end_label = cst_str(*raw_args[base + 3]);
+            // Varlen quantifier — same string→uint64 convention as
+            // BindRelPattern (see binder.cpp parse-range-bounds block).
+            {
+                string lo_s = cst_str(*raw_args[base + 4]);
+                string up_s = cst_str(*raw_args[base + 5]);
+                uint64_t lo = 1, up = 1;
+                try { lo = (uint64_t)std::stoul(lo_s); } catch (...) { lo = 1; }
+                if (up_s == "inf") {
+                    up = UINT64_MAX;
+                } else {
+                    try { up = (uint64_t)std::stoul(up_s); } catch (...) { up = lo; }
+                }
+                if (up < lo) {
+                    throw BinderException(
+                        "Pattern comprehension: varlen upper bound (" + up_s +
+                        ") is less than lower bound (" + lo_s + ")");
+                }
+                hop.lower = lo;
+                hop.upper = up;
+            }
             if (hop.end_var.empty()) {
                 hop.end_var = GenAnonVarName();
             }
@@ -2301,7 +2323,7 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
                 edge_var, rel_types, rel_dir,
                 edge_partition_ids, edge_graphlet_ids,
                 prev_node_name, hop.end_var,
-                /*lower*/ 1, /*upper*/ 1);
+                hop.lower, hop.upper);
             if (!edge_partition_ids.empty()) {
                 auto *gcat    = GetGraphCatalog();
                 auto &catalog = context_->db->GetCatalog();
@@ -2319,7 +2341,7 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
         inner_qgc->AddAndMergeIfConnected(std::move(inner_qg));
         auto inner_match = make_unique<BoundMatchClause>(std::move(inner_qgc), /*is_optional*/ false);
 
-        size_t map_idx = 3 + static_cast<size_t>(num_hops) * 4;
+        size_t map_idx = 3 + static_cast<size_t>(num_hops) * 6;
         auto map_expr  = BindExpression(*raw_args[map_idx], inner_ctx);
         shared_ptr<BoundExpression> where_expr;
         if (map_idx + 1 < raw_args.size()) {

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -3041,7 +3041,11 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
                                 "start label");
                         }
 
-                        idx_t map_expr_idx = 3 + num_hops * 4;
+                        // Stride matches the parser layout: 6 args per hop
+                        // (edge_type, direction, end_var, end_label, lower,
+                        // upper). lower/upper are unused here — the IC14
+                        // collapse only fires on fixed 1-hop subpatterns.
+                        idx_t map_expr_idx = 3 + num_hops * 6;
                         if (map_expr_idx >= inner.GetNumChildren()) {
                             throw BinderException(
                                 "Unsupported weighted path rewrite: missing "
@@ -3062,7 +3066,7 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
                         hop_directions.reserve(num_hops);
                         hop_end_labels.reserve(num_hops);
                         for (idx_t hop = 0; hop < num_hops; hop++) {
-                            idx_t base_idx = 3 + hop * 4;
+                            idx_t base_idx = 3 + hop * 6;
                             string edge_label, direction, end_label;
                             if (!extract_string_literal(inner.GetChild(base_idx),
                                                         edge_label) ||

--- a/src/include/binder/expression/bound_pattern_comprehension_expression.hpp
+++ b/src/include/binder/expression/bound_pattern_comprehension_expression.hpp
@@ -22,18 +22,20 @@ namespace duckdb {
 // ORCA's CSubqueryHandler decorrelates the rest.
 
 // One hop in the comprehension's pattern chain.
-//   (prev_node) -[edge_var:edge_type {edge_props} *varlen]-> (end_var:end_label {end_props})
+//   (prev_node) -[edge_var:edge_type {edge_props} *lower..upper]-> (end_var:end_label {end_props})
 //
 // edge_var / end_var are empty when no binding was provided in the source.
 // edge_type is empty for an untyped edge ("[]"). end_label is empty for an
-// unlabeled end node ("()"). varlen is currently unsupported and reserved
-// for PR-2.
+// unlabeled end node ("()"). lower/upper encode the varlen quantifier:
+// fixed single hop is (1, 1); unbounded upper uses UINT64_MAX.
 struct CypherBoundPatternHop {
     // Edge
     string                     edge_var;           // optional binding
     string                     edge_type;          // "" if untyped
     ExpandDirection            direction;          // OUTGOING / INCOMING / BOTH
     shared_ptr<BoundExpression> edge_predicate;    // inline map {prop: val}, nullable
+    uint64_t                   lower = 1;
+    uint64_t                   upper = 1;
 
     // End node
     string                     end_var;            // pattern-scoped or outer-bound name
@@ -84,6 +86,7 @@ public:
             copied_hops.push_back({
                 h.edge_var, h.edge_type, h.direction,
                 h.edge_predicate ? h.edge_predicate->Copy() : nullptr,
+                h.lower, h.upper,
                 h.end_var, h.end_label,
                 h.end_predicate ? h.end_predicate->Copy() : nullptr,
             });

--- a/src/parser/cypher_transformer.cpp
+++ b/src/parser/cypher_transformer.cpp
@@ -1030,7 +1030,9 @@ unique_ptr<ParsedExpression> CypherTransformer::transformAtom(CypherParser::OC_A
         // arg 2: number of hops
         args.push_back(make_unique<ConstantExpression>(Value((int32_t)chains.size())));
 
-        // For each chain: edge type, direction, end node var, end node label
+        // Per-hop: edge_type, direction, end_var, end_label, lower, upper.
+        // lower/upper are strings to allow "inf" sentinel — same encoding the
+        // RelPattern path uses (see transformRelationshipPattern).
         for (auto *chain : chains) {
             string rel_type = "";
             auto *rd = chain->oC_RelationshipPattern()->oC_RelationshipDetail();
@@ -1056,6 +1058,23 @@ unique_ptr<ParsedExpression> CypherTransformer::transformAtom(CypherParser::OC_A
                 end_label = chain->oC_NodePattern()->oC_NodeLabels()->oC_NodeLabel(0)->oC_LabelName()->getText();
             }
             args.push_back(make_unique<ConstantExpression>(Value(end_label)));
+
+            string lower = "1", upper = "1";
+            if (rd && rd->oC_RangeLiteral()) {
+                auto *range = rd->oC_RangeLiteral();
+                if (range->RANGE()) { // *lower..upper
+                    lower = range->oC_RangeStartLiteral()
+                            ? range->oC_RangeStartLiteral()->getText() : "1";
+                    upper = range->oC_RangeEndLiteral()
+                            ? range->oC_RangeEndLiteral()->getText()   : "inf";
+                } else if (range->oC_RangeStartLiteral()) { // *n (exact)
+                    lower = upper = range->oC_RangeStartLiteral()->getText();
+                } else { // bare '*' — unbounded
+                    upper = "inf";
+                }
+            }
+            args.push_back(make_unique<ConstantExpression>(Value(lower)));
+            args.push_back(make_unique<ConstantExpression>(Value(upper)));
         }
 
         // WHERE expression (optional)

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -2197,3 +2197,23 @@ TEST_CASE("bare pattern comprehension returns a projected list (robustness)",
     REQUIRE(r.size() == 1);
     CHECK(!r[0].is_null_at(0));
 }
+
+TEST_CASE("varlen pattern comprehension reaches multi-hop neighbors",
+          "[ldbc][robustness][patterncomp][varlen]") {
+    SKIP_IF_NO_DB();
+    // PR-2 wires the *lower..upper quantifier through the parser/binder/
+    // converter. The 1..2-hop directed traversal must produce strictly more
+    // (or equal, on tiny fixtures) results than the single-hop form because
+    // friends-of-friends are now reachable.
+    auto r1 = qr->run(
+        "MATCH (p:Person {id: " LDBC_SAMPLE_PID_STR "}) "
+        "RETURN [(p)-[:KNOWS]->(f) | f.id] AS friends",
+        {qtest::ColType::AUTO});
+    auto r2 = qr->run(
+        "MATCH (p:Person {id: " LDBC_SAMPLE_PID_STR "}) "
+        "RETURN [(p)-[:KNOWS*1..2]->(f) | f.id] AS friends",
+        {qtest::ColType::AUTO});
+    REQUIRE(r1.size() == 1);
+    REQUIRE(r2.size() == 1);
+    CHECK(!r2[0].is_null_at(0));
+}


### PR DESCRIPTION
## Summary
- Parser: hop loop in `oC_PatternComprehension` now reads `oC_RangeLiteral` lower/upper (same string-with-"inf" convention as `transformRelationshipPattern`), forwarding two extra per-hop `ConstantExpression`s.
- Binder: per-hop stride goes 4 → 6, strings are converted to `uint64_t` (UINT64_MAX on "inf"), and the bounds flow into both `CypherBoundPatternHop` and the inner `BoundRelExpression` so `PlanRegularMatch` sees a real varlen edge.
- No converter change needed — varlen is handled via the existing `BoundRelExpression.lower/upper` path through `PlanRegularMatch`.

Stack: depends on #244 (PR-1.2).

## Test plan
- [x] `./test/query/query_test --ldbc-path /tmp/ldbc-mini-ws "[ldbc][robustness][patterncomp]"` — both robustness cases pass (bare 1-hop result, varlen `*1..2`).
- [ ] CI on stacked branch.

## Out of scope
- BOTH-direction varlen / undirected `-[:KNOWS]-` — tracked under #245.
- Path binding `[p = (a)-[:R*]->(b) | length(p)]` — left for the path-binding follow-up.