### PR TITLE
fix(#253): plain varlen MATCH path = (a)-[:R*]->(b) RETURN length(path)

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -436,6 +436,27 @@ unique_ptr<NormalizedSingleQuery> Binder::BindSingleQuery(const SingleQuery& sq,
     auto final_part = BindFinalQueryPart(sq, ctx);
     nsq->AppendQueryPart(std::move(final_part));
 
+    // Sync the (final) PathUseMode discovered during expression binding
+    // back into every BoundQueryGraph that owns a path variable. The
+    // converter reads this off the bound tree instead of walking the
+    // BindContext chain. Issue #253.
+    for (idx_t pi = 0; pi < nsq->GetNumQueryParts(); pi++) {
+        auto *part = nsq->GetQueryPart(pi);
+        for (idx_t ri = 0; ri < part->GetNumReadingClauses(); ri++) {
+            auto *rc = part->GetReadingClause(ri);
+            if (rc->GetClauseType() != BoundClauseType::MATCH) continue;
+            auto *mc = static_cast<BoundMatchClause *>(rc);
+            const auto *qgc = mc->GetQueryGraphCollection();
+            for (uint32_t qi = 0; qi < qgc->GetNumQueryGraphs(); qi++) {
+                auto *qg = qgc->GetQueryGraph(qi);
+                if (qg->GetPathName().empty()) continue;
+                auto meta = ctx.GetPathMeta(qg->GetPathName());
+                qg->SetPathUseMode(
+                    static_cast<BoundQueryGraph::PathUseMode>(meta.use_mode));
+            }
+        }
+    }
+
     return nsq;
 }
 
@@ -2098,6 +2119,13 @@ shared_ptr<BoundExpression> Binder::BindVariableExpression(const ParsedVariableE
         return make_shared<BoundVariableExpression>(var, LogicalType::BIGINT, var);
     }
     if (ctx.HasPath(var)) {
+        // Any direct reference to a path variable (RETURN path, WITH path,
+        // path AS ...) needs the full node-edge interleaved LIST at
+        // runtime. The dedicated length/nodes/relationships handlers
+        // build their own BoundVariableExpression and bypass this branch,
+        // so reaching here means "use the path value itself" — widen to
+        // Full. Issue #253.
+        ctx.MarkPathUseMode(var, BindContext::PathUseMode::Full);
         return make_shared<BoundVariableExpression>(var, LogicalType::PATH(LogicalType::ANY), var);
     }
     // Check alias type registry (for WITH aliases like collect() → LIST, struct_pack → STRUCT)
@@ -2698,6 +2726,14 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
 
     // nodes(path) → path_nodes(path) — extract node IDs from path
     if (fname == "nodes" && expr.children.size() == 1) {
+        if (expr.children[0]->GetExpressionType() == ExpressionType::COLUMN_REF) {
+            auto *vexpr = dynamic_cast<const ParsedVariableExpression *>(
+                expr.children[0].get());
+            if (vexpr && ctx.HasPath(vexpr->GetVariableName())) {
+                ctx.MarkPathUseMode(vexpr->GetVariableName(),
+                                    BindContext::PathUseMode::Full);
+            }
+        }
         auto child = BindExpression(*expr.children[0], ctx);
         bound_expression_vector args;
         args.push_back(std::move(child));
@@ -2707,6 +2743,14 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
 
     // relationships(path) → path_rels(path) — extract edge IDs from path
     if ((fname == "relationships" || fname == "rels") && expr.children.size() == 1) {
+        if (expr.children[0]->GetExpressionType() == ExpressionType::COLUMN_REF) {
+            auto *vexpr = dynamic_cast<const ParsedVariableExpression *>(
+                expr.children[0].get());
+            if (vexpr && ctx.HasPath(vexpr->GetVariableName())) {
+                ctx.MarkPathUseMode(vexpr->GetVariableName(),
+                                    BindContext::PathUseMode::Full);
+            }
+        }
         auto child = BindExpression(*expr.children[0], ctx);
         bound_expression_vector args;
         args.push_back(std::move(child));
@@ -2758,9 +2802,21 @@ shared_ptr<BoundExpression> Binder::BindFunctionInvocation(const FunctionExpress
                     Value::BIGINT((int64_t)meta.num_chains),
                     GenExprName(expr));
             }
-            auto child = BindExpression(*expr.children[0], ctx);
+            // Varlen path — the converter needs to materialize a path
+            // column at runtime, but length(path) only consults the LIST
+            // header (list_entry_t.length). Mark LengthOnly so the
+            // physical operator can skip the element fill (#253).
+            ctx.MarkPathUseMode(path_var->GetVariableName(),
+                                BindContext::PathUseMode::LengthOnly);
+            // Build the BoundVariableExpression directly rather than via
+            // BindExpression — going through BindVariableExpression would
+            // re-mark the path variable's use mode (it can't tell whether
+            // its caller is `length` vs. a direct projection).
             bound_expression_vector args;
-            args.push_back(std::move(child));
+            args.push_back(make_shared<BoundVariableExpression>(
+                path_var->GetVariableName(),
+                LogicalType::PATH(LogicalType::ANY),
+                path_var->GetVariableName()));
             return make_shared<CypherBoundFunctionExpression>(
                 "path_length", LogicalType::BIGINT, std::move(args), GenExprName(expr));
         }

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -150,7 +150,8 @@ Cypher2OrcaConverter::Cypher2OrcaConverter(
     std::unordered_map<INT, LogicalType> &complex_type_registry,
     INT &next_complex_type_id,
     std::unordered_map<INT, ListComprehensionExprInfo> &list_comprehension_registry,
-    INT &next_list_comprehension_id)
+    INT &next_list_comprehension_id,
+    std::unordered_map<ULONG, uint8_t> &path_col_use_mode)
     : mp_(mp), context_(context), provider_(provider),
       col_name_map_(col_name_map),
       both_edge_partitions_(both_edge_partitions),
@@ -161,7 +162,8 @@ Cypher2OrcaConverter::Cypher2OrcaConverter(
       complex_type_registry_(complex_type_registry),
       next_complex_type_id_(next_complex_type_id),
       list_comprehension_registry_(list_comprehension_registry),
-      next_list_comprehension_id_(next_list_comprehension_id)
+      next_list_comprehension_id_(next_list_comprehension_id),
+      path_col_use_mode_(path_col_use_mode)
 {
     // Initialize system column key IDs from catalog.
     GraphCatalogEntry *gcat = GetGraphCatalog();
@@ -2043,6 +2045,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                                   ar_join_type, nullptr);
                         lhs_plan->getSchema()->appendSchema(edge_plan->getSchema());
                         lhs_plan->addBinaryParentOp(a_r_join_expr, edge_plan);
+                        MaybeWrapVarlenPath(lhs_plan, qg, *qedge);
                     } else {
                         // Unbound LHS: the per-partition A→R result replaces lhs_plan.
                         lhs_plan = new turbolynx::LogicalPlan(ar_result, first_combined_schema);
@@ -2110,6 +2113,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
 
                     lhs_plan->getSchema()->appendSchema(edge_plan->getSchema());
                     lhs_plan->addBinaryParentOp(a_r_join_expr, edge_plan);
+                    MaybeWrapVarlenPath(lhs_plan, qg, *qedge);
                 }
 
                 // --- R join B ---
@@ -2246,56 +2250,6 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
             }
         }
 
-        // Issue #253: `MATCH path = (a)-[:R*…]->(b) RETURN length(path) /
-        // nodes(path) / relationships(path)` needs a path column on the
-        // PathJoin output for the bind-time path variable to resolve at
-        // runtime. PlanShortestPath already does this for the
-        // shortestPath / allShortestPaths variants; we mirror its
-        // placeholder projection so the binder's BoundVariableExpression
-        // for `path` finds a colref in the schema. The physical operator
-        // (PhysicalVarlenAdjIdxJoin) fills the actual per-row LIST.
-        //
-        // Only emit when the binder marked the path as used (PathUseMode
-        // != None) — otherwise the projection is dead weight.
-        if (qg_plan != nullptr && !qg->GetPathName().empty() &&
-            qg->GetPathUseMode() != BoundQueryGraph::PathUseMode::None &&
-            !qg->GetQueryRels().empty()) {
-            auto &qedge = qg->GetQueryRels()[0];
-            const string &lhs_name = qedge->GetSrcNodeName();
-            const string &rhs_name = qedge->GetDstNodeName();
-            CColRef *lhs_id = qg_plan->getSchema()->getColRefOfKey(lhs_name, ID_KEY_ID);
-            CColRef *rhs_id = qg_plan->getSchema()->getColRefOfKey(rhs_name, ID_KEY_ID);
-            if (lhs_id && rhs_id) {
-                CColumnFactory *col_factory = COptCtxt::PoctxtFromTLS()->Pcf();
-                std::wstring w_path(qg->GetPathName().begin(),
-                                    qg->GetPathName().end());
-                const CWStringConst path_name_wstr(w_path.c_str());
-                CName path_cname(&path_name_wstr);
-                CColRef *path_col_ref = col_factory->PcrCreate(
-                    GetMDAccessor()->RetrieveType(&CMDIdGPDB::m_mdid_turbolynx_path),
-                    default_type_modifier, path_cname);
-
-                CExpressionArray *ident_array = GPOS_NEW(mp_) CExpressionArray(mp_);
-                ident_array->Append(GPOS_NEW(mp_) CExpression(
-                    mp_, GPOS_NEW(mp_) CScalarIdent(mp_, lhs_id)));
-                ident_array->Append(GPOS_NEW(mp_) CExpression(
-                    mp_, GPOS_NEW(mp_) CScalarIdent(mp_, rhs_id)));
-                CExpression *values_list = GPOS_NEW(mp_) CExpression(
-                    mp_, GPOS_NEW(mp_) CScalarValuesList(mp_), ident_array);
-                CExpression *proj_elem = GPOS_NEW(mp_) CExpression(
-                    mp_, GPOS_NEW(mp_) CScalarProjectElement(mp_, path_col_ref),
-                    values_list);
-                CExpressionArray *proj_array = GPOS_NEW(mp_) CExpressionArray(mp_);
-                proj_array->Append(proj_elem);
-                CExpression *proj_list = GPOS_NEW(mp_) CExpression(
-                    mp_, GPOS_NEW(mp_) CScalarProjectList(mp_), proj_array);
-                CExpression *proj_expr = GPOS_NEW(mp_) CExpression(
-                    mp_, GPOS_NEW(mp_) CLogicalProject(mp_),
-                    qg_plan->getPlanExpr(), proj_list);
-                qg_plan->addUnaryParentOp(proj_expr);
-                qg_plan->getSchema()->appendColumn(qg->GetPathName(), path_col_ref);
-            }
-        }
     }
     // Phase 2: process shortestPath QGs on the completed plan.
     // This mirrors what happens with separate MATCH clauses — shortestPath
