### PR TITLE
fix(#249) PR-β: widen type_mod plain-encoding + throw on registry miss

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -2669,15 +2669,8 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
                     }
                 }
                 string n = vexpr->GetVariableName() + "__nodes";
-                // UBIGINT (id=31) rather than ID (id=108): the pCypher type
-                // encoder packs LIST(LIST(child)) into a single INT type_mod
-                // as (LIST | child_mod << 8); child_mod for LIST(ID) is 108,
-                // which crosses the 10000 boundary that the decoder reserves
-                // for the complex-type registry, and the result decodes back
-                // as ANY. UBIGINT keeps the encoded mod under the boundary
-                // and is the same physical type at runtime.
                 return make_shared<BoundVariableExpression>(
-                    n, LogicalType::LIST(LogicalType::UBIGINT), n);
+                    n, LogicalType::LIST(LogicalType::ID), n);
             }
         }
     }
@@ -2697,15 +2690,8 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
                     }
                 }
                 string n = vexpr->GetVariableName() + "__rels";
-                // UBIGINT (id=31) rather than ID (id=108): the pCypher type
-                // encoder packs LIST(LIST(child)) into a single INT type_mod
-                // as (LIST | child_mod << 8); child_mod for LIST(ID) is 108,
-                // which crosses the 10000 boundary that the decoder reserves
-                // for the complex-type registry, and the result decodes back
-                // as ANY. UBIGINT keeps the encoded mod under the boundary
-                // and is the same physical type at runtime.
                 return make_shared<BoundVariableExpression>(
-                    n, LogicalType::LIST(LogicalType::UBIGINT), n);
+                    n, LogicalType::LIST(LogicalType::ID), n);
             }
         }
     }

