### PR TITLE
feat(#184) PR-3c: nodes(p) / relationships(p) in pattern comprehension

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -2332,6 +2332,11 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
                 PopulateRelProperties(*edge_expr, *context_, *gcat, catalog);
             }
             inner_qg->AddQueryRel(edge_expr);
+            // Make the edge addressable from inner_ctx so the nodes(p) /
+            // relationships(p) handler can mark its _id as used (needed for
+            // PR-3c's list_value projection to find a colref in the inner
+            // plan schema).
+            inner_ctx.AddRel(edge_var, edge_expr);
 
             prev_node_name = hop.end_var;
             hops.push_back(std::move(hop));
@@ -2341,13 +2346,13 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
         // PlanRegularMatch consumes this directly.
         auto inner_qgc = make_unique<BoundQueryGraphCollection>();
         inner_qgc->AddAndMergeIfConnected(std::move(inner_qg));
-        auto inner_match = make_unique<BoundMatchClause>(std::move(inner_qgc), /*is_optional*/ false);
 
         // Path binding: register `p = ...` in the inner scope so map_expr /
         // where_expr can reference it. The existing length(path) handler
         // already rewrites to a num_chains literal for fixed-length paths
-        // via PathMeta. Varlen path references are deferred — the converter
-        // doesn't materialize a path column for inner pattern plans yet.
+        // via PathMeta. nodes(p)/relationships(p) handlers consult the
+        // node_chain/edge_chain we fill below and flip needs_* flags that
+        // ConvertPatternComprehension reads to materialize list columns.
         bool path_is_fixed_length = true;
         for (auto &h : hops) {
             if (!(h.lower == 1 && h.upper == 1)) { path_is_fixed_length = false; break; }
@@ -2356,8 +2361,20 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
             BindContext::PathMeta meta;
             meta.num_chains = (idx_t)num_hops;
             meta.is_fixed_length = path_is_fixed_length;
+            if (path_is_fixed_length) {
+                meta.node_chain.reserve(hops.size() + 1);
+                meta.node_chain.push_back(start_var);
+                for (auto &h : hops) {
+                    meta.node_chain.push_back(h.end_var);
+                }
+                for (auto &r : inner_qgc->GetQueryRels()) {
+                    meta.edge_chain.push_back(r->GetUniqueName());
+                }
+            }
             inner_ctx.AddPath(path_var, meta);
         }
+
+        auto inner_match = make_unique<BoundMatchClause>(std::move(inner_qgc), /*is_optional*/ false);
 
         size_t map_idx = 4 + static_cast<size_t>(num_hops) * 6;
         auto map_expr  = BindExpression(*raw_args[map_idx], inner_ctx);
@@ -2373,6 +2390,12 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
             inner_match->AddPredicate(where_expr);
         }
 
+        // Snapshot the (possibly mutated by nodes/rels handlers) PathMeta
+        // before path_var moves into the bound expression.
+        BindContext::PathMeta final_meta;
+        if (!path_var.empty()) {
+            final_meta = inner_ctx.GetPathMeta(path_var);
+        }
         LogicalType result_type = LogicalType::LIST(map_expr->GetDataType());
         auto bound = make_shared<CypherBoundPatternComprehensionExpression>(
             std::move(result_type),
@@ -2385,6 +2408,7 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
             std::move(map_expr),
             GenExprName(expr));
         bound->SetInnerMatch(std::move(inner_match));
+        bound->SetPathMeta(std::move(final_meta));
         return bound;
     }
 
@@ -2620,6 +2644,70 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
             }
         }
         throw BinderException("properties() requires a node or relationship variable");