@@ -3790,6 +3744,74 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanEdgeScanSinglePartition(
 // ============================================================
 // Path scan (variable-length)
 // ============================================================
+
+// Wrap a freshly-built A→R varlen subtree with CLogicalVarlenPath so
+// the path column gets materialized at runtime. Sits directly above the
+// path-join (BELOW the eventual R-join-B): otherwise the column has to
+// pass through R-join-B's lowering, which drops it. The wrap follows
+// PlanShortestPath's two-child shape (child[1] = ScalarProjectList
+// defining path_col_ref) so ORCA's column lifecycle sees a clean origin
+// for the synthetic colref. PhysicalVarlenAdjIdxJoin fills the per-row
+// LIST during execution.
+void Cypher2OrcaConverter::MaybeWrapVarlenPath(
+    turbolynx::LogicalPlan *plan, const BoundQueryGraph *qg,
+    const BoundRelExpression &qedge)
+{
+    if (qg == nullptr || plan == nullptr) return;
+    if (!qedge.IsVariableLength()) return;
+    const string &path_name = qg->GetPathName();
+    if (path_name.empty()) return;
+    if (qg->GetPathUseMode() == BoundQueryGraph::PathUseMode::None) return;
+
+    const string &src_name = qedge.GetSrcNodeName();
+    const string &edge_name = qedge.GetUniqueName();
+    CColRef *src_id = plan->getSchema()->getColRefOfKey(src_name, ID_KEY_ID);
+    CColRef *edge_tid = plan->getSchema()->getColRefOfKey(edge_name, TID_KEY_ID);
+    if (src_id == nullptr || edge_tid == nullptr) return;
+
+    CColumnFactory *col_factory = COptCtxt::PoctxtFromTLS()->Pcf();
+    std::wstring w_path(path_name.begin(), path_name.end());
+    const CWStringConst path_name_wstr(w_path.c_str());
+    CName path_cname(&path_name_wstr);
+    // Use the standard LIST(UBIGINT) MD type rather than the in-house
+    // PATH MD type. A path is always a list of vertex/edge IDs anyway,
+    // and the standard LIST type takes the well-tested col-passthrough
+    // path through join lowerings (collect()-style flow), whereas PATH
+    // MD is not fully wired through every transform. ShortestPath gets
+    // away with PATH because it's a leaf-like op with no joins above it.
+    OID list_oid = LOGICAL_TYPE_BASE_ID + (OID)duckdb::LogicalTypeId::LIST;
+    IMDId *list_mdid = GPOS_NEW(mp_) CMDIdGPDB(IMDId::EmdidGeneral,
+                                               list_oid, 1, 0);
+    INT list_type_mod = GetTypeMod(duckdb::LogicalType::LIST(
+        duckdb::LogicalType::UBIGINT));
+    CColRef *path_col_ref = col_factory->PcrCreate(
+        GetMDAccessor()->RetrieveType(list_mdid), list_type_mod, path_cname);
+
+    CExpressionArray *ident_array = GPOS_NEW(mp_) CExpressionArray(mp_);
+    ident_array->Append(GPOS_NEW(mp_) CExpression(
+        mp_, GPOS_NEW(mp_) CScalarIdent(mp_, src_id)));
+    ident_array->Append(GPOS_NEW(mp_) CExpression(
+        mp_, GPOS_NEW(mp_) CScalarIdent(mp_, edge_tid)));
+    CExpression *values_list = GPOS_NEW(mp_) CExpression(
+        mp_, GPOS_NEW(mp_) CScalarValuesList(mp_), ident_array);
+    CExpression *proj_elem = GPOS_NEW(mp_) CExpression(
+        mp_, GPOS_NEW(mp_) CScalarProjectElement(mp_, path_col_ref),
+        values_list);
+    CExpressionArray *proj_array = GPOS_NEW(mp_) CExpressionArray(mp_);
+    proj_array->Append(proj_elem);
+    CExpression *proj_list = GPOS_NEW(mp_) CExpression(
+        mp_, GPOS_NEW(mp_) CScalarProjectList(mp_), proj_array);
+    CExpression *vp_expr = GPOS_NEW(mp_) CExpression(
+        mp_, GPOS_NEW(mp_) CLogicalVarlenPath(
+            mp_, GPOS_NEW(mp_) CName(mp_, path_cname), path_col_ref),
+        plan->getPlanExpr(), proj_list);
+
+    plan->addUnaryParentOp(vp_expr);
+    plan->getSchema()->appendColumn(path_name, path_col_ref);
+    path_col_use_mode_[path_col_ref->Id()] =
+        static_cast<uint8_t>(qg->GetPathUseMode());
+}
+
 void Cypher2OrcaConverter::RegisterPathDstPartitions(
     const BoundRelExpression &rel,
     const BoundNodeExpression &lhs_node,

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -2245,6 +2245,57 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                 qg_plan->addBinaryParentOp(cart_expr, node_plan);
             }
         }
+
+        // Issue #253: `MATCH path = (a)-[:R*…]->(b) RETURN length(path) /
+        // nodes(path) / relationships(path)` needs a path column on the
+        // PathJoin output for the bind-time path variable to resolve at
+        // runtime. PlanShortestPath already does this for the
+        // shortestPath / allShortestPaths variants; we mirror its
+        // placeholder projection so the binder's BoundVariableExpression
+        // for `path` finds a colref in the schema. The physical operator
+        // (PhysicalVarlenAdjIdxJoin) fills the actual per-row LIST.
+        //
+        // Only emit when the binder marked the path as used (PathUseMode
+        // != None) — otherwise the projection is dead weight.
+        if (qg_plan != nullptr && !qg->GetPathName().empty() &&
+            qg->GetPathUseMode() != BoundQueryGraph::PathUseMode::None &&
+            !qg->GetQueryRels().empty()) {
+            auto &qedge = qg->GetQueryRels()[0];
+            const string &lhs_name = qedge->GetSrcNodeName();
+            const string &rhs_name = qedge->GetDstNodeName();
+            CColRef *lhs_id = qg_plan->getSchema()->getColRefOfKey(lhs_name, ID_KEY_ID);
+            CColRef *rhs_id = qg_plan->getSchema()->getColRefOfKey(rhs_name, ID_KEY_ID);
+            if (lhs_id && rhs_id) {
+                CColumnFactory *col_factory = COptCtxt::PoctxtFromTLS()->Pcf();
+                std::wstring w_path(qg->GetPathName().begin(),
+                                    qg->GetPathName().end());
+                const CWStringConst path_name_wstr(w_path.c_str());
+                CName path_cname(&path_name_wstr);
+                CColRef *path_col_ref = col_factory->PcrCreate(
+                    GetMDAccessor()->RetrieveType(&CMDIdGPDB::m_mdid_turbolynx_path),
+                    default_type_modifier, path_cname);
+
+                CExpressionArray *ident_array = GPOS_NEW(mp_) CExpressionArray(mp_);
+                ident_array->Append(GPOS_NEW(mp_) CExpression(
+                    mp_, GPOS_NEW(mp_) CScalarIdent(mp_, lhs_id)));
+                ident_array->Append(GPOS_NEW(mp_) CExpression(
+                    mp_, GPOS_NEW(mp_) CScalarIdent(mp_, rhs_id)));
+                CExpression *values_list = GPOS_NEW(mp_) CExpression(
+                    mp_, GPOS_NEW(mp_) CScalarValuesList(mp_), ident_array);
+                CExpression *proj_elem = GPOS_NEW(mp_) CExpression(
+                    mp_, GPOS_NEW(mp_) CScalarProjectElement(mp_, path_col_ref),
+                    values_list);
+                CExpressionArray *proj_array = GPOS_NEW(mp_) CExpressionArray(mp_);
+                proj_array->Append(proj_elem);
+                CExpression *proj_list = GPOS_NEW(mp_) CExpression(
+                    mp_, GPOS_NEW(mp_) CScalarProjectList(mp_), proj_array);
+                CExpression *proj_expr = GPOS_NEW(mp_) CExpression(
+                    mp_, GPOS_NEW(mp_) CLogicalProject(mp_),
+                    qg_plan->getPlanExpr(), proj_list);
+                qg_plan->addUnaryParentOp(proj_expr);
+                qg_plan->getSchema()->appendColumn(qg->GetPathName(), path_col_ref);
+            }
+        }
     }
     // Phase 2: process shortestPath QGs on the completed plan.
     // This mirrors what happens with separate MATCH clauses — shortestPath

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -150,8 +150,7 @@ Cypher2OrcaConverter::Cypher2OrcaConverter(
     std::unordered_map<INT, LogicalType> &complex_type_registry,
     INT &next_complex_type_id,
     std::unordered_map<INT, ListComprehensionExprInfo> &list_comprehension_registry,
-    INT &next_list_comprehension_id,
-    std::unordered_map<ULONG, uint8_t> &path_col_use_mode)
+    INT &next_list_comprehension_id)
     : mp_(mp), context_(context), provider_(provider),
       col_name_map_(col_name_map),
       both_edge_partitions_(both_edge_partitions),