--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -62,12 +62,6 @@ namespace duckdb {
 namespace turbolynx {
 using namespace duckdb;
 
-// ============================================================
-// Helper: convert OID + type_mod back to LogicalType
-// (mirrors Planner::pConvertTypeOidToLogicalType)
-// ============================================================
-static duckdb::LogicalType OidToLogicalType(OID oid, INT type_mod);
-
 class LocalScalarVarGuard {
 public:
     LocalScalarVarGuard(std::unordered_map<string, CColRef *> &vars_p,
@@ -96,20 +90,17 @@ private:
     CColRef *previous = nullptr;
 };
 
-// Local wrappers around turbolynx::DecodeTypeId / DecodeTypeMod so existing
-// callers in this file keep their signatures. These don't see the converter's
-// complex-type registry: registry-encoded modifiers fall back to ANY (same
-// behavior as before the refactor — see issue #249 for the encoder reform
-// that will fix this for real).
-static duckdb::LogicalTypeId OidToLogicalTypeId(OID oid)
+// Instance-method definitions: see header for rationale (registry access).
+duckdb::LogicalTypeId Cypher2OrcaConverter::OidToLogicalTypeId(OID oid) const
 {
     return turbolynx::DecodeTypeId((uint32_t)oid);
 }
 
-static duckdb::LogicalType OidToLogicalType(OID oid, INT type_mod)
+duckdb::LogicalType Cypher2OrcaConverter::OidToLogicalType(OID oid,
+                                                            INT type_mod) const
 {
     return turbolynx::DecodeTypeMod((uint32_t)oid, (int32_t)type_mod,
-                                    /*registry*/ nullptr);
+                                    &complex_type_registry_);
 }
 
 // ============================================================

--- a/src/include/common/orca_type_encoding.hpp
+++ b/src/include/common/orca_type_encoding.hpp
@@ -23,10 +23,23 @@ namespace turbolynx {
 
 using ComplexTypeRegistry = std::unordered_map<int32_t, duckdb::LogicalType>;
 
-// Modifiers in [COMPLEX_TYPE_REGISTRY_MIN, ...) are treated as registry
-// handles rather than bit-packed metadata. PR-α preserves the historical
-// boundary; PR-β will widen it together with the LIST child slot.
-constexpr int32_t COMPLEX_TYPE_REGISTRY_MIN = 10000;
+// type_mod is a signed 32-bit ORCA INT. We carve it into three regions:
+//   * mod < 0                          — historical sentinel (-1 = default
+//                                        LIST(UBIGINT)); left intact for
+//                                        backward compatibility.
+//   * 0 ≤ mod < COMPLEX_TYPE_REGISTRY_MIN
+//                                      — bit-packed plain encoding.
+//   * mod ≥ COMPLEX_TYPE_REGISTRY_MIN  — registry handle (bit 30 set).
+//
+// Plain encoding uses an 8-bit-per-level layout: for a LIST type, the low
+// byte holds the child LogicalTypeId and the next byte starts the
+// grand-child's recursive encoding. That gives us 30 usable bits / 8 bits
+// per level → up to ~LIST(LIST(LIST(scalar))) before plain encoding
+// overflows. Beyond that the encoder falls back to the registry. The
+// previous boundary (10000) collided with the plain encoding of
+// LIST(LIST(child)) whenever the inner child had a LogicalTypeId ≥ ~39,
+// which silently aliased the type back to ANY (issue #249).
+constexpr int32_t COMPLEX_TYPE_REGISTRY_MIN = 0x40000000;  // bit 30
 
 inline duckdb::LogicalTypeId DecodeTypeId(uint32_t oid)
 {
@@ -39,15 +52,26 @@ inline duckdb::LogicalTypeId DecodeTypeId(uint32_t oid)
 // LOGICAL_TYPE_BASE_ID + LogicalTypeId.id() at the call site; this helper
 // only produces the INT modifier.
 //
-// `registry` and `next_complex_id` are used to stash types that don't fit
-// the bit-packed layout (STRUCT fields, LIST(STRUCT)). They are required
-// for those cases — pass nullptr only when the caller already knows the
-// type is bit-packable.
+// `registry` and `next_complex_id` are required for any type that can't
+// fit in the bit-packed layout (STRUCT fields, LIST(STRUCT), deeply-nested
+// LIST whose packed encoding would overflow into the registry-handle
+// region). Pass nullptr only when the caller already knows the type is
+// bit-packable.
 inline int32_t EncodeTypeMod(const duckdb::LogicalType &type,
                               ComplexTypeRegistry *registry,
                               int32_t *next_complex_id)
 {
     using duckdb::LogicalTypeId;
+    auto stash_registry = [&]() -> int32_t {
+        if (!registry || !next_complex_id) {
+            throw duckdb::InternalException(
+                "EncodeTypeMod: complex/deeply-nested type requires registry");
+        }
+        int32_t id = (*next_complex_id)++;
+        (*registry)[id] = type;
+        return id;
+    };
+
     if (type.id() == LogicalTypeId::DECIMAL) {
         uint16_t w = (uint16_t)duckdb::DecimalType::GetWidth(type);
         uint16_t s = (uint16_t)duckdb::DecimalType::GetScale(type);
@@ -57,35 +81,30 @@ inline int32_t EncodeTypeMod(const duckdb::LogicalType &type,
         auto &child = duckdb::ListType::GetChildType(type);
         if (child.id() == LogicalTypeId::LIST) {
             int32_t cmod = EncodeTypeMod(child, registry, next_complex_id);
-            return (int32_t)LogicalTypeId::LIST | (cmod << 8);
+            // Child itself ended up as a registry handle — promote the
+            // whole type. Same idea if the packed result would overflow
+            // into the registry-handle region.
+            if (cmod >= COMPLEX_TYPE_REGISTRY_MIN) return stash_registry();
+            int32_t packed = (int32_t)LogicalTypeId::LIST | (cmod << 8);
+            if (packed >= COMPLEX_TYPE_REGISTRY_MIN) return stash_registry();
+            return packed;
         }
-        if (child.id() == LogicalTypeId::STRUCT) {
-            if (!registry || !next_complex_id) {
-                throw duckdb::InternalException(
-                    "EncodeTypeMod: LIST(STRUCT) requires registry");
-            }
-            int32_t id = (*next_complex_id)++;
-            (*registry)[id] = type;  // store full LIST(STRUCT(...))
-            return id;
-        }
+        if (child.id() == LogicalTypeId::STRUCT) return stash_registry();
         return (int32_t)child.id();
     }
-    if (type.id() == LogicalTypeId::STRUCT) {
-        if (!registry || !next_complex_id) {
-            throw duckdb::InternalException(
-                "EncodeTypeMod: STRUCT requires registry");
-        }
-        int32_t id = (*next_complex_id)++;
-        (*registry)[id] = type;
-        return id;
-    }
+    if (type.id() == LogicalTypeId::STRUCT) return stash_registry();
     return 0;
 }
 
 // Decode (oid, INT type_mod) back into a LogicalType. `registry` is the
-// converter-populated map; when null, registry handles fall through to the
-// legacy ANY-on-miss behavior (preserved so call sites that historically
-// didn't pass a registry still compile).
+// converter-populated map. Two-mode behavior:
+//   * With a registry: handles in the [COMPLEX_TYPE_REGISTRY_MIN, …) region
+//     are looked up and an entry miss throws — silent ANY-on-miss is the
+//     class of footgun this whole refactor is meant to eliminate.
+//   * Without a registry: callers (notably the file-scope helper in
+//     cypher2orca_scalar) historically plain-decoded the modifier
+//     unconditionally; preserve that so they don't suddenly start seeing
+//     ANY/throw for registry-encoded LIST(STRUCT).
 inline duckdb::LogicalType DecodeTypeMod(uint32_t oid, int32_t type_mod,
                                           const ComplexTypeRegistry *registry)
 {
@@ -103,15 +122,12 @@ inline duckdb::LogicalType DecodeTypeMod(uint32_t oid, int32_t type_mod,
         if (type_mod == -1) {
             return duckdb::LogicalType::LIST(duckdb::LogicalType::UBIGINT);
         }
-        // With a registry: registry handles win, miss falls back to ANY
-        // (legacy). Without a registry: callers (notably the file-scope
-        // helper in cypher2orca_scalar) historically plain-decoded the
-        // modifier unconditionally — keep that behavior so they don't
-        // suddenly start seeing ANY for registry-encoded LIST(STRUCT).
         if (registry && type_mod >= COMPLEX_TYPE_REGISTRY_MIN) {
             auto it = registry->find(type_mod);
             if (it != registry->end()) return it->second;
-            return duckdb::LogicalType::ANY;
+            throw duckdb::InternalException(
+                "DecodeTypeMod: LIST registry handle " +
+                std::to_string(type_mod) + " has no entry");
         }
         uint32_t cooid = (uint32_t)(type_mod & 0xFF) + LOGICAL_TYPE_BASE_ID;
         int32_t cmod = (type_mod >> 8);
@@ -124,7 +140,9 @@ inline duckdb::LogicalType DecodeTypeMod(uint32_t oid, int32_t type_mod,
         type_mod >= COMPLEX_TYPE_REGISTRY_MIN) {
         auto it = registry->find(type_mod);
         if (it != registry->end()) return it->second;
-        return duckdb::LogicalType::ANY;
+        throw duckdb::InternalException(
+            "DecodeTypeMod: STRUCT registry handle " +
+            std::to_string(type_mod) + " has no entry");
     }
     return duckdb::LogicalType(tid);
 }

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -340,6 +340,12 @@ private:
 
     // Type helpers
     INT GetTypeMod(const LogicalType &type);
+    // (oid, type_mod) → LogicalType, consulting this converter's
+    // complex-type registry so LIST(STRUCT(...)) / STRUCT(...) decode
+    // back to their concrete shape. Lives on the instance because the
+    // registry is per-converter state.
+    duckdb::LogicalType OidToLogicalType(OID oid, INT type_mod) const;
+    duckdb::LogicalTypeId OidToLogicalTypeId(OID oid) const;
     OID GetTypeOidFromCExpr(CExpression *expr);
     INT GetTypeModFromCExpr(CExpression *expr);
     LogicalType LogicalTypeFromCExpr(CExpression *expr);

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -552,7 +552,9 @@ private:
 	// registry index in the type modifier. Physical planner resolves back via
 	// ResolveComplexType().
 	std::unordered_map<INT, duckdb::LogicalType> complex_type_registry;
-	INT next_complex_type_id = 10000;  // start above normal modifier range
+	// Start above the plain-encoding boundary (bit 30); see
+	// COMPLEX_TYPE_REGISTRY_MIN in common/orca_type_encoding.hpp.
+	INT next_complex_type_id = turbolynx::COMPLEX_TYPE_REGISTRY_MIN;
 	std::unordered_map<INT, turbolynx::ListComprehensionExprInfo> list_comprehension_registry;
 	INT next_list_comprehension_id = 20000;
 

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -100,7 +100,7 @@ void Planner::reset()
     mpv_null_colref_props.clear();
     mpv_colref_to_scan_idx_.clear();
     complex_type_registry.clear();
-    next_complex_type_id = 10000;
+    next_complex_type_id = turbolynx::COMPLEX_TYPE_REGISTRY_MIN;
     list_comprehension_registry.clear();
     next_list_comprehension_id = 20000;
     pipeline_operator_types.clear();

--- a/test/common/test_orca_type_encoding.cpp
+++ b/test/common/test_orca_type_encoding.cpp
@@ -85,17 +85,36 @@ TEST_CASE("orca_type_encoding: LIST(LIST(UBIGINT)) round-trips",
     CHECK(ListType::GetChildType(child).id() == LogicalTypeId::UBIGINT);
 }
 
-TEST_CASE("orca_type_encoding: LIST(LIST(ID)) currently aliases to ANY (issue #249)",
-          "[common][orca_type_encoding][!shouldfail]") {
-    // ID has LogicalTypeId 108, so the nested encoding produces
-    // 101 | (108 << 8) = 27749 — past the 10000 registry boundary, but
-    // the encoder didn't actually register anything. The decoder takes
-    // the registry branch, misses, and returns ANY. Marked !shouldfail so
-    // CI documents the latent bug without making the suite fail.
+TEST_CASE("orca_type_encoding: LIST(LIST(ID)) round-trips after boundary widening",
+          "[common][orca_type_encoding]") {
+    // Plain encoding now lives in [0, 0x40000000); the previous 10000
+    // boundary collided with LIST(LIST(ID)) (encoded mod = 27749) and
+    // sent it through the registry branch, which had no entry and
+    // returned ANY. With the wider boundary the same modifier decodes
+    // back to the original type.
     auto t = LogicalType::LIST(LogicalType::LIST(LogicalType::ID));
     auto rt = RoundTrip(t);
     REQUIRE(rt.id() == LogicalTypeId::LIST);
     auto &child = ListType::GetChildType(rt);
-    CHECK(child.id() == LogicalTypeId::LIST);
+    REQUIRE(child.id() == LogicalTypeId::LIST);
     CHECK(ListType::GetChildType(child).id() == LogicalTypeId::ID);
+}
+
+TEST_CASE("orca_type_encoding: STRUCT round-trip via registry",
+          "[common][orca_type_encoding]") {
+    child_list_t<LogicalType> fields;
+    fields.emplace_back("a", LogicalType::BIGINT);
+    fields.emplace_back("b", LogicalType::VARCHAR);
+    auto t = LogicalType::STRUCT(std::move(fields));
+    auto rt = RoundTrip(t);
+    REQUIRE(rt.id() == LogicalTypeId::STRUCT);
+    CHECK(StructType::GetChildCount(rt) == 2);
+}
+
+TEST_CASE("orca_type_encoding: decode of unknown registry handle throws",
+          "[common][orca_type_encoding]") {
+    ComplexTypeRegistry empty;
+    CHECK_THROWS(DecodeTypeMod(
+        (uint32_t)LOGICAL_TYPE_BASE_ID + (uint32_t)LogicalTypeId::LIST,
+        turbolynx::COMPLEX_TYPE_REGISTRY_MIN + 1, &empty));
 }


### PR DESCRIPTION
## Summary
- Move the registry-handle boundary from 10000 to **0x40000000** (bit 30). Plain bit-packed encodings now have room for LIST nesting whose inner child fits in a byte — i.e. every current LogicalTypeId, including the ones that crossed the old boundary.
- Encoder: if packing would land in the registry region after one more level, fall back to the registry instead of corrupting the value.
- Decoder: unregistered registry handles **throw InternalException** instead of silently returning ANY. That diagnostic is what would have caught PR-3c's collision immediately.
- Revert PR-3c's \`UBIGINT\`-instead-of-\`ID\` workaround in the \`nodes(p)\` / \`relationships(p)\` handlers — semantically correct \`LogicalType::ID\` now round-trips properly.

Stack: depends on #250 (PR-α).

Closes #249.

## Test plan
- [x] \`./test/unittest \"[common][orca_type_encoding]\"\` — 7/7 (LIST(LIST(ID)) round-trips as a positive assertion now; new STRUCT round-trip; CHECK_THROWS on unregistered handle).
- [x] \`./test/query/query_test --ldbc-path /tmp/ldbc-mini-ws \"[ldbc][robustness][patterncomp]\"\` — 5/5.
- [x] \`./test/query/query_test --ldbc-path /tmp/ldbc-mini-ws \"[ic14]\"\` — 3/3.
- [ ] CI on stacked branch.