### PR TITLE
refactor(#249) PR-α: unify ORCA type_mod encoding behind a single helper

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -9,6 +9,7 @@
 #include "catalog/catalog.hpp"
 #include "catalog/catalog_wrapper.hpp"
 #include "common/constants.hpp"
+#include "common/orca_type_encoding.hpp"
 #include "main/database.hpp"
 #include "binder/expression/bound_property_expression.hpp"
 #include "binder/expression/bound_function_expression.hpp"
@@ -4526,31 +4527,8 @@ GraphCatalogEntry *Cypher2OrcaConverter::GetGraphCatalog()
 // ============================================================
 INT Cypher2OrcaConverter::GetTypeMod(const LogicalType &type)
 {
-    INT mod = 0;
-    if (type.id() == LogicalTypeId::DECIMAL) {
-        uint16_t ws = DecimalType::GetWidth(type);
-        ws = ws << 8 | DecimalType::GetScale(type);
-        mod = ws;
-    } else if (type.id() == LogicalTypeId::LIST) {
-        auto &child = ListType::GetChildType(type);
-        if (child.id() == LogicalTypeId::LIST) {
-            INT child_mod = GetTypeMod(child);
-            mod = (INT)LogicalTypeId::LIST | child_mod << 8;
-        } else if (child.id() == LogicalTypeId::STRUCT) {
-            // Store STRUCT child in registry, use registry index as modifier
-            INT reg_id = next_complex_type_id_++;
-            complex_type_registry_[reg_id] = type;  // store full LIST(STRUCT(...))
-            mod = reg_id;
-        } else {
-            mod = (INT)child.id();
-        }
-    } else if (type.id() == LogicalTypeId::STRUCT) {
-        // STRUCT as standalone (not in LIST) — also use registry
-        INT reg_id = next_complex_type_id_++;
-        complex_type_registry_[reg_id] = type;
-        mod = reg_id;
-    }
-    return mod;
+    return (INT)turbolynx::EncodeTypeMod(type, &complex_type_registry_,
+                                         &next_complex_type_id_);
 }
 
 bool Cypher2OrcaConverter::IsCastingFunction(const string &func_name)

--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -8,6 +8,7 @@
 #include "binder/expression/bound_pattern_comprehension_expression.hpp"
 #include "binder/expression/bound_property_expression.hpp"
 #include "binder/expression/bound_variable_expression.hpp"
+#include "common/orca_type_encoding.hpp"
 #include "gpopt/operators/CScalarSubquery.h"
 #include "gpopt/operators/CScalarSubqueryExists.h"
 #include "gpopt/operators/CScalarSubqueryNotExists.h"
@@ -95,32 +96,20 @@ private:
     CColRef *previous = nullptr;
 };
 
+// Local wrappers around turbolynx::DecodeTypeId / DecodeTypeMod so existing
+// callers in this file keep their signatures. These don't see the converter's
+// complex-type registry: registry-encoded modifiers fall back to ANY (same
+// behavior as before the refactor — see issue #249 for the encoder reform
+// that will fix this for real).
 static duckdb::LogicalTypeId OidToLogicalTypeId(OID oid)
 {
-    return (duckdb::LogicalTypeId)(
-        static_cast<std::underlying_type_t<duckdb::LogicalTypeId>>(
-            (oid - LOGICAL_TYPE_BASE_ID) % NUM_MAX_LOGICAL_TYPES));
+    return turbolynx::DecodeTypeId((uint32_t)oid);
 }
 
 static duckdb::LogicalType OidToLogicalType(OID oid, INT type_mod)
 {
-    auto tid = OidToLogicalTypeId(oid);
-    if (tid == duckdb::LogicalTypeId::DECIMAL) {
-        if (type_mod <= 0) return duckdb::LogicalType::DECIMAL(12, 2);
-        uint8_t w = (uint8_t)(type_mod >> 8);
-        uint8_t s = (uint8_t)(type_mod & 0xFF);
-        return duckdb::LogicalType::DECIMAL(w, s);
-    }
-    if (tid == duckdb::LogicalTypeId::LIST) {
-        if (type_mod < 0) return duckdb::LogicalType::LIST(duckdb::LogicalType::UBIGINT);
-        OID child_oid = (OID)(type_mod & 0xFF) + LOGICAL_TYPE_BASE_ID;
-        INT child_mod = (type_mod >> 8);
-        return duckdb::LogicalType::LIST(OidToLogicalType(child_oid, child_mod));
-    }
-    if (tid == duckdb::LogicalTypeId::PATH) {
-        return duckdb::LogicalType::LIST(duckdb::LogicalType::UBIGINT);
-    }
-    return duckdb::LogicalType(tid);
+    return turbolynx::DecodeTypeMod((uint32_t)oid, (int32_t)type_mod,
+                                    /*registry*/ nullptr);
 }
 
 // ============================================================