@@ -162,8 +161,7 @@ Cypher2OrcaConverter::Cypher2OrcaConverter(
       complex_type_registry_(complex_type_registry),
       next_complex_type_id_(next_complex_type_id),
       list_comprehension_registry_(list_comprehension_registry),
-      next_list_comprehension_id_(next_list_comprehension_id),
-      path_col_use_mode_(path_col_use_mode)
+      next_list_comprehension_id_(next_list_comprehension_id)
 {
     // Initialize system column key IDs from catalog.
     GraphCatalogEntry *gcat = GetGraphCatalog();
@@ -3802,14 +3800,11 @@ void Cypher2OrcaConverter::MaybeWrapVarlenPath(
     CExpression *proj_list = GPOS_NEW(mp_) CExpression(
         mp_, GPOS_NEW(mp_) CScalarProjectList(mp_), proj_array);
     CExpression *vp_expr = GPOS_NEW(mp_) CExpression(
-        mp_, GPOS_NEW(mp_) CLogicalVarlenPath(
-            mp_, GPOS_NEW(mp_) CName(mp_, path_cname), path_col_ref),
+        mp_, GPOS_NEW(mp_) CLogicalVarlenPath(mp_, path_col_ref),
         plan->getPlanExpr(), proj_list);
 
     plan->addUnaryParentOp(vp_expr);
     plan->getSchema()->appendColumn(path_name, path_col_ref);
-    path_col_use_mode_[path_col_ref->Id()] =
-        static_cast<uint8_t>(qg->GetPathUseMode());
 }
 
 void Cypher2OrcaConverter::RegisterPathDstPartitions(

--- a/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
+++ b/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
@@ -95,7 +95,9 @@ public:
 	int start_lv;
 	int end_lv;
 	vector<uint64_t> current_path;
-	// vector<uint64_t> current_path_vid; // temp
+	// Path target vids parallel to current_path edges. Only populated
+	// when the op needs to emit a path LIST at runtime.
+	vector<uint64_t> current_path_vid;
 	bool first_time_in_this_loop = true;
 
 	// initialize rest of operator members
@@ -364,6 +366,12 @@ uint64_t PhysicalVarlenAdjIdxJoin::VarlengthExpand_internal(ExecutionContext& co
 			addNewPathToOutput(tgt_adj_column, eid_adj_column,
 			                   state.output_idx + num_found_paths,
 			                   state.current_path, src_vid, 0);
+			if (path_col_idx >= 0) {
+				writePathColumnForRow(chunk,
+				                      state.output_idx + num_found_paths,
+				                      src_vid, state.current_path,
+				                      state.current_path_vid);
+			}
 			if (++num_found_paths == remaining_output) return num_found_paths;
 		}
 	}
@@ -387,7 +395,7 @@ uint64_t PhysicalVarlenAdjIdxJoin::VarlengthExpand_internal(ExecutionContext& co
 			state.iso_checker->removeFromSet(edgeid_to_remove);
 #endif
             state.current_path.pop_back();
-			// state.current_path_vid.pop_back(); // temp
+			if (path_col_idx >= 0) state.current_path_vid.pop_back();
             state.cur_lv--;
 			state.dfs_it->reduceLevel();
             continue;
@@ -403,7 +411,7 @@ uint64_t PhysicalVarlenAdjIdxJoin::VarlengthExpand_internal(ExecutionContext& co
             state.iso_checker->removeFromSet(edgeid_to_remove);
 #endif
             state.current_path.pop_back();
-			// state.current_path_vid.pop_back(); //temp
+			if (path_col_idx >= 0) state.current_path_vid.pop_back();
             state.cur_lv--;
             continue;
         }
@@ -418,7 +426,7 @@ uint64_t PhysicalVarlenAdjIdxJoin::VarlengthExpand_internal(ExecutionContext& co
         // traverse more
         state.cur_lv++;
 		state.current_path.push_back(new_edge_id);
-		// state.current_path_vid.push_back(new_tgt_id); // temp
+		if (path_col_idx >= 0) state.current_path_vid.push_back(new_tgt_id);
 
 		// fprintf(stdout, "src_vid %ld, cur_lv %d, Path: [", src_vid, state.cur_lv);
 		// for (int path_idx = 0; path_idx < state.current_path.size(); path_idx++) {
@@ -446,6 +454,12 @@ uint64_t PhysicalVarlenAdjIdxJoin::VarlengthExpand_internal(ExecutionContext& co
                                    state.output_idx + num_found_paths,
                                    state.current_path, new_tgt_id,
                                    new_edge_id);
+                if (path_col_idx >= 0) {
+                    writePathColumnForRow(chunk,
+                                          state.output_idx + num_found_paths,
+                                          src_vid, state.current_path,
+                                          state.current_path_vid);
+                }
                 if (++num_found_paths == remaining_output) break;
             }
         }
@@ -477,6 +491,28 @@ void PhysicalVarlenAdjIdxJoin::addNewPathToOutput(
 	if (load_eid && eid_adj_column) {
 		eid_adj_column[output_idx] = new_edge_id;
 	}
+}
+
+// Writes a node-edge-interleaved LIST into the path slot for the row
+// at output_idx. Layout matches what path_length / path_nodes /
+// path_rels expect: [src_vid, e0, n0, e1, n1, …, e_{k-1}, dst_vid].
+// current_path holds the edge IDs visited along the row's DFS branch;
+// current_path_vid (parallel) holds the intermediate target vertex IDs.
+void PhysicalVarlenAdjIdxJoin::writePathColumnForRow(
+    DataChunk &chunk, uint64_t output_idx, uint64_t src_vid,
+    const vector<uint64_t> &current_path,
+    const vector<uint64_t> &current_path_vid) const {
+	if (path_col_idx < 0) return;
+	D_ASSERT(current_path.size() == current_path_vid.size());
+	vector<Value> path_vec;
+	path_vec.reserve(2 * current_path.size() + 1);
+	path_vec.push_back(Value::UBIGINT(src_vid));
+	for (size_t i = 0; i < current_path.size(); i++) {
+		path_vec.push_back(Value::UBIGINT(current_path[i]));
+		path_vec.push_back(Value::UBIGINT(current_path_vid[i]));
+	}
+	Value path_val = Value::LIST(LogicalType::UBIGINT, std::move(path_vec));
+	chunk.data[path_col_idx].SetValue(output_idx, path_val);
 }
 
 std::string PhysicalVarlenAdjIdxJoin::ParamsToString() const {

--- a/src/include/binder/bind_context.hpp
+++ b/src/include/binder/bind_context.hpp
@@ -47,6 +47,18 @@ public:
     }
 
     // ---- Path bindings ----
+    // How the bound path variable is consumed downstream — drives whether
+    // the converter materializes the path column at runtime and at what
+    // detail. None = column not needed at all; LengthOnly = list_entry_t
+    // length suffices (cheap, length(path) only); Full = interleaved
+    // node-edge LIST is required (nodes(path), relationships(path), or
+    // direct path reference). Issue #253.
+    enum class PathUseMode : uint8_t {
+        None = 0,
+        LengthOnly = 1,
+        Full = 2,
+    };
+
     struct PathMeta {
         idx_t num_chains = 0;       // total relationship hops in the pattern
         bool  is_fixed_length = true;  // all rels have lower==upper==1
@@ -63,6 +75,10 @@ public:
         // the inner plan and which synthetic name to address.
         bool needs_node_list = false;
         bool needs_rel_list = false;
+        // Set by binder helpers as the path variable's downstream uses are
+        // discovered. The converter widens to the strictest mode requested
+        // (Full > LengthOnly > None) when emitting the path column.
+        PathUseMode use_mode = PathUseMode::None;
     };
     void AddPath(const string& name) {
         path_bindings_.insert(name);
@@ -93,6 +109,21 @@ public:
     void MarkPathNeedsRels(const string& name) {
         auto it = path_meta_.find(name);
         if (it != path_meta_.end()) it->second.needs_rel_list = true;
+    }
+    // Widen the path's use mode — never narrows. Walks outer scopes too,
+    // because a MATCH-bound path can be consumed inside a later WITH/RETURN
+    // that lives in a child BindContext.
+    void MarkPathUseMode(const string& name, PathUseMode mode) {
+        auto it = path_meta_.find(name);
+        if (it != path_meta_.end()) {
+            if ((uint8_t)mode > (uint8_t)it->second.use_mode) {
+                it->second.use_mode = mode;
+            }
+            return;
+        }
+        if (outer_) {
+            const_cast<BindContext *>(outer_)->MarkPathUseMode(name, mode);
+        }
     }
 
     void AddPathRelsAlias(const string& alias, const string& path_name) {

--- a/src/include/binder/graph_pattern/bound_query_graph.hpp
+++ b/src/include/binder/graph_pattern/bound_query_graph.hpp
@@ -83,6 +83,15 @@ public:
     const string& GetPathName() const { return path_name; }
     void SetPathName(string name) { path_name = std::move(name); }
 
+    // ---- Path-variable use-mode propagated from BindContext::PathMeta ----
+    // Mirrors BindContext::PathUseMode (kept here to avoid pulling bind
+    // context into the bound-tree header). The binder syncs the value at
+    // the end of BindRegularQuery so the converter can read it off the
+    // bound tree without re-walking the BindContext chain. Issue #253.
+    enum class PathUseMode : uint8_t { None = 0, LengthOnly = 1, Full = 2 };
+    PathUseMode GetPathUseMode() const { return path_use_mode; }
+    void SetPathUseMode(PathUseMode m) { path_use_mode = m; }
+
     // ---- Merging connected components ----
     bool IsConnected(const BoundQueryGraph& other) const;
     void Merge(const BoundQueryGraph& other);
@@ -94,6 +103,7 @@ private:
     vector<shared_ptr<BoundRelExpression>>     query_rels;
     PathType                                   path_type = PathType::NONE;
     string                                     path_name;
+    PathUseMode                                path_use_mode = PathUseMode::None;
 };
 
 // Collection of connected query graphs from a single MATCH clause.

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -45,6 +45,7 @@
 #include "gpopt/operators/CLogicalGbAgg.h"
 #include "gpopt/operators/CLogicalShortestPath.h"
 #include "gpopt/operators/CLogicalAllShortestPath.h"
+#include "gpopt/operators/CLogicalVarlenPath.h"
 #include "gpopt/operators/CScalarConst.h"
 #include "gpopt/operators/CScalarCmp.h"
 #include "gpopt/operators/CScalarBoolOp.h"
@@ -152,7 +153,13 @@ public:
                          std::unordered_map<INT, LogicalType> &complex_type_registry,
                          INT &next_complex_type_id,
                          std::unordered_map<INT, ListComprehensionExprInfo> &list_comprehension_registry,
-                         INT &next_list_comprehension_id);
+                         INT &next_list_comprehension_id,
+                         // Path-colref id → use mode, written when
+                         // wrapping a varlen MATCH path in
+                         // CLogicalVarlenPath; read by the planner
+                         // lowering to forward the materialization mode
+                         // into PhysicalVarlenAdjIdxJoin.
+                         std::unordered_map<ULONG, uint8_t> &path_col_use_mode);
 
     // Entry point: convert a fully-bound regular query into a ORCA LogicalPlan.
     turbolynx::LogicalPlan *Convert(const BoundRegularQuery &query);
@@ -208,6 +215,14 @@ private:
     turbolynx::LogicalPlan *PlanEdgeScanSinglePartition(
         const BoundRelExpression &rel, size_t partition_idx);
     turbolynx::LogicalPlan *PlanPathGet(const BoundRelExpression &rel);
+    // Wrap an A-R varlen subtree with CLogicalVarlenPath so the path
+    // column gets materialized at runtime — but only when the binder
+    // flagged the path variable as used. Inserted between the path-join
+    // and the eventual R-join-B so the path column rides the join's
+    // outer passthrough without any intermediate op dropping it.
+    void MaybeWrapVarlenPath(turbolynx::LogicalPlan *plan,
+                             const BoundQueryGraph *qg,
+                             const BoundRelExpression &qedge);
     // Record the dst-vertex-pattern partition list for a VarLen edge so
     // the planner uses it as the output-vertex filter (#36).
     void RegisterPathDstPartitions(const BoundRelExpression &rel,
@@ -390,6 +405,7 @@ private:
     INT &next_complex_type_id_;
     std::unordered_map<INT, ListComprehensionExprInfo> &list_comprehension_registry_;
     INT &next_list_comprehension_id_;
+    std::unordered_map<ULONG, uint8_t> &path_col_use_mode_;
     std::unordered_map<string, CColRef *> local_scalar_vars_;
 
     GraphCatalogEntry *graph_cat_ = nullptr;

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -153,13 +153,7 @@ public:
                          std::unordered_map<INT, LogicalType> &complex_type_registry,
                          INT &next_complex_type_id,
                          std::unordered_map<INT, ListComprehensionExprInfo> &list_comprehension_registry,
-                         INT &next_list_comprehension_id,
-                         // Path-colref id → use mode, written when
-                         // wrapping a varlen MATCH path in
-                         // CLogicalVarlenPath; read by the planner
-                         // lowering to forward the materialization mode
-                         // into PhysicalVarlenAdjIdxJoin.
-                         std::unordered_map<ULONG, uint8_t> &path_col_use_mode);
+                         INT &next_list_comprehension_id);
 
     // Entry point: convert a fully-bound regular query into a ORCA LogicalPlan.
     turbolynx::LogicalPlan *Convert(const BoundRegularQuery &query);
@@ -405,7 +399,6 @@ private:
     INT &next_complex_type_id_;
     std::unordered_map<INT, ListComprehensionExprInfo> &list_comprehension_registry_;
     INT &next_list_comprehension_id_;
-    std::unordered_map<ULONG, uint8_t> &path_col_use_mode_;
     std::unordered_map<string, CColRef *> local_scalar_vars_;
 
     GraphCatalogEntry *graph_cat_ = nullptr;

--- a/src/include/execution/physical_operator/physical_varlen_adjidxjoin.hpp
+++ b/src/include/execution/physical_operator/physical_varlen_adjidxjoin.hpp
@@ -29,14 +29,13 @@ public:
 					   uint64_t min_length, uint64_t max_length, vector<uint32_t> &outer_col_map, vector<uint32_t> &inner_col_map,
 					   std::unordered_set<uint16_t> dst_partition_ids = {},
 					   // When a CPhysicalVarlenPath wrap folded path
-					   // materialization into this op, these tell Execute
-					   // where to write the per-row path LIST and how
-					   // deeply to fill it. (-1 / 0 = no path column.)
-					   int64_t path_col_idx = -1,
-					   uint8_t path_use_mode = 0)
+					   // materialization into this op, this tells Execute
+					   // where to write the per-row path LIST.
+					   // (-1 = no path column.)
+					   int64_t path_col_idx = -1)
 		: CypherPhysicalOperator(PhysicalOperatorType::VARLEN_ADJ_IDX_JOIN, sch), adjidx_obj_ids(adjidx_obj_ids), join_type(join_type), sid_col_idx(sid_col_idx), load_eid(load_eid), min_length(min_length), max_length(max_length),
 			outer_col_map(move(outer_col_map)), inner_col_map(move(inner_col_map)), dst_partition_ids(std::move(dst_partition_ids)),
-			path_col_idx(path_col_idx), path_use_mode(path_use_mode)
+			path_col_idx(path_col_idx)
 		{ }
 
     // common interface
@@ -77,9 +76,8 @@ private:
 	// Empty means no filtering (all output passes).
 	std::unordered_set<uint16_t> dst_partition_ids;
 
-	// Path column slot in the output chunk + materialization mode.
+	// Path column slot in the output chunk.
 	int64_t path_col_idx;