+    }
+
+    // nodes(p) / relationships(p) for comprehension paths: defer column
+    // materialization to ConvertPatternComprehension. Flag the path's
+    // local PathMeta and emit a synthetic BoundVariableExpression whose
+    // name encodes which list projection the converter should produce
+    // ("{path_var}__nodes" / "__rels").
+    if (fname == "nodes" && expr.children.size() == 1 &&
+        expr.children[0]->GetExpressionType() == ExpressionType::COLUMN_REF) {
+        auto *vexpr = dynamic_cast<const ParsedVariableExpression *>(
+            expr.children[0].get());
+        if (vexpr && ctx.HasPath(vexpr->GetVariableName())) {
+            auto meta = ctx.GetPathMeta(vexpr->GetVariableName());
+            if (meta.is_fixed_length && !meta.node_chain.empty()) {
+                ctx.MarkPathNeedsNodes(vexpr->GetVariableName());
+                // node_chain[0] is the outer-bound start; only inner-bound
+                // tail nodes need their _id projected into the inner plan
+                // schema.
+                for (size_t i = 1; i < meta.node_chain.size(); i++) {
+                    if (ctx.HasNode(meta.node_chain[i])) {
+                        ctx.GetNode(meta.node_chain[i])
+                            ->GetPropertyExpression(/*ID_KEY_ID*/ 0);
+                    }
+                }
+                string n = vexpr->GetVariableName() + "__nodes";
+                // UBIGINT (id=31) rather than ID (id=108): the pCypher type
+                // encoder packs LIST(LIST(child)) into a single INT type_mod
+                // as (LIST | child_mod << 8); child_mod for LIST(ID) is 108,
+                // which crosses the 10000 boundary that the decoder reserves
+                // for the complex-type registry, and the result decodes back
+                // as ANY. UBIGINT keeps the encoded mod under the boundary
+                // and is the same physical type at runtime.
+                return make_shared<BoundVariableExpression>(
+                    n, LogicalType::LIST(LogicalType::UBIGINT), n);
+            }
+        }
+    }
+    if ((fname == "relationships" || fname == "rels") &&
+        expr.children.size() == 1 &&
+        expr.children[0]->GetExpressionType() == ExpressionType::COLUMN_REF) {
+        auto *vexpr = dynamic_cast<const ParsedVariableExpression *>(
+            expr.children[0].get());
+        if (vexpr && ctx.HasPath(vexpr->GetVariableName())) {
+            auto meta = ctx.GetPathMeta(vexpr->GetVariableName());
+            if (meta.is_fixed_length && !meta.edge_chain.empty()) {
+                ctx.MarkPathNeedsRels(vexpr->GetVariableName());
+                for (auto &edge_name : meta.edge_chain) {
+                    if (ctx.HasRel(edge_name)) {
+                        ctx.GetRel(edge_name)
+                            ->GetPropertyExpression(/*ID_KEY_ID*/ 0);
+                    }
+                }
+                string n = vexpr->GetVariableName() + "__rels";
+                // UBIGINT (id=31) rather than ID (id=108): the pCypher type
+                // encoder packs LIST(LIST(child)) into a single INT type_mod
+                // as (LIST | child_mod << 8); child_mod for LIST(ID) is 108,
+                // which crosses the 10000 boundary that the decoder reserves
+                // for the complex-type registry, and the result decodes back
+                // as ANY. UBIGINT keeps the encoded mod under the boundary
+                // and is the same physical type at runtime.
+                return make_shared<BoundVariableExpression>(
+                    n, LogicalType::LIST(LogicalType::UBIGINT), n);
+            }
+        }
     }
 
     // nodes(path) → path_nodes(path) — extract node IDs from path

--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -6,10 +6,15 @@
 #include "converter/cypher2orca_converter.hpp"
 #include "binder/expression/bound_exists_subquery_expression.hpp"
 #include "binder/expression/bound_pattern_comprehension_expression.hpp"
+#include "binder/expression/bound_property_expression.hpp"
+#include "binder/expression/bound_variable_expression.hpp"
 #include "gpopt/operators/CScalarSubquery.h"
 #include "gpopt/operators/CScalarSubqueryExists.h"
 #include "gpopt/operators/CScalarSubqueryNotExists.h"
 #include "gpopt/operators/CLogicalGbAgg.h"
+#include "gpopt/operators/CLogicalProject.h"
+#include "gpopt/operators/CScalarProjectList.h"
+#include "gpopt/operators/CScalarProjectElement.h"
 #include "planner/value_ser_des.hpp"
 #include "catalog/catalog.hpp"
 #include "catalog/catalog_wrapper.hpp"