--- a/src/include/common/orca_type_encoding.hpp
+++ b/src/include/common/orca_type_encoding.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "catalog/catalog.hpp"  // LOGICAL_TYPE_BASE_ID, NUM_MAX_LOGICAL_TYPES
+#include "common/exception.hpp"
+#include "common/types.hpp"
+
+#include <cstdint>
+#include <type_traits>
+#include <unordered_map>
+
+namespace turbolynx {
+
+// Single source of truth for packing a duckdb::LogicalType into ORCA's
+// (oid, type_mod) pair. ORCA's type metadata is a single INT modifier
+// alongside the type OID, so anything that can't fit in that INT — STRUCT
+// fields, deeply-nested LIST element types — lives in a side registry the
+// converter writes and the planner reads.
+//
+// The three sites that previously open-coded this logic
+// (Cypher2OrcaConverter::GetTypeMod, the static OidToLogicalType in
+// cypher2orca_scalar.cpp, and Planner::pConvertTypeOidToLogicalType) now go
+// through these helpers so encode and decode stay in lock-step.
+
+using ComplexTypeRegistry = std::unordered_map<int32_t, duckdb::LogicalType>;
+
+// Modifiers in [COMPLEX_TYPE_REGISTRY_MIN, ...) are treated as registry
+// handles rather than bit-packed metadata. PR-α preserves the historical
+// boundary; PR-β will widen it together with the LIST child slot.
+constexpr int32_t COMPLEX_TYPE_REGISTRY_MIN = 10000;
+
+inline duckdb::LogicalTypeId DecodeTypeId(uint32_t oid)
+{
+    using TidUnder = std::underlying_type_t<duckdb::LogicalTypeId>;
+    return static_cast<duckdb::LogicalTypeId>(
+        static_cast<TidUnder>((oid - LOGICAL_TYPE_BASE_ID) % NUM_MAX_LOGICAL_TYPES));
+}
+
+// Encode a LogicalType into ORCA's (oid, INT type_mod). The OID is
+// LOGICAL_TYPE_BASE_ID + LogicalTypeId.id() at the call site; this helper
+// only produces the INT modifier.
+//
+// `registry` and `next_complex_id` are used to stash types that don't fit
+// the bit-packed layout (STRUCT fields, LIST(STRUCT)). They are required
+// for those cases — pass nullptr only when the caller already knows the
+// type is bit-packable.
+inline int32_t EncodeTypeMod(const duckdb::LogicalType &type,
+                              ComplexTypeRegistry *registry,
+                              int32_t *next_complex_id)
+{
+    using duckdb::LogicalTypeId;
+    if (type.id() == LogicalTypeId::DECIMAL) {
+        uint16_t w = (uint16_t)duckdb::DecimalType::GetWidth(type);
+        uint16_t s = (uint16_t)duckdb::DecimalType::GetScale(type);
+        return ((int32_t)w << 8) | s;
+    }
+    if (type.id() == LogicalTypeId::LIST) {
+        auto &child = duckdb::ListType::GetChildType(type);
+        if (child.id() == LogicalTypeId::LIST) {
+            int32_t cmod = EncodeTypeMod(child, registry, next_complex_id);
+            return (int32_t)LogicalTypeId::LIST | (cmod << 8);
+        }
+        if (child.id() == LogicalTypeId::STRUCT) {
+            if (!registry || !next_complex_id) {
+                throw duckdb::InternalException(
+                    "EncodeTypeMod: LIST(STRUCT) requires registry");
+            }
+            int32_t id = (*next_complex_id)++;
+            (*registry)[id] = type;  // store full LIST(STRUCT(...))
+            return id;
+        }
+        return (int32_t)child.id();
+    }
+    if (type.id() == LogicalTypeId::STRUCT) {
+        if (!registry || !next_complex_id) {
+            throw duckdb::InternalException(
+                "EncodeTypeMod: STRUCT requires registry");
+        }
+        int32_t id = (*next_complex_id)++;
+        (*registry)[id] = type;
+        return id;
+    }
+    return 0;
+}
+
+// Decode (oid, INT type_mod) back into a LogicalType. `registry` is the
+// converter-populated map; when null, registry handles fall through to the
+// legacy ANY-on-miss behavior (preserved so call sites that historically
+// didn't pass a registry still compile).
+inline duckdb::LogicalType DecodeTypeMod(uint32_t oid, int32_t type_mod,
+                                          const ComplexTypeRegistry *registry)
+{
+    using duckdb::LogicalTypeId;
+    auto tid = DecodeTypeId(oid);
+    if (tid == LogicalTypeId::DECIMAL) {
+        if (type_mod == 0 || type_mod == -1) {
+            return duckdb::LogicalType::DECIMAL(12, 2);
+        }
+        uint8_t w = (uint8_t)(type_mod >> 8);
+        uint8_t s = (uint8_t)(type_mod & 0xFF);
+        return duckdb::LogicalType::DECIMAL(w, s);
+    }
+    if (tid == LogicalTypeId::LIST) {
+        if (type_mod == -1) {
+            return duckdb::LogicalType::LIST(duckdb::LogicalType::UBIGINT);
+        }
+        if (type_mod >= COMPLEX_TYPE_REGISTRY_MIN) {
+            if (registry) {
+                auto it = registry->find(type_mod);
+                if (it != registry->end()) return it->second;
+            }
+            return duckdb::LogicalType::ANY;
+        }
+        uint32_t cooid = (uint32_t)(type_mod & 0xFF) + LOGICAL_TYPE_BASE_ID;
+        int32_t cmod = (type_mod >> 8);
+        return duckdb::LogicalType::LIST(DecodeTypeMod(cooid, cmod, registry));
+    }
+    if (tid == LogicalTypeId::PATH) {
+        return duckdb::LogicalType::LIST(duckdb::LogicalType::UBIGINT);
+    }
+    if (tid == LogicalTypeId::STRUCT && type_mod >= COMPLEX_TYPE_REGISTRY_MIN) {
+        if (registry) {
+            auto it = registry->find(type_mod);
+            if (it != registry->end()) return it->second;
+        }
+        return duckdb::LogicalType::ANY;
+    }
+    return duckdb::LogicalType(tid);
+}
+
+}  // namespace turbolynx