-	uint8_t path_use_mode;
 };
 
 } // namespace turbolynx

--- a/src/include/execution/physical_operator/physical_varlen_adjidxjoin.hpp
+++ b/src/include/execution/physical_operator/physical_varlen_adjidxjoin.hpp
@@ -27,9 +27,16 @@ public:
 
 	PhysicalVarlenAdjIdxJoin(Schema& sch, vector<uint64_t> adjidx_obj_ids, JoinType join_type, uint64_t sid_col_idx, bool load_eid,
 					   uint64_t min_length, uint64_t max_length, vector<uint32_t> &outer_col_map, vector<uint32_t> &inner_col_map,
-					   std::unordered_set<uint16_t> dst_partition_ids = {})
+					   std::unordered_set<uint16_t> dst_partition_ids = {},
+					   // When a CPhysicalVarlenPath wrap folded path
+					   // materialization into this op, these tell Execute
+					   // where to write the per-row path LIST and how
+					   // deeply to fill it. (-1 / 0 = no path column.)
+					   int64_t path_col_idx = -1,
+					   uint8_t path_use_mode = 0)
 		: CypherPhysicalOperator(PhysicalOperatorType::VARLEN_ADJ_IDX_JOIN, sch), adjidx_obj_ids(adjidx_obj_ids), join_type(join_type), sid_col_idx(sid_col_idx), load_eid(load_eid), min_length(min_length), max_length(max_length),
-			outer_col_map(move(outer_col_map)), inner_col_map(move(inner_col_map)), dst_partition_ids(std::move(dst_partition_ids))
+			outer_col_map(move(outer_col_map)), inner_col_map(move(inner_col_map)), dst_partition_ids(std::move(dst_partition_ids)),
+			path_col_idx(path_col_idx), path_use_mode(path_use_mode)
 		{ }
 
     // common interface
@@ -50,6 +57,7 @@ public:
 private:
     uint64_t VarlengthExpand_internal(ExecutionContext& context, uint64_t src_vid, DataChunk &chunk, OperatorState &lstate, int64_t remaining_output) const;
 	void addNewPathToOutput(uint64_t *tgt_adj_column, uint64_t *eid_adj_column, uint64_t output_idx, vector<uint64_t> &current_path, uint64_t new_tgt_id, uint64_t new_edge_id) const;
+	void writePathColumnForRow(DataChunk &chunk, uint64_t output_idx, uint64_t src_vid, const vector<uint64_t> &current_path, const vector<uint64_t> &current_path_vid) const;
 
 	uint64_t min_length;
 	uint64_t max_length;
@@ -68,6 +76,10 @@ private:
 	// Destination partition filter for VarLen: only output vertices in these partitions.
 	// Empty means no filtering (all output passes).
 	std::unordered_set<uint16_t> dst_partition_ids;
+
+	// Path column slot in the output chunk + materialization mode.
+	int64_t path_col_idx;
+	uint8_t path_use_mode;
 };
 
 } // namespace turbolynx

--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CLogicalVarlenPath.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CLogicalVarlenPath.h
@@ -1,0 +1,126 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2026 TurboLynx
+//
+//	@filename:
+//		CLogicalVarlenPath.h
+//
+//	@doc:
+//		Logical wrap that requests path-column materialization on a plain
+//		variable-length MATCH path = (a)-[:R*..]->(b) subtree.
+//
+//		Mirrors CLogicalShortestPath's two-child shape — child[0] is the
+//		PathJoin subtree, child[1] is a CScalarProjectList that defines
+//		the path colref — so the path column's origin is properly
+//		established in ORCA's column lifecycle. The placeholder is later
+//		filled at runtime by PhysicalVarlenAdjIdxJoin.
+//---------------------------------------------------------------------------
+#ifndef GPOS_CLogicalVarlenPath_H
+#define GPOS_CLogicalVarlenPath_H
+
+#include "gpos/base.h"
+
+#include "gpopt/operators/CExpressionHandle.h"
+#include "gpopt/operators/CLogicalUnary.h"
+
+namespace gpopt
+{
+class CLogicalVarlenPath : public CLogicalUnary
+{
+private:
+	CLogicalVarlenPath(const CLogicalVarlenPath &);
+
+public:
+	// ctor for xform pattern
+	explicit CLogicalVarlenPath(CMemoryPool *mp);
+
+	// ctor
+	CLogicalVarlenPath(CMemoryPool *mp, const CName *pnameAlias,
+					   CColRef *path_col_ref);
+
+	virtual ~CLogicalVarlenPath();
+
+	virtual EOperatorId
+	Eopid() const
+	{
+		return EopLogicalVarlenPath;
+	}
+
+	virtual const CHAR *
+	SzId() const
+	{
+		return "CLogicalVarlenPath";
+	}
+
+	virtual BOOL Matches(COperator *pop) const;
+
+	const CName *
+	PnameAlias() const
+	{
+		return m_pnameAlias;
+	}
+
+	CColRef *
+	PcrPath() const
+	{
+		return m_path_col_ref;
+	}
+
+	//-------------------------------------------------------------------------------------
+	// Derived Relational Properties
+	//-------------------------------------------------------------------------------------
+
+	virtual CColRefSet *DeriveOutputColumns(CMemoryPool *, CExpressionHandle &);
+
+	virtual CColRefSet *DeriveOuterReferences(CMemoryPool *mp,
+											  CExpressionHandle &exprhdl);
+
+	virtual CColRefSet *DeriveNotNullColumns(CMemoryPool *mp,
+											 CExpressionHandle &exprhdl) const;
+
+	virtual CPropConstraint *DerivePropertyConstraint(
+		CMemoryPool *mp, CExpressionHandle &exprhdl) const;
+
+	//-------------------------------------------------------------------------------------
+	// Required Relational Properties
+	//-------------------------------------------------------------------------------------
+
+	virtual CColRefSet *PcrsStat(CMemoryPool *mp, CExpressionHandle &exprhdl,
+								 CColRefSet *pcrsInput,
+								 ULONG child_index) const;
+
+	//-------------------------------------------------------------------------------------
+	// Derived Stats
+	//-------------------------------------------------------------------------------------
+
+	virtual IStatistics *PstatsDerive(CMemoryPool *mp,
+									  CExpressionHandle &exprhdl,
+									  IStatisticsArray *stats_ctxt) const;
+
+	CXformSet *PxfsCandidates(CMemoryPool *mp) const;
+
+	static CLogicalVarlenPath *
+	PopConvert(COperator *pop)
+	{
+		GPOS_ASSERT(NULL != pop);
+		GPOS_ASSERT(EopLogicalVarlenPath == pop->Eopid());
+
+		return reinterpret_cast<CLogicalVarlenPath *>(pop);
+	}
+
+	virtual IOstream &OsPrint(IOstream &os) const;
+
+private:
+	const CName *m_pnameAlias;
+
+	// the materialized path colref; defined by child[1]'s ProjectList
+	CColRef *m_path_col_ref;
+
+};	// class CLogicalVarlenPath
+
+}  // namespace gpopt
+
+
+#endif	// !GPOS_CLogicalVarlenPath_H
+
+// EOF

--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CLogicalVarlenPath.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CLogicalVarlenPath.h
@@ -35,8 +35,7 @@ public:
 	explicit CLogicalVarlenPath(CMemoryPool *mp);
 
 	// ctor
-	CLogicalVarlenPath(CMemoryPool *mp, const CName *pnameAlias,
-					   CColRef *path_col_ref);
+	CLogicalVarlenPath(CMemoryPool *mp, CColRef *path_col_ref);
 
 	virtual ~CLogicalVarlenPath();
 
@@ -53,12 +52,6 @@ public:
 	}
 
 	virtual BOOL Matches(COperator *pop) const;
-
-	const CName *
-	PnameAlias() const
-	{
-		return m_pnameAlias;
-	}
 
 	CColRef *
 	PcrPath() const
@@ -111,8 +104,6 @@ public:
 	virtual IOstream &OsPrint(IOstream &os) const;
 
 private:
-	const CName *m_pnameAlias;
-
 	// the materialized path colref; defined by child[1]'s ProjectList
 	CColRef *m_path_col_ref;
 

--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/COperator.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/COperator.h
@@ -116,6 +116,7 @@ public:
 		EopLogicalPathApply,				// S62VAR added
 		EopLogicalShortestPath,				// S62VAR added
 		EopLogicalAllShortestPath,				// S62VAR added
+		EopLogicalVarlenPath,				// S62VAR added
 		EopLogicalInnerCorrelatedApply,
 		EopLogicalIndexApply,
 		EopLogicalIndexPathApply,			// S62VAR added
@@ -257,6 +258,7 @@ public:
 		EopPhysicalComputeScalarColumnar,			// S62 Added
 		EopPhysicalShortestPath,				// S62 Added
 		EopPhysicalAllShortestPath,				// S62 Added
+		EopPhysicalVarlenPath,				// S62 Added
 		EopPhysicalSpool,
 		EopPhysicalPartitionSelector,
 		EopPhysicalPartitionSelectorDML,

--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CPhysicalVarlenPath.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CPhysicalVarlenPath.h
@@ -27,8 +27,7 @@ private:
 public:
 	CPhysicalVarlenPath(CMemoryPool *mp);
 
-	CPhysicalVarlenPath(CMemoryPool *mp, const CName *pnameAlias,
-						CColRef *path_col_ref);
+	CPhysicalVarlenPath(CMemoryPool *mp, CColRef *path_col_ref);
 
 	virtual ~CPhysicalVarlenPath();
 
@@ -50,12 +49,6 @@ public:
 	FInputOrderSensitive() const
 	{
 		return true;
-	}
-
-	const CName *
-	PnameAlias() const
-	{
-		return m_pnameAlias;
 	}
 
 	CColRef *
@@ -154,8 +147,6 @@ public:
 	}
 
 private:
-	const CName *m_pnameAlias;
-
 	CColRef *m_path_col_ref;
 
 };	// class CPhysicalVarlenPath

