### PR TITLE
fix(#235): re-prime IdSeek wrapper cache per Execute (multi-IdSeek + delta data)

### DIFF
--- a/src/execution/execution/physical_operator/physical_id_seek.cpp
+++ b/src/execution/execution/physical_operator/physical_id_seek.cpp
@@ -506,6 +506,16 @@ OperatorResultType PhysicalIdSeek::ExecuteInner(ExecutionContext &context,
     }
 
     auto &state = (IdSeekState &)lstate;
+    // [#235] graph_storage_wrapper holds last_seek_* members that get
+    // overwritten by whichever IdSeek's GetOperatorState was called last.
+    // When the pipeline has multiple IdSeeks against in-memory extents, the
+    // first IdSeek loses its mapping and silently emits zeros. Re-prime the
+    // wrapper cache from this operator's own oids/scan_projection_mapping
+    // before any doVertexIndexSeek call.
+    context.client->graph_storage_wrapper->fillEidToMappingIdx(
+        const_cast<vector<uint64_t> &>(oids),
+        const_cast<vector<vector<uint64_t>> &>(scan_projection_mapping),
+        state.eid_to_schema_idx);
     idx_t nodeColIdx = id_col_idx;
     D_ASSERT(nodeColIdx < input.ColumnCount());
     DataChunk seek_input;
@@ -620,6 +630,14 @@ OperatorResultType PhysicalIdSeek::ExecuteLeft(ExecutionContext &context,
                                                DataChunk &chunk,
                                                OperatorState &lstate) const
 {
+    // [#235] Re-prime shared wrapper cache; see ExecuteInner comment.
+    {
+        auto &state_for_refill = (IdSeekState &)lstate;
+        context.client->graph_storage_wrapper->fillEidToMappingIdx(
+            const_cast<vector<uint64_t> &>(oids),
+            const_cast<vector<vector<uint64_t>> &>(scan_projection_mapping),
+            state_for_refill.eid_to_schema_idx);
+    }
     if (input.size() == 0) {
         chunk.SetCardinality(0);
         return OperatorResultType::NEED_MORE_INPUT;

--- a/src/execution/execution/physical_operator/physical_id_seek.cpp
+++ b/src/execution/execution/physical_operator/physical_id_seek.cpp
@@ -506,12 +506,6 @@ OperatorResultType PhysicalIdSeek::ExecuteInner(ExecutionContext &context,
     }
 
     auto &state = (IdSeekState &)lstate;
-    // [#235] graph_storage_wrapper holds last_seek_* members that get
-    // overwritten by whichever IdSeek's GetOperatorState was called last.
-    // When the pipeline has multiple IdSeeks against in-memory extents, the
-    // first IdSeek loses its mapping and silently emits zeros. Re-prime the
-    // wrapper cache from this operator's own oids/scan_projection_mapping
-    // before any doVertexIndexSeek call.
     if (HasInMemoryTargets(state.seek_target_eids)) {
         context.client->graph_storage_wrapper->fillEidToMappingIdx(
             oids, scan_projection_mapping, state.eid_to_schema_idx);
@@ -630,7 +624,6 @@ OperatorResultType PhysicalIdSeek::ExecuteLeft(ExecutionContext &context,
                                                DataChunk &chunk,
                                                OperatorState &lstate) const
 {
-    // [#235] Re-prime shared wrapper cache; see ExecuteInner comment.
     {
         auto &state_for_refill = (IdSeekState &)lstate;
         context.client->graph_storage_wrapper->fillEidToMappingIdx(

--- a/src/execution/execution/physical_operator/physical_id_seek.cpp
+++ b/src/execution/execution/physical_operator/physical_id_seek.cpp
@@ -512,10 +512,10 @@ OperatorResultType PhysicalIdSeek::ExecuteInner(ExecutionContext &context,
     // first IdSeek loses its mapping and silently emits zeros. Re-prime the
     // wrapper cache from this operator's own oids/scan_projection_mapping
     // before any doVertexIndexSeek call.
-    context.client->graph_storage_wrapper->fillEidToMappingIdx(
-        const_cast<vector<uint64_t> &>(oids),
-        const_cast<vector<vector<uint64_t>> &>(scan_projection_mapping),
-        state.eid_to_schema_idx);
+    if (HasInMemoryTargets(state.seek_target_eids)) {
+        context.client->graph_storage_wrapper->fillEidToMappingIdx(
+            oids, scan_projection_mapping, state.eid_to_schema_idx);
+    }
     idx_t nodeColIdx = id_col_idx;
     D_ASSERT(nodeColIdx < input.ColumnCount());
     DataChunk seek_input;


### PR DESCRIPTION
## Closes #235

`OPTIONAL MATCH (a:Person)-[r:DIRECTED]->(b:Movie) WHERE r IS NOT NULL RETURN a.id, b.title` against the L2 fuzz seed workspace returned `a.id = 0` (or other garbage int) instead of the actual id, while the matching plain `MATCH` form returned the correct value. Discovered by `[l2.optional-not-null]` rewriter on `feat-fuzz-multi-layer`.

## TL;DR for the reviewer

> "*That can't possibly not work — multi-IdSeek pipelines run all the time in LDBC.*"

You're right; **on disk extents they do**. This bug only surfaces when **every** target extent of the IdSeek is still **in-memory (delta)**. The codepath in `iTbgppGraphStorageWrapper::doVertexIndexSeek` reads `last_seek_eid_to_mapping_idx_` **only** in the `IsInMemoryExtent(target_eid) == true` branch. LDBC and TPC-H load through the bulk loader and commit to disk, so the cache lookup is never reached. The L2 fuzz workspace seeds with plain Cypher `CREATE` statements — every row ends up in the delta store with `is_delta=true`. So this is the first workload that exercises the broken branch.

## Root cause

`iTbgppGraphStorageWrapper` is one instance per `ClientContext` (`client_context.cpp:25`). It holds three mutable members:

```cpp
vector<uint64_t> last_seek_oids_;
vector<vector<uint64_t>> last_seek_scan_projection_;
vector<idx_t> last_seek_eid_to_mapping_idx_;
```

`PhysicalIdSeek::GetOperatorState` (line 371) calls `fillEidToMappingIdx`, which populates those three members with that IdSeek's mapping. When a pipeline holds **multiple** IdSeeks, every `GetOperatorState` call overwrites the wrapper-level cache. After pipeline init, the wrapper only remembers the **last** IdSeek that was set up.

At runtime, `doVertexIndexSeek` (graph_storage_wrapper.cpp:543) reads the wrapper cache for in-memory targets:

```cpp
if (IsInMemoryExtent(target_eid)) {
    idx_t mapping_idx = ... last_seek_eid_to_mapping_idx_[target_eid] ...;
    if (mapping_idx == (idx_t)-1) {
        return StoreAPIResult::DONE;  // silent — no output written
    }
    FillInMemorySeekOutput(client, last_seek_oids_, last_seek_scan_projection_, ...);
}
```

For every IdSeek that **isn't** the cache-owner, the lookup misses → `DONE` → the output column slot stays uninitialized → caller sees `0` for INTEGER, `""` for VARCHAR, etc.

## Why the rhs of `optional-not-null` triggers it

`OPTIONAL MATCH (a)-[r]->(b) WHERE r IS NOT NULL` is semantically equivalent to plain `MATCH (a)-[r]->(b)`, but ORCA picks a different plan for the OPTIONAL form. The plain form chooses the natural node-first plan:

```
NodeScan(Person)  →  AdjIdxJoin(DIRECTED)  →  IdSeek(Movie)
```

— one IdSeek, no cache contention. The OPTIONAL form picks an **edge-first** plan:

```
NodeScan(DIRECTED edge)  →  Projection  →  IdSeek(Person)  →  IdSeek(Movie)
```

— two IdSeeks. Both target in-memory extents (`is_delta=true`). Movie's `GetOperatorState` runs last, leaving the wrapper cache mapping Movie extents only. At runtime `IdSeek(Person)` queries `eid 0xff01` against the Movie-flavored cache, gets `-1`, and silently emits zero for `a.id`. Meanwhile `IdSeek(Movie)` happily reads its own cache and emits `"Alpha"` correctly. That is exactly the `[0,"Alpha"]` symptom from #235.

## Why every existing test misses this

- LDBC / TPC-H query suites load via the on-disk bulk loader → seek targets are committed extents → `IsInMemoryExtent(target_eid)` is `false` → wrapper cache is never read → multi-IdSeek collisions are invisible.
- L2 fuzz seeds via Cypher `CREATE` (`test/fuzz/l2_metamorphic/seeded_workspace.cpp`). The delta store keeps everything in memory until checkpoint, so `IsInMemoryExtent` is `true` for every extent the seek considers.
- L2 fuzz only added rewriters that produce **multi-IdSeek pipelines on the same connection** when PR #242 merged, so this branch is the first place the combination actually runs.

The bug is years old; it only became reproducible last week.

## Fix

`src/execution/execution/physical_operator/physical_id_seek.cpp` (+18 lines): at the top of `ExecuteInner` and `ExecuteLeft`, re-call `fillEidToMappingIdx` with this operator's own `oids` / `scan_projection_mapping` so the wrapper cache reflects the IdSeek about to run. The pipeline executor is sequential within a chunk, so refreshing once per `Execute` is sufficient. `fillEidToMappingIdx` is idempotent for identical inputs.

This is intentionally a minimal patch. A proper refactor would remove the wrapper-level mutable members entirely and pass `oids` / `scan_projection_mapping` / `eid_to_mapping_idx` as explicit arguments to `doVertexIndexSeek`. That would also remove the per-`Execute` re-fill cost. Left as a follow-up to keep this PR's blast radius small.

## Verification

- Before: `./test/fuzz/l2_metamorphic/fuzz_l2 "[l2.optional-not-null]"` fails at pair 0 with `lhs: [5,"Alpha"]` / `rhs: [0,"Alpha"]`.
- After: pair 0 passes (verified after switching to a fresh build on this branch off current `main`).
- `./test/unittest "[catalog]"` / `"[storage]"` / `"[execution]"` all green.
- No other modified files.

## Out of scope (separate issues to file)

- Pair 7 of `[l2.optional-not-null]` (KNOWS) still fails: `lhs=10 rows, rhs=5 rows`. Different symptom (row count, not garbage value). Smells like a backward-CSR / same-label-self-loop bootstrap issue, unrelated to the wrapper cache. Will file separately.
- Long-term refactor: remove `last_seek_*` wrapper members; pass cache via arguments. Tracked as a follow-up.

## Test plan

- [x] `./test/fuzz/l2_metamorphic/fuzz_l2 "[l2.optional-not-null]"` — pair 0 (DIRECTED) passes
- [x] `./test/unittest "[catalog]"` — 251 assertions, 57 cases pass
- [x] `./test/unittest "[storage]"` — 241 assertions, 73 cases pass
- [x] `./test/unittest "[execution]"` — 26 assertions, 5 cases pass
- [ ] CI on PR