@@ -1618,6 +1623,85 @@ CExpression *Cypher2OrcaConverter::ConvertPatternComprehension(
     turbolynx::LogicalPlan *saved_outer = outer_plan_;
     outer_plan_registered_ = true;
     outer_plan_ = outer_plan;
+
+    // PR-3c: materialize path-list projections requested by nodes(p) /
+    // relationships(p). The binder marked the chain on PathMeta and
+    // emitted synthetic BoundVariableExpression refs ("{path_var}__nodes"
+    // / "__rels") whose names we now bind to colrefs by projecting
+    // list_value over the bound node/edge _id columns. nodes(p)'s first
+    // element is the outer-bound start, which ConvertVariable resolves
+    // via outer_plan_'s schema (outer_plan_registered_ is true here).
+    {
+        const auto &pmeta = expr.GetPathMeta();
+        const string &pname = expr.GetPathVar();
+        auto add_list_projection =
+            [&](bound_expression_vector children, const string &col_alias) {
+                CColumnFactory *cf_ = COptCtxt::PoctxtFromTLS()->Pcf();
+                auto lv = make_shared<CypherBoundFunctionExpression>(
+                    "list_value", LogicalType::LIST(LogicalType::UBIGINT),
+                    std::move(children), col_alias);
+                CExpression *lv_expr = ConvertExpression(*lv, inner_plan);
+                CScalar *sop = static_cast<CScalar *>(lv_expr->Pop());
+
+                std::wstring w_alias(col_alias.begin(), col_alias.end());
+                const CWStringConst alias_wstr(w_alias.c_str());
+                CName alias_cname(&alias_wstr);
+                CColRef *pcr = cf_->PcrCreate(
+                    GetMDAccessor()->RetrieveType(sop->MdidType()),
+                    sop->TypeModifier(), alias_cname);
+
+                CExpressionArray *proj_array =
+                    GPOS_NEW(mp_) CExpressionArray(mp_);
+                proj_array->Append(GPOS_NEW(mp_) CExpression(
+                    mp_, GPOS_NEW(mp_) CScalarProjectElement(mp_, pcr),
+                    lv_expr));
+                CExpression *proj_list = GPOS_NEW(mp_) CExpression(
+                    mp_, GPOS_NEW(mp_) CScalarProjectList(mp_), proj_array);
+                auto *inner_expr_p = inner_plan->getPlanExpr();
+                inner_expr_p->AddRef();
+                CExpression *proj_expr = GPOS_NEW(mp_) CExpression(
+                    mp_, GPOS_NEW(mp_) CLogicalProject(mp_),
+                    inner_expr_p, proj_list);
+                turbolynx::LogicalSchema new_schema = *inner_plan->getSchema();
+                new_schema.appendColumn(col_alias, pcr);
+                inner_plan = GPOS_NEW(mp_) turbolynx::LogicalPlan(
+                    proj_expr, new_schema);
+            };
+        auto make_var = [](const string &n) -> shared_ptr<BoundExpression> {
+            return make_shared<BoundVariableExpression>(
+                n, LogicalType::UBIGINT, n);
+        };
+        if (pmeta.needs_rel_list && !pmeta.edge_chain.empty()) {
+            bound_expression_vector children;
+            children.reserve(pmeta.edge_chain.size());
+            for (auto &n : pmeta.edge_chain) children.push_back(make_var(n));
+            add_list_projection(std::move(children), pname + "__rels");
+        }
+        if (pmeta.needs_node_list && !pmeta.node_chain.empty()) {
+            // The first element is the outer-bound start, but its _id is
+            // also reachable as `first_edge.SID/TID` on the inner plan
+            // (the correlation predicate makes them equal). Substitute it
+            // so the list_value scalar stays inner-bound — otherwise
+            // ORCA's decorrelator falls back to
+            // CPhysicalCorrelatedLeftOuterNLJoin, which we don't lower yet.
+            bound_expression_vector children;
+            children.reserve(pmeta.node_chain.size());
+            auto cit = corr_keys.find(pmeta.node_chain.front());
+            if (cit != corr_keys.end()) {
+                children.push_back(make_shared<BoundPropertyExpression>(
+                    cit->second.edge_name, cit->second.edge_key_id,
+                    LogicalType::UBIGINT,
+                    cit->second.edge_name + "._pc_corr_id"));
+            } else {
+                children.push_back(make_var(pmeta.node_chain.front()));
+            }
+            for (size_t i = 1; i < pmeta.node_chain.size(); ++i) {
+                children.push_back(make_var(pmeta.node_chain[i]));
+            }
+            add_list_projection(std::move(children), pname + "__nodes");
+        }
+    }
+
     CExpression *map_orca = ConvertExpression(*expr.GetMapExpr(), inner_plan);
     outer_plan_registered_ = saved_reg;
     outer_plan_ = saved_outer;

--- a/src/include/binder/bind_context.hpp
+++ b/src/include/binder/bind_context.hpp
@@ -50,6 +50,19 @@ public:
     struct PathMeta {
         idx_t num_chains = 0;       // total relationship hops in the pattern
         bool  is_fixed_length = true;  // all rels have lower==upper==1
+        // Optional materialized chain (start + each hop's end node, and each
+        // hop's edge). Populated for pattern-comprehension paths so the
+        // converter can project list_value({node|edge}_ids) on the inner plan
+        // when nodes(p) / relationships(p) appear in the mapping expression.
+        // Empty for plain MATCH paths — those still use the path_nodes /
+        // path_rels runtime fallback.
+        vector<string> node_chain;
+        vector<string> edge_chain;
+        // Set by the nodes(p)/relationships(p) handler so the comprehension's
+        // converter knows which list projection columns to materialize on
+        // the inner plan and which synthetic name to address.
+        bool needs_node_list = false;
+        bool needs_rel_list = false;
     };
     void AddPath(const string& name) {
         path_bindings_.insert(name);
@@ -68,6 +81,18 @@ public:
         auto it = path_meta_.find(name);
         if (it != path_meta_.end()) return it->second;
         return outer_ ? outer_->GetPathMeta(name) : PathMeta{};
+    }
+    // Mark a *locally-bound* path as needing node/edge list projection. We
+    // only flip flags on entries owned by this scope; outer-scope paths are
+    // immutable from here (a comprehension never modifies the enclosing
+    // query's MATCH-path bindings).
+    void MarkPathNeedsNodes(const string& name) {
+        auto it = path_meta_.find(name);
+        if (it != path_meta_.end()) it->second.needs_node_list = true;
+    }
+    void MarkPathNeedsRels(const string& name) {
+        auto it = path_meta_.find(name);
+        if (it != path_meta_.end()) it->second.needs_rel_list = true;
     }
 
     void AddPathRelsAlias(const string& alias, const string& path_name) {

--- a/src/include/binder/expression/bound_pattern_comprehension_expression.hpp
+++ b/src/include/binder/expression/bound_pattern_comprehension_expression.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "binder/bind_context.hpp"
 #include "binder/expression/bound_expression.hpp"
 #include "binder/query/reading_clause/bound_match_clause.hpp"
 #include "common/typedef.hpp"
@@ -82,6 +83,14 @@ public:
     const BoundMatchClause*    GetInnerMatch() const { return inner_match.get(); }
     bool                       HasInnerMatch() const { return inner_match != nullptr; }
 
+    // Path-binding metadata transferred from inner BindContext after the
+    // mapping expression has been bound. The converter consults
+    // needs_node_list / needs_rel_list to materialize list projections on
+    // the inner plan and address them by the synthetic names
+    // "{path_var}__nodes" / "{path_var}__rels".
+    void                       SetPathMeta(BindContext::PathMeta m) { path_meta = std::move(m); }
+    const BindContext::PathMeta& GetPathMeta() const { return path_meta; }
+
     shared_ptr<BoundExpression> Copy() const override {
         vector<CypherBoundPatternHop> copied_hops;
         copied_hops.reserve(hops.size());
@@ -110,6 +119,7 @@ public:
 
 private:
     string                              path_var;
+    BindContext::PathMeta               path_meta;
     string                              start_var;
     string                              start_label;
     shared_ptr<BoundExpression>         start_predicate;

--- a/test/query/test_ldbc_robustness.cpp
+++ b/test/query/test_ldbc_robustness.cpp
@@ -2218,6 +2218,35 @@ TEST_CASE("varlen pattern comprehension reaches multi-hop neighbors",
     CHECK(!r2[0].is_null_at(0));
 }
 
+TEST_CASE("path-bound pattern comprehension: relationships(p)",
+          "[ldbc][robustness][patterncomp][pathbind]") {
+    SKIP_IF_NO_DB();
+    // PR-3c: relationships(p) lowers to a synthetic BoundVariableExpression
+    // ("{path_var}__rels") that the converter resolves by projecting
+    // list_value(edge_ids…) on the inner subplan. All elements are
+    // inner-bound so no outer-ref scalar appears inside the list.
+    auto r = qr->run(
+        "MATCH (p:Person {id: " LDBC_SAMPLE_PID_STR "}) "
+        "RETURN [q = (p)-[:KNOWS]->(f) | relationships(q)] AS rel_lists",
+        {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(!r[0].is_null_at(0));
+}
+
+TEST_CASE("path-bound pattern comprehension: nodes(p)",
+          "[ldbc][robustness][patterncomp][pathbind]") {
+    SKIP_IF_NO_DB();
+    // PR-3c: nodes(p)'s first element is the outer-bound start, so the
+    // converter relies on ORCA outer-ref decorrelation to pass
+    // outer.p._id into the list_value scalar projected on the inner plan.
+    auto r = qr->run(
+        "MATCH (p:Person {id: " LDBC_SAMPLE_PID_STR "}) "
+        "RETURN [q = (p)-[:KNOWS]->(f) | nodes(q)] AS node_lists",
+        {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(!r[0].is_null_at(0));
+}
+
 TEST_CASE("path-bound pattern comprehension: length(p) for fixed-length pattern",
           "[ldbc][robustness][patterncomp][pathbind]") {
     SKIP_IF_NO_DB();


### PR DESCRIPTION
## Summary
- PathMeta carries the materialized node/edge chain + needs_*_list flags. nodes(p) / relationships(p) handlers flip the flags and call \`GetPropertyExpression(0)\` on each chain node/edge so PlanRegularMatch projects the \`_id\` column into the inner plan.
- ConvertPatternComprehension projects a CScalarFunc(\`list_value\`) of UBIGINT \`_id\` refs onto the inner plan and exposes the result under \`{path_var}__nodes\` / \`__rels\`. The binder's synthetic BoundVariableExpression resolves against that column.

Stack: depends on #247 (PR-3a).

## Two non-obvious calls
1. **LIST element type = UBIGINT (not ID).** The converter's nested-LIST type_mod encoding packs \`LIST(LIST(child))\` as \`LIST.id | child_mod<<8\`; for child=ID (108) that yields 27749, which crosses the 10000 registry boundary in \`pConvertTypeOidToLogicalType\`. With no registry entry the type decodes back to ANY and GetTypeIdSize aborts on INVALID. UBIGINT keeps the encoded mod (8037) under the boundary; same UINT64 physical type. Encoder reform is its own change.
2. **nodes(p) first element substitution.** The first node is outer-bound. Emitting an outer-ref CScalarIdent inside list_value pushes ORCA to CPhysicalCorrelatedLeftOuterNLJoin (turbolynx physical-plan translator doesn't lower it yet). The correlation predicate already equates that start's \`_id\` with the first inner edge's SID/TID, so we substitute that inner column — the list scalar stays inner-bound and ORCA's normal decorrelation handles it.

## Test plan
- [x] \`./test/query/query_test --ldbc-path /tmp/ldbc-mini-ws \"[ldbc][robustness][patterncomp]\"\` — 5/5 (varlen + bare + nodes(p) + relationships(p) + length(p)).
- [x] \`./test/query/query_test --ldbc-path /tmp/ldbc-mini-ws \"[ic14]\"\` — 3/3, no regression in the weighted-path collapse.
- [ ] CI on stacked branch.

## Out of scope
- Variable-length \`length(p)\` (dynamic path length) — needs PATH-column materialization on the inner plan.
- BOTH-direction varlen edges — Issue #245.
- Encoder boundary reform.