--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CPhysicalVarlenPath.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CPhysicalVarlenPath.h
@@ -1,0 +1,167 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2026 TurboLynx
+//
+//	@filename:
+//		CPhysicalVarlenPath.h
+//
+//	@doc:
+//		Physical wrap that materializes a path column on a plain
+//		variable-length MATCH path = (a)-[:R*..]->(b) subtree.
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CPhysicalVarlenPath_H
+#define GPOPT_CPhysicalVarlenPath_H
+
+#include "gpos/base.h"
+
+#include "gpopt/base/COrderSpec.h"
+#include "gpopt/operators/CPhysical.h"
+
+namespace gpopt
+{
+class CPhysicalVarlenPath : public CPhysical
+{
+private:
+	CPhysicalVarlenPath(const CPhysicalVarlenPath &);
+
+public:
+	CPhysicalVarlenPath(CMemoryPool *mp);
+
+	CPhysicalVarlenPath(CMemoryPool *mp, const CName *pnameAlias,
+						CColRef *path_col_ref);
+
+	virtual ~CPhysicalVarlenPath();
+
+	virtual EOperatorId
+	Eopid() const
+	{
+		return EopPhysicalVarlenPath;
+	}
+
+	virtual const CHAR *
+	SzId() const
+	{
+		return "CPhysicalVarlenPath";
+	}
+
+	virtual BOOL Matches(COperator *pop) const;
+
+	virtual BOOL
+	FInputOrderSensitive() const
+	{
+		return true;
+	}
+
+	const CName *
+	PnameAlias() const
+	{
+		return m_pnameAlias;
+	}
+
+	CColRef *
+	PcrPath() const
+	{
+		return m_path_col_ref;
+	}
+
+	//-------------------------------------------------------------------------------------
+	// Required Plan Properties
+	//-------------------------------------------------------------------------------------
+
+	virtual CColRefSet *PcrsRequired(
+		CMemoryPool *mp, CExpressionHandle &exprhdl, CColRefSet *pcrsRequired,
+		ULONG child_index, CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq);
+
+	virtual CCTEReq *PcteRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
+								  CCTEReq *pcter, ULONG child_index,
+								  CDrvdPropArray *pdrgpdpCtxt,
+								  ULONG ulOptReq) const;
+
+	virtual COrderSpec *PosRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
+									COrderSpec *posRequired, ULONG child_index,
+									CDrvdPropArray *pdrgpdpCtxt,
+									ULONG ulOptReq) const;
+
+	virtual CDistributionSpec *PdsRequired(CMemoryPool *mp,
+										   CExpressionHandle &exprhdl,
+										   CDistributionSpec *pdsRequired,
+										   ULONG child_index,
+										   CDrvdPropArray *pdrgpdpCtxt,
+										   ULONG ulOptReq) const;
+
+	virtual CRewindabilitySpec *PrsRequired(CMemoryPool *mp,
+											CExpressionHandle &exprhdl,
+											CRewindabilitySpec *prsRequired,
+											ULONG child_index,
+											CDrvdPropArray *pdrgpdpCtxt,
+											ULONG ulOptReq) const;
+
+	virtual CPartitionPropagationSpec *PppsRequired(
+		CMemoryPool *mp, CExpressionHandle &exprhdl,
+		CPartitionPropagationSpec *pppsRequired, ULONG child_index,
+		CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq);
+
+	virtual BOOL FProvidesReqdCols(CExpressionHandle &exprhdl,
+								   CColRefSet *pcrsRequired,
+								   ULONG ulOptReq) const;
+
+	//-------------------------------------------------------------------------------------
+	// Derived Plan Properties
+	//-------------------------------------------------------------------------------------
+
+	virtual COrderSpec *PosDerive(CMemoryPool *mp,
+								  CExpressionHandle &exprhdl) const;
+
+	virtual CDistributionSpec *PdsDerive(CMemoryPool *mp,
+										 CExpressionHandle &exprhdl) const;
+
+	virtual CRewindabilitySpec *PrsDerive(CMemoryPool *mp,
+										  CExpressionHandle &exprhdl) const;
+
+	virtual CPartIndexMap *PpimDerive(CMemoryPool *,
+									  CExpressionHandle &exprhdl,
+									  CDrvdPropCtxt *) const;
+
+	virtual CPartFilterMap *PpfmDerive(CMemoryPool *,
+									   CExpressionHandle &exprhdl) const;
+
+	//-------------------------------------------------------------------------------------
+	// Enforced Properties
+	//-------------------------------------------------------------------------------------
+
+	virtual CEnfdProp::EPropEnforcingType EpetOrder(
+		CExpressionHandle &exprhdl, const CEnfdOrder *peo) const;
+
+	virtual CEnfdProp::EPropEnforcingType EpetRewindability(
+		CExpressionHandle &,
+		const CEnfdRewindability *) const;
+
+	virtual BOOL
+	FPassThruStats() const
+	{
+		return false;
+	}
+
+	virtual IOstream &OsPrint(IOstream &) const;
+
+	static CPhysicalVarlenPath *
+	PopConvert(COperator *pop)
+	{
+		GPOS_ASSERT(NULL != pop);
+		GPOS_ASSERT(EopPhysicalVarlenPath == pop->Eopid());
+
+		return dynamic_cast<CPhysicalVarlenPath *>(pop);
+	}
+
+private:
+	const CName *m_pnameAlias;
+
+	CColRef *m_path_col_ref;
+
+};	// class CPhysicalVarlenPath
+
+}  // namespace gpopt
+
+#endif	// !GPOPT_CPhysicalVarlenPath_H
+
+// EOF

--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/xforms/CXform.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/xforms/CXform.h
@@ -237,6 +237,7 @@ public:
 		ExfIndexPathGet2IndexPathScan,
 		ExfImplementShortestPath,
 		ExfImplementAllShortestPath,
+		ExfImplementVarlenPath,
 		ExfExpandNAryJoinGEM,
 		ExfImplementUnnest,
 		// S62 done

--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/xforms/CXformImplementVarlenPath.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/xforms/CXformImplementVarlenPath.h
@@ -1,0 +1,56 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2026 TurboLynx
+//
+//	@filename:
+//		CXformImplementVarlenPath.h
+//
+//	@doc:
+//		Transform CLogicalVarlenPath → CPhysicalVarlenPath.
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CXformImplementVarlenPath_H
+#define GPOPT_CXformImplementVarlenPath_H
+
+#include "gpos/base.h"
+
+#include "gpopt/xforms/CXformImplementation.h"
+
+namespace gpopt
+{
+using namespace gpos;
+
+class CXformImplementVarlenPath : public CXformImplementation
+{
+private:
+	CXformImplementVarlenPath(const CXformImplementVarlenPath &);
+
+public:
+	explicit CXformImplementVarlenPath(CMemoryPool *mp);
+
+	virtual ~CXformImplementVarlenPath()
+	{
+	}
+
+	virtual EXformId
+	Exfid() const
+	{
+		return ExfImplementVarlenPath;
+	}
+
+	virtual const CHAR *
+	SzId() const
+	{
+		return "CXformImplementVarlenPath";
+	}
+
+	virtual EXformPromise Exfp(CExpressionHandle &exprhdl) const;
+
+	void Transform(CXformContext *, CXformResult *, CExpression *) const;
+
+};	// class CXformImplementVarlenPath
+
+}  // namespace gpopt
+
+#endif	// !CXformImplementVarlenPath
+
+// EOF

--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/xforms/xforms.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/xforms/xforms.h
@@ -173,6 +173,7 @@
 #include "gpopt/xforms/CXformIndexPathGet2IndexPathScan.h"
 #include "gpopt/xforms/CXformImplementShortestPath.h"
 #include "gpopt/xforms/CXformImplementAllShortestPath.h"
+#include "gpopt/xforms/CXformImplementVarlenPath.h"
 #include "gpopt/xforms/CXformImplementUnnest.h"
 
 #endif	// !GPOPT_xforms_H

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -110,6 +110,7 @@
 #include "gpopt/operators/CPhysicalStreamAggDeduplicate.h"
 #include "gpopt/operators/CPhysicalShortestPath.h"
 #include "gpopt/operators/CPhysicalAllShortestPath.h"
+#include "gpopt/operators/CPhysicalVarlenPath.h"
 #include "gpopt/operators/CPhysicalUnnest.h"
 #include "gpopt/operators/CPhysicalConstTableGet.h"
 
@@ -325,6 +326,8 @@ private:
 	// shortestPath
 	duckdb::CypherPhysicalOperatorGroups* pTransformEopShortestPath(CExpression* plan_expr);
 	duckdb::CypherPhysicalOperatorGroups* pTransformEopAllShortestPath(CExpression* plan_expr);
+	// varlen path materialization wrap
+	duckdb::CypherPhysicalOperatorGroups* pTransformEopPhysicalVarlenPath(CExpression* plan_expr);
 
 	// unnest / UNWIND
 	duckdb::CypherPhysicalOperatorGroups *pTransformEopUnnest(CExpression *plan_expr);
@@ -609,6 +612,18 @@ private:
 	// vector<CColRef *> colrefs_for_dsi; // should include columns used for grouping key / join column
 	CColRefSet *colrefs_for_dsi = nullptr;
 	bool analyze_ongoing = false;
+
+	// Path-colref id → use mode for every CLogicalVarlenPath wrap the
+	// converter emits. Read by pTransformEopPhysicalVarlenPath to forward
+	// the materialization mode into PhysicalVarlenAdjIdxJoin.
+	std::unordered_map<ULONG, uint8_t> path_col_use_mode_;
+
+	// Path-materialization request signalled from a CPhysicalVarlenPath
+	// lowering down into the next PhysicalVarlenAdjIdxJoin in the same
+	// subtree. The first consumer clears both fields so siblings don't
+	// double-consume.
+	gpopt::CColRef *pending_path_col_ref_ = nullptr;
+	uint8_t pending_path_use_mode_ = 0;
 
 	// md provider
 	gpmd::MDProviderTBGPP *provider = nullptr;

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -613,17 +613,10 @@ private:
 	CColRefSet *colrefs_for_dsi = nullptr;
 	bool analyze_ongoing = false;
 
-	// Path-colref id → use mode for every CLogicalVarlenPath wrap the
-	// converter emits. Read by pTransformEopPhysicalVarlenPath to forward
-	// the materialization mode into PhysicalVarlenAdjIdxJoin.
-	std::unordered_map<ULONG, uint8_t> path_col_use_mode_;
-
 	// Path-materialization request signalled from a CPhysicalVarlenPath
 	// lowering down into the next PhysicalVarlenAdjIdxJoin in the same
-	// subtree. The first consumer clears both fields so siblings don't
-	// double-consume.
+	// subtree. The first consumer clears it so siblings don't double-consume.
 	gpopt::CColRef *pending_path_col_ref_ = nullptr;
-	uint8_t pending_path_use_mode_ = 0;
 
 	// md provider
 	gpmd::MDProviderTBGPP *provider = nullptr;