--- a/src/include/common/orca_type_encoding.hpp
+++ b/src/include/common/orca_type_encoding.hpp
@@ -103,11 +103,14 @@ inline duckdb::LogicalType DecodeTypeMod(uint32_t oid, int32_t type_mod,
         if (type_mod == -1) {
             return duckdb::LogicalType::LIST(duckdb::LogicalType::UBIGINT);
         }
-        if (type_mod >= COMPLEX_TYPE_REGISTRY_MIN) {
-            if (registry) {
-                auto it = registry->find(type_mod);
-                if (it != registry->end()) return it->second;
-            }
+        // With a registry: registry handles win, miss falls back to ANY
+        // (legacy). Without a registry: callers (notably the file-scope
+        // helper in cypher2orca_scalar) historically plain-decoded the
+        // modifier unconditionally — keep that behavior so they don't
+        // suddenly start seeing ANY for registry-encoded LIST(STRUCT).
+        if (registry && type_mod >= COMPLEX_TYPE_REGISTRY_MIN) {
+            auto it = registry->find(type_mod);
+            if (it != registry->end()) return it->second;
             return duckdb::LogicalType::ANY;
         }
         uint32_t cooid = (uint32_t)(type_mod & 0xFF) + LOGICAL_TYPE_BASE_ID;
@@ -117,11 +120,10 @@ inline duckdb::LogicalType DecodeTypeMod(uint32_t oid, int32_t type_mod,
     if (tid == LogicalTypeId::PATH) {
         return duckdb::LogicalType::LIST(duckdb::LogicalType::UBIGINT);
     }
-    if (tid == LogicalTypeId::STRUCT && type_mod >= COMPLEX_TYPE_REGISTRY_MIN) {
-        if (registry) {
-            auto it = registry->find(type_mod);
-            if (it != registry->end()) return it->second;
-        }
+    if (tid == LogicalTypeId::STRUCT && registry &&
+        type_mod >= COMPLEX_TYPE_REGISTRY_MIN) {
+        auto it = registry->find(type_mod);
+        if (it != registry->end()) return it->second;
         return duckdb::LogicalType::ANY;
     }
     return duckdb::LogicalType(tid);

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -12,6 +12,7 @@
 #include "common/enums/index_type.hpp"
 #include "common/constants.hpp"
 #include "catalog/catalog.hpp"
+#include "common/orca_type_encoding.hpp"
 #include "catalog/catalog_entry/index_catalog_entry.hpp"
 #include "catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "main/database.hpp"
@@ -418,40 +419,11 @@ private:
 		return name;
 	}
 	inline duckdb::LogicalType pConvertTypeOidToLogicalType(OID oid, INT type_mod) {
-		auto type_id = pConvertTypeOidToLogicalTypeId(oid);
-		if (type_id == duckdb::LogicalTypeId::DECIMAL) {
-			if (type_mod == 0 || type_mod == -1) {
-				return duckdb::LogicalType::DECIMAL(12, 2);
-			} 
-			else {
-				uint8_t width = (uint8_t)(type_mod >> 8);
-				uint8_t scale = (uint8_t)(type_mod & 0xFF);
-				return duckdb::LogicalType::DECIMAL(width, scale);
-			}
-		}
-		else if (type_id == duckdb::LogicalTypeId::LIST) {
-			if (type_mod == -1) {
-				return duckdb::LogicalType::LIST(duckdb::LogicalType::UBIGINT);
-			}
-			if (type_mod >= 10000) {
-				// Complex type — look up full LIST(STRUCT(...)) from registry
-				return ResolveComplexType(type_mod);
-			}
-			INT child_type_oid = (type_mod & 0xFF) + LOGICAL_TYPE_BASE_ID;
-			INT child_type_mod = (type_mod >> 8);
-			return duckdb::LogicalType::LIST(pConvertTypeOidToLogicalType((OID)child_type_oid, child_type_mod));
-		}
-		else if (type_id == duckdb::LogicalTypeId::PATH) {
-			return duckdb::LogicalType::LIST(duckdb::LogicalType::UBIGINT);
-		}
-		else if (type_id == duckdb::LogicalTypeId::STRUCT && type_mod >= 10000) {
-			// Complex type — look up full type from registry
-			return ResolveComplexType(type_mod);
-		}
-		return duckdb::LogicalType(type_id);
+		return turbolynx::DecodeTypeMod((uint32_t)oid, (int32_t)type_mod,
+		                                &complex_type_registry);
 	}
 	inline duckdb::LogicalTypeId pConvertTypeOidToLogicalTypeId(OID oid) {
-		return (duckdb::LogicalTypeId) static_cast<std::underlying_type_t<duckdb::LogicalTypeId>>((oid - LOGICAL_TYPE_BASE_ID) % NUM_MAX_LOGICAL_TYPES);
+		return turbolynx::DecodeTypeId((uint32_t)oid);
 	}
 	duckdb::CypherPhysicalOperatorGroups *pBuildSchemaflowGraphForBinaryJoin(CExpression *plan_expr, duckdb::CypherPhysicalOperator *op, duckdb::Schema& output_schema, bool swap_children = false);
 	duckdb::CypherPhysicalOperatorGroups *pBuildSchemaflowGraphForBinaryJoin(CExpression *plan_expr, duckdb::CypherPhysicalOperator *op, duckdb::Schema& output_schema,

--- a/test/common/test_orca_type_encoding.cpp
+++ b/test/common/test_orca_type_encoding.cpp
@@ -1,0 +1,101 @@
+// =============================================================================
+// [common][orca_type_encoding] round-trip unit tests
+// =============================================================================
+// Tag: [common][orca_type_encoding]
+//
+// Encode/decode LogicalType <-> (oid, type_mod) goes through three call sites
+// (converter::GetTypeMod, the static OidToLogicalType in cypher2orca_scalar,
+// Planner::pConvertTypeOidToLogicalType). The shared helper in
+// common/orca_type_encoding.hpp is the single source of truth; these tests
+// pin the round-trip behavior so any future encoder reform stays compatible.
+//
+// Issue #249 tracks the longer-term reform (boundary widening + sentinel
+// bit); these tests document what the *current* encoding can represent.
+// =============================================================================
+
+#include "catch.hpp"
+
+#include "catalog/catalog.hpp"
+#include "common/orca_type_encoding.hpp"
+#include "common/types.hpp"
+
+using namespace duckdb;
+using turbolynx::ComplexTypeRegistry;
+using turbolynx::DecodeTypeMod;
+using turbolynx::EncodeTypeMod;
+
+namespace {
+
+// Convenience: encode + decode through a freshly-allocated registry.
+LogicalType RoundTrip(const LogicalType &input) {
+    ComplexTypeRegistry registry;
+    int32_t next_id = turbolynx::COMPLEX_TYPE_REGISTRY_MIN;
+    int32_t mod = EncodeTypeMod(input, &registry, &next_id);
+    uint32_t oid = (uint32_t)LOGICAL_TYPE_BASE_ID + (uint32_t)input.id();
+    return DecodeTypeMod(oid, mod, &registry);
+}
+
+}  // namespace
+
+TEST_CASE("orca_type_encoding: scalar round-trip", "[common][orca_type_encoding]") {
+    for (auto id : {LogicalTypeId::BIGINT, LogicalTypeId::UBIGINT,
+                    LogicalTypeId::INTEGER, LogicalTypeId::VARCHAR,
+                    LogicalTypeId::BOOLEAN, LogicalTypeId::DOUBLE,
+                    LogicalTypeId::ID}) {
+        LogicalType t(id);
+        auto rt = RoundTrip(t);
+        CHECK(rt.id() == t.id());
+    }
+}
+
+TEST_CASE("orca_type_encoding: DECIMAL preserves width and scale",
+          "[common][orca_type_encoding]") {
+    auto t = LogicalType::DECIMAL(18, 4);
+    auto rt = RoundTrip(t);
+    REQUIRE(rt.id() == LogicalTypeId::DECIMAL);
+    CHECK(DecimalType::GetWidth(rt) == 18);
+    CHECK(DecimalType::GetScale(rt) == 4);
+}
+
+TEST_CASE("orca_type_encoding: LIST of small-id scalar round-trips",
+          "[common][orca_type_encoding]") {
+    // Both BIGINT (id=14) and UBIGINT (id=31) are safely below the
+    // historical 256-wraparound and the 10000 registry boundary.
+    auto t1 = LogicalType::LIST(LogicalType::BIGINT);
+    auto rt1 = RoundTrip(t1);
+    REQUIRE(rt1.id() == LogicalTypeId::LIST);
+    CHECK(ListType::GetChildType(rt1).id() == LogicalTypeId::BIGINT);
+
+    auto t2 = LogicalType::LIST(LogicalType::UBIGINT);
+    auto rt2 = RoundTrip(t2);
+    REQUIRE(rt2.id() == LogicalTypeId::LIST);
+    CHECK(ListType::GetChildType(rt2).id() == LogicalTypeId::UBIGINT);
+}
+
+TEST_CASE("orca_type_encoding: LIST(LIST(UBIGINT)) round-trips",
+          "[common][orca_type_encoding]") {
+    // PR-3c's working case: nodes(p) / relationships(p) emit this shape.
+    // Encoded mod = LIST.id | (UBIGINT.id << 8) = 101 | 7936 = 8037, which
+    // stays below the registry boundary.
+    auto t = LogicalType::LIST(LogicalType::LIST(LogicalType::UBIGINT));
+    auto rt = RoundTrip(t);
+    REQUIRE(rt.id() == LogicalTypeId::LIST);
+    auto &child = ListType::GetChildType(rt);
+    REQUIRE(child.id() == LogicalTypeId::LIST);
+    CHECK(ListType::GetChildType(child).id() == LogicalTypeId::UBIGINT);
+}
+
+TEST_CASE("orca_type_encoding: LIST(LIST(ID)) currently aliases to ANY (issue #249)",
+          "[common][orca_type_encoding][!shouldfail]") {
+    // ID has LogicalTypeId 108, so the nested encoding produces
+    // 101 | (108 << 8) = 27749 — past the 10000 registry boundary, but
+    // the encoder didn't actually register anything. The decoder takes
+    // the registry branch, misses, and returns ANY. Marked !shouldfail so
+    // CI documents the latent bug without making the suite fail.
+    auto t = LogicalType::LIST(LogicalType::LIST(LogicalType::ID));
+    auto rt = RoundTrip(t);
+    REQUIRE(rt.id() == LogicalTypeId::LIST);
+    auto &child = ListType::GetChildType(rt);
+    CHECK(child.id() == LogicalTypeId::LIST);
+    CHECK(ListType::GetChildType(child).id() == LogicalTypeId::ID);
+}


### PR DESCRIPTION
## Summary
- New \`common/orca_type_encoding.hpp\` holds the encode/decode functions as free helpers parametrized on a nullable \`ComplexTypeRegistry\`.
- The three open-coded callers — \`Cypher2OrcaConverter::GetTypeMod\`, the static \`OidToLogicalType\` in \`cypher2orca_scalar.cpp\`, and \`Planner::pConvertTypeOidToLogicalType\` — are now thin forwards.
- Behavior is otherwise unchanged: PR-α intentionally does not touch the 10000 registry boundary or the single-byte LIST child slot; that reform is PR-β under #249.

## Why
The three open-coded versions drifted apart. Notable inconsistencies the helper smooths over:
- \`converter::OidToLogicalType\` did **not** consult the complex-type registry, so any registry-encoded modifier silently plain-decoded as nested LIST and returned ANY.
- DECIMAL default-on-zero handling differed (\`<= 0\` vs \`== 0 || == -1\`).
- Recursion went through the wrong helper if the caller forgot to set up the registry.

Putting them behind one helper makes encoding behavior obvious and lets PR-β change the wire format in a single edit.

## Test plan
- [x] New \`[common][orca_type_encoding]\` round-trip suite (\`./test/unittest \"[common][orca_type_encoding]\"\`).
- [x] \`[ldbc][robustness][patterncomp]\` 5/5 still passes.
- [x] \`[ic14]\` 3/3 still passes.
- [ ] CI on the stacked branch.

## Notes
- \`LIST(LIST(ID))\` round-trips to ANY today (collision against the 10000 registry boundary); pinned under \`[!shouldfail]\` so the latent bug is documented but the suite stays green. Lifting the tag is the acceptance check for PR-β.

Stack: depends on #248 (PR-3c).