--- a/src/optimizer/orca/gporca/libgpdbcost/CCostModelGPDB.cpp
+++ b/src/optimizer/orca/gporca/libgpdbcost/CCostModelGPDB.cpp
@@ -74,6 +74,7 @@ const CCostModelGPDB::SCostMapping CCostModelGPDB::m_rgcm[] = {
 
 	{COperator::EopPhysicalShortestPath, CostShortestPath},
 	{COperator::EopPhysicalAllShortestPath, CostShortestPath},
+	{COperator::EopPhysicalVarlenPath, CostShortestPath},
 	{COperator::EopPhysicalUnnest, CostConstTableGet},  // UNWIND: trivial cost
 
 	{COperator::EopPhysicalTVF, CostTVF},
@@ -2164,7 +2165,8 @@ CCostModelGPDB::CostShortestPath(CMemoryPool *mp, CExpressionHandle &exprhdl,
 	GPOS_ASSERT(NULL != pcmgpdb);
 	GPOS_ASSERT(NULL != pci);
 	GPOS_ASSERT(COperator::EopPhysicalShortestPath == exprhdl.Pop()->Eopid() ||
-				COperator::EopPhysicalAllShortestPath == exprhdl.Pop()->Eopid());
+				COperator::EopPhysicalAllShortestPath == exprhdl.Pop()->Eopid() ||
+				COperator::EopPhysicalVarlenPath == exprhdl.Pop()->Eopid());
 
 	// log operation below
 	const CDouble rows = CDouble(std::max(1.0, pci->Rows()));

--- a/src/optimizer/orca/gporca/libgpopt/operators/CLogicalVarlenPath.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/operators/CLogicalVarlenPath.cpp
@@ -22,17 +22,12 @@
 using namespace gpopt;
 
 CLogicalVarlenPath::CLogicalVarlenPath(CMemoryPool *mp)
-	: CLogicalUnary(mp),
-	  m_pnameAlias(NULL),
-	  m_path_col_ref(NULL)
+	: CLogicalUnary(mp), m_path_col_ref(NULL)
 {
 }
 
-CLogicalVarlenPath::CLogicalVarlenPath(CMemoryPool *mp, const CName *pnameAlias,
-									   CColRef *path_col_ref)
-	: CLogicalUnary(mp),
-	  m_pnameAlias(pnameAlias),
-	  m_path_col_ref(path_col_ref)
+CLogicalVarlenPath::CLogicalVarlenPath(CMemoryPool *mp, CColRef *path_col_ref)
+	: CLogicalUnary(mp), m_path_col_ref(path_col_ref)
 {
 	GPOS_ASSERT(NULL != path_col_ref);
 }

--- a/src/optimizer/orca/gporca/libgpopt/operators/CLogicalVarlenPath.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/operators/CLogicalVarlenPath.cpp
@@ -1,0 +1,137 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2026 TurboLynx
+//
+//	@filename:
+//		CLogicalVarlenPath.cpp
+//
+//	@doc:
+//		Implementation of logical VarlenPath operator.
+//---------------------------------------------------------------------------
+
+#include "gpopt/operators/CLogicalVarlenPath.h"
+
+#include "gpos/base.h"
+
+#include "gpopt/base/CColRefSet.h"
+#include "gpopt/operators/CExpression.h"
+#include "gpopt/operators/CExpressionHandle.h"
+#include "gpopt/xforms/CXformUtils.h"
+#include "naucrates/statistics/CStatistics.h"
+
+using namespace gpopt;
+
+CLogicalVarlenPath::CLogicalVarlenPath(CMemoryPool *mp)
+	: CLogicalUnary(mp),
+	  m_pnameAlias(NULL),
+	  m_path_col_ref(NULL)
+{
+}
+
+CLogicalVarlenPath::CLogicalVarlenPath(CMemoryPool *mp, const CName *pnameAlias,
+									   CColRef *path_col_ref)
+	: CLogicalUnary(mp),
+	  m_pnameAlias(pnameAlias),
+	  m_path_col_ref(path_col_ref)
+{
+	GPOS_ASSERT(NULL != path_col_ref);
+}
+
+CLogicalVarlenPath::~CLogicalVarlenPath()
+{
+}
+
+CColRefSet *
+CLogicalVarlenPath::DeriveOutputColumns(CMemoryPool *mp, CExpressionHandle &exprhdl)
+{
+	GPOS_ASSERT(2 == exprhdl.Arity());
+
+	CColRefSet *pcrs = GPOS_NEW(mp) CColRefSet(mp);
+
+	pcrs->Include(exprhdl.DeriveOutputColumns(0));
+	pcrs->Union(exprhdl.DeriveDefinedColumns(1));
+
+	return pcrs;
+}
+
+CColRefSet *
+CLogicalVarlenPath::DeriveOuterReferences(CMemoryPool *mp,
+										  CExpressionHandle &exprhdl)
+{
+	return CLogical::DeriveOuterReferences(mp, exprhdl);
+}
+
+CColRefSet *
+CLogicalVarlenPath::DeriveNotNullColumns(CMemoryPool *mp,
+										 CExpressionHandle &exprhdl) const
+{
+	CColRefSet *pcrs = GPOS_NEW(mp) CColRefSet(mp);
+	pcrs->Include(exprhdl.DeriveNotNullColumns(0));
+	return pcrs;
+}
+
+CPropConstraint *
+CLogicalVarlenPath::DerivePropertyConstraint(CMemoryPool *mp,
+											 CExpressionHandle &exprhdl) const
+{
+	return PpcDeriveConstraintPassThru(exprhdl, 0 /* ulChild */);
+}
+
+CColRefSet *
+CLogicalVarlenPath::PcrsStat(CMemoryPool *mp, CExpressionHandle &exprhdl,
+							 CColRefSet *pcrsInput, ULONG child_index) const
+{
+	CColRefSet *pcrs = GPOS_NEW(mp) CColRefSet(mp);
+	pcrs->Union(exprhdl.DeriveUsedColumns(1));
+
+	CColRefSet *pcrsRequired =
+		PcrsReqdChildStats(mp, exprhdl, pcrsInput, pcrs, child_index);
+	pcrs->Release();
+
+	return pcrsRequired;
+}
+
+IStatistics *
+CLogicalVarlenPath::PstatsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl,
+								 IStatisticsArray *	 // not used
+) const
+{
+	return PstatsDeriveDummy(mp, exprhdl, CStatistics::DefaultRelationRows);
+}
+
+BOOL
+CLogicalVarlenPath::Matches(COperator *pop) const
+{
+	if (pop->Eopid() != Eopid())
+	{
+		return false;
+	}
+
+	CLogicalVarlenPath *popVP = reinterpret_cast<CLogicalVarlenPath *>(pop);
+	return CColRef::Equals(m_path_col_ref, popVP->PcrPath());
+}
+
+CXformSet *
+CLogicalVarlenPath::PxfsCandidates(CMemoryPool *mp) const
+{
+	CXformSet *xform_set = GPOS_NEW(mp) CXformSet(mp);
+	(void) xform_set->ExchangeSet(CXform::ExfImplementVarlenPath);
+	return xform_set;
+}
+
+IOstream &
+CLogicalVarlenPath::OsPrint(IOstream &os) const
+{
+	os << SzId() << " (";
+	if (NULL != m_path_col_ref)
+	{
+		os << " Path Col: [";
+		m_path_col_ref->OsPrint(os);
+		os << "]";
+	}
+	os << " )";
+	return os;
+}
+
+
+// EOF

--- a/src/optimizer/orca/gporca/libgpopt/operators/CPhysicalVarlenPath.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/operators/CPhysicalVarlenPath.cpp
@@ -1,0 +1,227 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2026 TurboLynx
+//
+//	@filename:
+//		CPhysicalVarlenPath.cpp
+//
+//	@doc:
+//		Implementation of physical VarlenPath operator.
+//---------------------------------------------------------------------------
+
+#include "gpopt/operators/CPhysicalVarlenPath.h"
+
+#include "gpos/base.h"
+
+#include "gpopt/base/CUtils.h"
+#include "gpopt/operators/CExpressionHandle.h"
+#include "gpopt/base/CDistributionSpecAny.h"
+
+
+using namespace gpopt;
+
+
+CPhysicalVarlenPath::CPhysicalVarlenPath(CMemoryPool *mp)
+	: CPhysical(mp),
+	  m_pnameAlias(NULL),
+	  m_path_col_ref(NULL)
+{
+	GPOS_ASSERT(NULL != mp);
+}
+
+CPhysicalVarlenPath::CPhysicalVarlenPath(CMemoryPool *mp, const CName *pnameAlias,
+										 CColRef *path_col_ref)
+	: CPhysical(mp),
+	  m_pnameAlias(pnameAlias),
+	  m_path_col_ref(path_col_ref)
+{
+}
+
+CPhysicalVarlenPath::~CPhysicalVarlenPath()
+{
+}
+
+BOOL
+CPhysicalVarlenPath::Matches(COperator *pop) const
+{
+	if (pop->Eopid() != Eopid())
+	{
+		return false;
+	}
+	return true;
+}
+
+CColRefSet *
+CPhysicalVarlenPath::PcrsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
+								  CColRefSet *pcrsRequired, ULONG child_index,
+								  CDrvdPropArray *,	 // pdrgpdpCtxt
+								  ULONG				 // ulOptReq
+)
+{
+	GPOS_ASSERT(0 == child_index);
+
+	CColRefSet *pcrs = GPOS_NEW(mp) CColRefSet(mp);
+	pcrs->Union(pcrsRequired);
+
+	CColRefSet *prcsOutput = PcrsChildReqd(mp, exprhdl, pcrsRequired, child_index, 1);
+	pcrs->Release();
+
+	return prcsOutput;
+}
+
+COrderSpec *
+CPhysicalVarlenPath::PosRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
+								 COrderSpec *posRequired, ULONG child_index,
+								 CDrvdPropArray *,	// pdrgpdpCtxt
+								 ULONG				// ulOptReq
+) const
+{
+	GPOS_ASSERT(0 == child_index);
+
+	return PosPassThru(mp, exprhdl, posRequired, child_index);
+}
+
+CDistributionSpec *
+CPhysicalVarlenPath::PdsRequired(CMemoryPool *mp, CExpressionHandle &,
+								 CDistributionSpec *, ULONG, CDrvdPropArray *,
+								 ULONG) const
+{
+	return GPOS_NEW(mp) CDistributionSpecAny(this->Eopid());
+}
+
+CRewindabilitySpec *
+CPhysicalVarlenPath::PrsRequired(CMemoryPool *mp,
+								 CExpressionHandle &,	// exprhdl
+								 CRewindabilitySpec *,	// prsRequired
+								 ULONG,					// child_index
+								 CDrvdPropArray *,		// pdrgpdpCtxt
+								 ULONG					// ulOptReq
+) const
+{
+	GPOS_ASSERT(NULL != mp);
+
+	return GPOS_NEW(mp) CRewindabilitySpec(CRewindabilitySpec::ErtNone,
+										   CRewindabilitySpec::EmhtNoMotion);
+}
+
+CPartitionPropagationSpec *
+CPhysicalVarlenPath::PppsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
+								  CPartitionPropagationSpec *pppsRequired_unused,
+								  ULONG
+#ifdef GPOS_DEBUG
+									  child_index
+#endif
+								  ,
+								  CDrvdPropArray *,	 // pdrgpdpCtxt
+								  ULONG				 // ulOptReq
+)
+{
+	GPOS_ASSERT(0 == child_index);
+	GPOS_ASSERT(NULL != pppsRequired_unused);
+
+	return CPhysical::PppsRequiredPushThruUnresolvedUnary(
+		mp, exprhdl, pppsRequired_unused, CPhysical::EppcProhibited, NULL);
+}
+
+CCTEReq *
+CPhysicalVarlenPath::PcteRequired(CMemoryPool *mp_unused,
+								  CExpressionHandle &,	// exprhdl
+								  CCTEReq *pcter,
+								  ULONG
+#ifdef GPOS_DEBUG
+									  child_index
+#endif
+								  ,
+								  CDrvdPropArray *,	 // pdrgpdpCtxt
+								  ULONG				 // ulOptReq
+) const
+{
+	(void)mp_unused;
+	GPOS_ASSERT(0 == child_index);
+	return PcterPushThru(pcter);
+}
+
+BOOL
+CPhysicalVarlenPath::FProvidesReqdCols(CExpressionHandle &exprhdl,
+									   CColRefSet *pcrsRequired,
+									   ULONG  // ulOptReq
+) const
+{
+	CColRefSet *pcrs = GPOS_NEW(m_mp) CColRefSet(m_mp);
+	pcrs->Union(exprhdl.DeriveOutputColumns(0));
+	pcrs->Union(exprhdl.DeriveDefinedColumns(1));
+
+	BOOL fProvidesCols = pcrs->ContainsAll(pcrsRequired);
+	pcrs->Release();
+
+	return fProvidesCols;
+}
+
+COrderSpec *
+CPhysicalVarlenPath::PosDerive(CMemoryPool *,  // mp
+							   CExpressionHandle &exprhdl) const
+{
+	return PosDerivePassThruOuter(exprhdl);
+}
+
+CDistributionSpec *
+CPhysicalVarlenPath::PdsDerive(CMemoryPool *,  // mp
+							   CExpressionHandle &exprhdl) const
+{
+	return PdsDerivePassThruOuter(exprhdl);
+}
+
+CRewindabilitySpec *
+CPhysicalVarlenPath::PrsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
+{
+	return PrsDerivePassThruOuter(mp, exprhdl);
+}
+
+CPartIndexMap *
+CPhysicalVarlenPath::PpimDerive(CMemoryPool *, CExpressionHandle &exprhdl,
+								CDrvdPropCtxt *) const
+{
+	return PpimPassThruOuter(exprhdl);
+}
+
+CPartFilterMap *
+CPhysicalVarlenPath::PpfmDerive(CMemoryPool *, CExpressionHandle &exprhdl) const
+{
+	return PpfmPassThruOuter(exprhdl);
+}
+
+CEnfdProp::EPropEnforcingType
+CPhysicalVarlenPath::EpetOrder(CExpressionHandle &,	 // exprhdl
+							   const CEnfdOrder *peo) const
+{
+	GPOS_ASSERT(NULL != peo);
+	GPOS_ASSERT(!peo->PosRequired()->IsEmpty());
+
+	return CEnfdProp::EpetRequired;
+}
+
+CEnfdProp::EPropEnforcingType
+CPhysicalVarlenPath::EpetRewindability(CExpressionHandle &,		  // exprhdl
+									   const CEnfdRewindability * // per
+) const
+{
+	return CEnfdProp::EpetOptional;
+}
+
+IOstream &
+CPhysicalVarlenPath::OsPrint(IOstream &os) const
+{
+	os << SzId() << "( ";
+	if (NULL != m_path_col_ref)
+	{
+		os << " Path Col: [";
+		m_path_col_ref->OsPrint(os);
+		os << "]";
+	}
+	os << " )";
+	return os;
+}
+
+
+
+// EOF

--- a/src/optimizer/orca/gporca/libgpopt/operators/CPhysicalVarlenPath.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/operators/CPhysicalVarlenPath.cpp
@@ -22,18 +22,13 @@ using namespace gpopt;
 
 
 CPhysicalVarlenPath::CPhysicalVarlenPath(CMemoryPool *mp)
-	: CPhysical(mp),
-	  m_pnameAlias(NULL),
-	  m_path_col_ref(NULL)
+	: CPhysical(mp), m_path_col_ref(NULL)
 {
 	GPOS_ASSERT(NULL != mp);
 }
 
-CPhysicalVarlenPath::CPhysicalVarlenPath(CMemoryPool *mp, const CName *pnameAlias,
-										 CColRef *path_col_ref)
-	: CPhysical(mp),
-	  m_pnameAlias(pnameAlias),
-	  m_path_col_ref(path_col_ref)
+CPhysicalVarlenPath::CPhysicalVarlenPath(CMemoryPool *mp, CColRef *path_col_ref)
+	: CPhysical(mp), m_path_col_ref(path_col_ref)
 {
 }
 

--- a/src/optimizer/orca/gporca/libgpopt/xforms/CXformFactory.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/xforms/CXformFactory.cpp
@@ -307,6 +307,7 @@ CXformFactory::Instantiate()
 	Add(GPOS_NEW(m_mp) CXformIndexPathGet2IndexPathScan(m_mp));
 	Add(GPOS_NEW(m_mp) CXformImplementShortestPath(m_mp));
 	Add(GPOS_NEW(m_mp) CXformImplementAllShortestPath(m_mp));
+	Add(GPOS_NEW(m_mp) CXformImplementVarlenPath(m_mp));
 	Add(GPOS_NEW(m_mp) CXformExpandNAryJoinGEM(m_mp));
 	Add(GPOS_NEW(m_mp) CXformImplementUnnest(m_mp));
 

--- a/src/optimizer/orca/gporca/libgpopt/xforms/CXformImplementVarlenPath.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/xforms/CXformImplementVarlenPath.cpp
@@ -56,8 +56,7 @@ CXformImplementVarlenPath::Transform(CXformContext *pxfctxt, CXformResult *pxfre
 	pexprScalar->AddRef();
 
 	CExpression *pexprPhysical = GPOS_NEW(mp) CExpression(
-		mp, GPOS_NEW(mp) CPhysicalVarlenPath(mp, popVP->PnameAlias(),
-											 popVP->PcrPath()),
+		mp, GPOS_NEW(mp) CPhysicalVarlenPath(mp, popVP->PcrPath()),
 		pexprRelational, pexprScalar);
 
 	pxfres->Add(pexprPhysical);

--- a/src/optimizer/orca/gporca/libgpopt/xforms/CXformImplementVarlenPath.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/xforms/CXformImplementVarlenPath.cpp
@@ -1,0 +1,67 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2026 TurboLynx
+//
+//	@filename:
+//		CXformImplementVarlenPath.cpp
+//
+//	@doc:
+//		Implementation of VarlenPath xform.
+//---------------------------------------------------------------------------
+
+#include "gpopt/xforms/CXformImplementVarlenPath.h"
+
+#include "gpos/base.h"
+
+#include "gpopt/operators/CExpressionHandle.h"
+#include "gpopt/operators/CLogicalVarlenPath.h"
+#include "gpopt/operators/CPatternLeaf.h"
+#include "gpopt/operators/CPhysicalVarlenPath.h"
+
+using namespace gpopt;
+
+
+CXformImplementVarlenPath::CXformImplementVarlenPath(CMemoryPool *mp)
+	:  // pattern: child[0] = relational subtree, child[1] = ScalarProjectList
+	  CXformImplementation(
+		  GPOS_NEW(mp) CExpression(
+			  mp, GPOS_NEW(mp) CLogicalVarlenPath(mp),
+			  GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CPatternLeaf(mp)),
+			  GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CPatternTree(mp))))
+{
+}
+
+CXform::EXformPromise
+CXformImplementVarlenPath::Exfp(CExpressionHandle &exprhdl) const
+{
+	(void) exprhdl;
+	return CXform::ExfpHigh;
+}
+
+void
+CXformImplementVarlenPath::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
+									 CExpression *pexpr) const
+{
+	GPOS_ASSERT(NULL != pxfctxt);
+	GPOS_ASSERT(FPromising(pxfctxt->Pmp(), this, pexpr));
+	GPOS_ASSERT(FCheckPattern(pexpr));
+
+	CMemoryPool *mp = pxfctxt->Pmp();
+
+	CLogicalVarlenPath *popVP = CLogicalVarlenPath::PopConvert(pexpr->Pop());
+	CExpression *pexprRelational = (*pexpr)[0];
+	CExpression *pexprScalar = (*pexpr)[1];
+
+	pexprRelational->AddRef();
+	pexprScalar->AddRef();
+
+	CExpression *pexprPhysical = GPOS_NEW(mp) CExpression(
+		mp, GPOS_NEW(mp) CPhysicalVarlenPath(mp, popVP->PnameAlias(),
+											 popVP->PcrPath()),
+		pexprRelational, pexprScalar);
+
+	pxfres->Add(pexprPhysical);
+}
+
+
+// EOF

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -101,9 +101,7 @@ void Planner::reset()
     mpv_colref_to_scan_idx_.clear();
     complex_type_registry.clear();
     next_complex_type_id = turbolynx::COMPLEX_TYPE_REGISTRY_MIN;
-    path_col_use_mode_.clear();
     pending_path_col_ref_ = nullptr;
-    pending_path_use_mode_ = 0;
     list_comprehension_registry.clear();
     next_list_comprehension_id = 20000;
     pipeline_operator_types.clear();
@@ -498,8 +496,7 @@ void *Planner::_orcaExec(void *planner_ptr)
             planner->complex_type_registry,
             planner->next_complex_type_id,
             planner->list_comprehension_registry,
-            planner->next_list_comprehension_id,
-            planner->path_col_use_mode_);
+            planner->next_list_comprehension_id);
         LogicalPlan *logical_plan = converter.Convert(*planner->bound_regular_query);
         planner->wrap_final_with_optional = logical_plan->isWrapWithOptional();
         CExpression *orca_logical_plan = logical_plan->getPlanExpr();

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -101,6 +101,9 @@ void Planner::reset()
     mpv_colref_to_scan_idx_.clear();
     complex_type_registry.clear();
     next_complex_type_id = turbolynx::COMPLEX_TYPE_REGISTRY_MIN;
+    path_col_use_mode_.clear();
+    pending_path_col_ref_ = nullptr;
+    pending_path_use_mode_ = 0;
     list_comprehension_registry.clear();
     next_list_comprehension_id = 20000;
     pipeline_operator_types.clear();
@@ -495,7 +498,8 @@ void *Planner::_orcaExec(void *planner_ptr)
             planner->complex_type_registry,
             planner->next_complex_type_id,
             planner->list_comprehension_registry,
-            planner->next_list_comprehension_id);
+            planner->next_list_comprehension_id,
+            planner->path_col_use_mode_);
         LogicalPlan *logical_plan = converter.Convert(*planner->bound_regular_query);
         planner->wrap_final_with_optional = logical_plan->isWrapWithOptional();
         CExpression *orca_logical_plan = logical_plan->getPlanExpr();

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -743,6 +743,10 @@ Planner::pTraverseTransformPhysicalPlan(CExpression *plan_expr)
 			result = pTransformEopAllShortestPath(plan_expr);
 			break;
 		}
+		case COperator::EOperatorId::EopPhysicalVarlenPath: {
+			result = pTransformEopPhysicalVarlenPath(plan_expr);
+			break;
+		}
 		case COperator::EOperatorId::EopPhysicalUnnest: {
 			result = pTransformEopUnnest(plan_expr);
 			break;
@@ -3083,6 +3087,23 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToVarlenAdjIdxJoin(
     }
 
     /* Generate operator and push */
+    // When a CLogicalVarlenPath wrap above this varlen requested path
+    // materialization, pTransformEopPhysicalVarlenPath sets the pending
+    // colref before traversing in. Append it to our output schema (the
+    // wrap's child[0].PcrsRequired excludes the path col, so it's
+    // absent until we add it here) and tell the runtime to fill the
+    // per-row LIST.
+    int64_t path_col_idx = -1;
+    uint8_t path_use_mode = 0;
+    if (pending_path_col_ref_ != nullptr) {
+        output_cols->Append(pending_path_col_ref_);
+        types.push_back(pGetColumnsDuckDBType(pending_path_col_ref_));
+        path_col_idx = (int64_t)(output_cols->Size() - 1);
+        path_use_mode = pending_path_use_mode_;
+        pending_path_col_ref_ = nullptr;
+        pending_path_use_mode_ = 0;
+    }
+
     duckdb::Schema tmp_schema;
     tmp_schema.setStoredTypes(types);
     uint64_t upper_bound = pathscan_op->UpperBound();
@@ -3091,11 +3112,28 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToVarlenAdjIdxJoin(
     duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalVarlenAdjIdxJoin(
         tmp_schema, path_index_oids, duckdb::JoinType::INNER, sid_col_idx, false,
         lower_bound, upper_bound, outer_col_map,
-        inner_col_map, std::move(dst_partition_ids));
+        inner_col_map, std::move(dst_partition_ids),
+        path_col_idx, path_use_mode);
 
     result->push_back(op);
 
     pBuildSchemaFlowGraphForUnaryOperator(tmp_schema);
+
+    // The emitted chunk is now wider than plan_expr->Prpp()->PcrsRequired()
+    // because of the appended path column. Downstream operators need to
+    // see the path col at its physical position when they compute
+    // input_col_map; refresh physical_plan_output_colrefs so the next op
+    // (typically the CPhysicalVarlenPath wrap, then a projection)
+    // resolves path_col_ref to the right physical index.
+    if (path_col_idx >= 0) {
+        physical_plan_output_colrefs.clear();
+        physical_plan_output_positions.clear();
+        for (ULONG col_idx = 0; col_idx < output_cols->Size(); col_idx++) {
+            physical_plan_output_colrefs.push_back(output_cols->operator[](col_idx));
+            physical_plan_output_positions.push_back(col_idx);
+        }
+        preserve_explicit_physical_output_layout = true;
+    }
 
     return result;
 }
@@ -9381,6 +9419,44 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopUnnest(
     result->push_back(op);
 
     pBuildSchemaFlowGraphForUnaryOperator(tmp_schema);
+
+    return result;
+}
+
+// CPhysicalVarlenPath asks the inner PhysicalVarlenAdjIdxJoin to fill a
+// path-LIST column at runtime. The wrap emits no physical op of its own:
+// it just signals via pending_path_col_ref_ + pending_path_use_mode_, and
+// the first PhysicalVarlenAdjIdxJoin lowering in the subtree consumes
+// them and appends the path col to its output schema.
+duckdb::CypherPhysicalOperatorGroups *
+Planner::pTransformEopPhysicalVarlenPath(CExpression *plan_expr)
+{
+    CPhysicalVarlenPath *vp_op = (CPhysicalVarlenPath *)plan_expr->Pop();
+    CColRef *path_col = vp_op->PcrPath();
+    D_ASSERT(path_col != nullptr);
+
+    auto it = path_col_use_mode_.find(path_col->Id());
+    uint8_t use_mode = (it != path_col_use_mode_.end()) ? it->second : 0;
+
+    pending_path_col_ref_ = path_col;
+    pending_path_use_mode_ = use_mode;
+
+    duckdb::CypherPhysicalOperatorGroups *result =
+        pTraverseTransformPhysicalPlan(plan_expr->PdrgPexpr()->operator[](0));
+
+    // pTraverseTransformPhysicalPlan's wrapper resets the preserve flag
+    // after every op. Re-arm it here so the layout the inner varlen set
+    // (with path_col_ref appended) survives at this wrap level — the
+    // wrap emits no own physical op, so its chunk IS the varlen's chunk.
+    if (!physical_plan_output_colrefs.empty()) {
+        preserve_explicit_physical_output_layout = true;
+    }
+
+    // If for any reason no consumer claimed the pending (e.g. the wrap
+    // sat above a non-varlen subtree), clear so siblings aren't
+    // contaminated.
+    pending_path_col_ref_ = nullptr;
+    pending_path_use_mode_ = 0;
 
     return result;
 }

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -3094,14 +3094,11 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToVarlenAdjIdxJoin(
     // absent until we add it here) and tell the runtime to fill the
     // per-row LIST.
     int64_t path_col_idx = -1;
-    uint8_t path_use_mode = 0;
     if (pending_path_col_ref_ != nullptr) {
         output_cols->Append(pending_path_col_ref_);
         types.push_back(pGetColumnsDuckDBType(pending_path_col_ref_));
         path_col_idx = (int64_t)(output_cols->Size() - 1);
-        path_use_mode = pending_path_use_mode_;
         pending_path_col_ref_ = nullptr;
-        pending_path_use_mode_ = 0;
     }
 
     duckdb::Schema tmp_schema;
@@ -3113,7 +3110,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToVarlenAdjIdxJoin(
         tmp_schema, path_index_oids, duckdb::JoinType::INNER, sid_col_idx, false,
         lower_bound, upper_bound, outer_col_map,
         inner_col_map, std::move(dst_partition_ids),
-        path_col_idx, path_use_mode);
+        path_col_idx);
 
     result->push_back(op);
 
@@ -9435,11 +9432,7 @@ Planner::pTransformEopPhysicalVarlenPath(CExpression *plan_expr)
     CColRef *path_col = vp_op->PcrPath();
     D_ASSERT(path_col != nullptr);
 
-    auto it = path_col_use_mode_.find(path_col->Id());
-    uint8_t use_mode = (it != path_col_use_mode_.end()) ? it->second : 0;
-
     pending_path_col_ref_ = path_col;
-    pending_path_use_mode_ = use_mode;
 
     duckdb::CypherPhysicalOperatorGroups *result =
         pTraverseTransformPhysicalPlan(plan_expr->PdrgPexpr()->operator[](0));
@@ -9456,7 +9449,6 @@ Planner::pTransformEopPhysicalVarlenPath(CExpression *plan_expr)
     // sat above a non-varlen subtree), clear so siblings aren't
     // contaminated.
     pending_path_col_ref_ = nullptr;
-    pending_path_use_mode_ = 0;
 
     return result;
 }

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -546,6 +546,126 @@ TEST_CASE("length on string (not path)", "[ldbc][filter][path]") {
 }
 
 // ============================================================
+// Plain varlen path materialization
+// ------------------------------------------------------------
+// MATCH path = (a)-[:R*N..M]-(b) RETURN length(path) was crashing
+// because PathJoin never projected a path column (shortestPath did).
+// Validate the materialization through the path functions.
+// ============================================================
+
+TEST_CASE("length(path) on plain varlen *N..N is exactly N",
+          "[ldbc][filter][path][varlen]") {
+    SKIP_IF_NO_DB();
+    // Endpoint-bound varlen: enumerates 7 paths of length 3 between
+    // SAMPLE_PATH_SRC_ID and SAMPLE_PATH_DEST_ID, every row should
+    // report length == 3.
+    auto q = "MATCH (src:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH (dst:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_DEST_ID) + "}) "
+             "MATCH path = (src)-[:KNOWS*" + std::to_string(ldbc::SAMPLE_PATH_LEN) +
+             ".." + std::to_string(ldbc::SAMPLE_PATH_LEN) + "]-(dst) "
+             "RETURN length(path) AS len";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() == (size_t)ldbc::SAMPLE_PATH_NUM_ALL_SHORTEST);
+    for (size_t i = 0; i < r.size(); i++) {
+        CHECK(r[i].int64_at(0) == ldbc::SAMPLE_PATH_LEN);
+    }
+}
+
+TEST_CASE("nodes(path) / relationships(path) on plain varlen size match",
+          "[ldbc][filter][path][varlen]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (src:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH (dst:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_DEST_ID) + "}) "
+             "MATCH path = (src)-[:KNOWS*" + std::to_string(ldbc::SAMPLE_PATH_LEN) +
+             ".." + std::to_string(ldbc::SAMPLE_PATH_LEN) + "]-(dst) "
+             "RETURN size(nodes(path)) AS nc, size(relationships(path)) AS rc";
+    auto r = qr->run(q.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() == (size_t)ldbc::SAMPLE_PATH_NUM_ALL_SHORTEST);
+    for (size_t i = 0; i < r.size(); i++) {
+        CHECK(r[i].int64_at(0) == ldbc::SAMPLE_PATH_LEN + 1);
+        CHECK(r[i].int64_at(1) == ldbc::SAMPLE_PATH_LEN);
+    }
+}
+
+TEST_CASE("length(path) on plain varlen ordered descending",
+          "[ldbc][filter][path][varlen]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (src:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH path = (src)-[:KNOWS*1..2]->(b:Person) "
+             "RETURN length(path) AS len ORDER BY len DESC LIMIT 3";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() <= 3);
+    if (r.size() >= 2) {
+        CHECK(r[0].int64_at(0) >= r[1].int64_at(0));
+    }
+    for (size_t i = 0; i < r.size(); i++) {
+        CHECK(r[i].int64_at(0) >= 1);
+        CHECK(r[i].int64_at(0) <= 2);
+    }
+}
+
+TEST_CASE("count by length(path) groups plain varlen rows",
+          "[ldbc][filter][path][varlen]") {
+    SKIP_IF_NO_DB();
+    // group-by aggregation over a path function — exercises that the
+    // path column survives the projection-then-Hash/StreamAgg pipeline.
+    auto q = "MATCH (src:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH path = (src)-[:KNOWS*1..2]->(b:Person) "
+             "RETURN length(path) AS len, count(*) AS c ORDER BY len";
+    auto r = qr->run(q.c_str(),
+        {qtest::ColType::INT64, qtest::ColType::INT64});
+    REQUIRE(r.size() >= 1);
+    int64_t prev = 0;
+    int64_t total = 0;
+    for (size_t i = 0; i < r.size(); i++) {
+        CHECK(r[i].int64_at(0) > prev);  // strictly increasing length
+        prev = r[i].int64_at(0);
+        total += r[i].int64_at(1);
+    }
+    CHECK(total >= 1);
+}
+
+TEST_CASE("count(path) on plain varlen counts rows",
+          "[ldbc][filter][path][varlen]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (src:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH path = (src)-[:KNOWS*1..2]->(b:Person) "
+             "RETURN count(path) AS c";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].int64_at(0) >= 1);
+}
+
+TEST_CASE("plain varlen path materialization with bidirectional edge",
+          "[ldbc][filter][path][varlen]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (src:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH (dst:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_DEST_ID) + "}) "
+             "MATCH path = (src)-[:KNOWS*" + std::to_string(ldbc::SAMPLE_PATH_LEN) +
+             ".." + std::to_string(ldbc::SAMPLE_PATH_LEN) + "]-(dst) "
+             "RETURN length(path) AS len";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() == (size_t)ldbc::SAMPLE_PATH_NUM_ALL_SHORTEST);
+    for (size_t i = 0; i < r.size(); i++) {
+        CHECK(r[i].int64_at(0) == ldbc::SAMPLE_PATH_LEN);
+    }
+}
+
+TEST_CASE("plain varlen path materialization is inert without path use",
+          "[ldbc][filter][path][varlen]") {
+    SKIP_IF_NO_DB();
+    // PathUseMode::None — the binder never flags path as used, so the
+    // converter must NOT emit the CLogicalVarlenPath wrap (its cost
+    // would otherwise show up against this baseline).
+    auto q = "MATCH (src:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH path = (src)-[:KNOWS*1..2]->(b:Person) "
+             "RETURN b.id AS bid LIMIT 1";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() == 1);
+}
+
+// ============================================================
 // Reduce tests (M3)
 // ============================================================
 


### PR DESCRIPTION
## Closes #253

`MATCH path = (a)-[:R*N..M]->(b) RETURN length(path)` (and `nodes(path)`, `relationships(path)`) was SIGABRT-ing because ORCA's PathJoin never projected a path column. ShortestPath / allShortestPaths got away with this because their physical op is leaf-like — there's no join above it that has to passthrough the column. Plain varlen sits below at least the R-join-B, so the materialization needs to flow through one or more join lowerings.

## Approach

A new ORCA op pair models the same column-lifecycle shape as `CLogicalShortestPath`, but inserted **below** the R-join-B so the path column rides each join's natural outer-input passthrough — no per-op patching needed.

- `CLogicalVarlenPath` / `CPhysicalVarlenPath` (+ `CXformImplementVarlenPath`): two-child shape (child[0] = path-join subtree, child[1] = `ScalarProjectList` that defines the synthetic path colref). Registered with `CXformFactory` and the GPDB cost model.
- Converter `MaybeWrapVarlenPath`: emits the wrap right after the A→R path-join when the binder flagged the path variable as used (Phase 1's `PathUseMode != None`).
- Planner `pTransformEopPhysicalVarlenPath`: emits no own physical op — signals via `pending_path_col_ref_` and lets the inner `PhysicalVarlenAdjIdxJoin` append `path_col_ref` to its output schema. Re-arms `preserve_explicit_physical_output_layout` so the inner's layout survives `pTraverseTransformPhysicalPlan`'s wrapper.
- Runtime `PhysicalVarlenAdjIdxJoin::writePathColumnForRow`: emits a node-edge-interleaved `LIST(UBIGINT)` per row (`[src, e0, n0, e1, n1, …, e_{k-1}, dst]`) — the layout `path_length` / `path_nodes` / `path_rels` already expect.

The path colref uses **`LIST(UBIGINT)` MD** instead of the `m_mdid_turbolynx_path` that ShortestPath uses. The collect()-style col passthrough is well-tested for standard `LIST`; the PATH MD is only wired for ShortestPath's leaf-like shape.

## Commits

- **Phase 2a** (`3271170cc`): standalone ORCA op pair + xform + factory/cost registration. No callers yet.
- **Phase 2b** (`8d532dff1`): converter wrap + planner lowering + runtime LIST materialization + 7 new tests.
- **Cleanup** (`be46e9a7e`): drop dead-weight (`path_use_mode` propagation never read at runtime; `m_pnameAlias` field never accessed).

## Test plan

- [x] 7 new `[ldbc][filter][path][varlen]` cases — endpoint-bound exact length, `nodes`/`relationships` size match, ORDER BY, count, group-by-length, bidirectional, `PathUseMode::None` baseline (wrap inert).
- [x] All 14 `[ldbc][filter][path]` tests pass (existing + new) against `test/data/ldbc-mini`.
- [x] Local `ctest` shows no new regressions; only pre-existing `list_contains_nested` and `reduce with collect result` fail (unrelated, fail on `main` too).
- [ ] CI

## Known follow-up (not fixed here)

Two query shapes still hit the projection-lowering type assert because Filter / WITH ops don't carry the LIST through their col map:

- `WHERE length(path) > N` — Filter creates a DICTIONARY view that loses LIST type.
- `WITH length(path) AS L RETURN L` — intermediate projection drops the path col.

Both have the same root cause (intermediate op not passing through `LIST` type cleanly). Will file as separate issues so this PR stays scoped to the SIGABRT closure.