### PR TITLE
fix(#253): preserve child layout through Filter for varlen path

### DIFF
--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -6469,6 +6469,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopPhysicalFilter(
     pBuildSchemaFlowGraphForUnaryOperator(tmp_schema);
 
     // we need further projection if we don't need filter column anymore
+    bool added_follow_projection = false;
     if (output_cols->Size() != outer_cols->Size()) {
         duckdb::Schema output_schema;
         output_schema.setStoredTypes(output_types);
@@ -6487,7 +6488,18 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopPhysicalFilter(
             result->push_back(op);
 
             pBuildSchemaFlowGraphForUnaryOperator(output_schema);
+            added_follow_projection = true;
         }
+    }
+
+    // Filter without a follow-up projection preserves the child's chunk
+    // layout (it only selects rows). Re-arm the explicit-layout flag so
+    // pTraverseTransformPhysicalPlan's wrapper doesn't reset
+    // physical_plan_output_colrefs to Filter's PcrsRequired — which
+    // would shrink it past the actual chunk width and mis-align
+    // downstream BoundReferenceExpression indices.
+    if (!added_follow_projection && !physical_plan_output_colrefs.empty()) {
+        preserve_explicit_physical_output_layout = true;
     }
 
     return result;

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -652,6 +652,56 @@ TEST_CASE("plain varlen path materialization with bidirectional edge",
     }
 }
 
+TEST_CASE("WHERE length(path) filter on plain varlen",
+          "[ldbc][filter][path][varlen]") {
+    SKIP_IF_NO_DB();
+    // Filter sits directly above CPhysicalVarlenPath and inherits the
+    // path-bearing chunk layout. The Filter lowering must not let the
+    // post-op wrapper shrink physical_plan_output_colrefs to its own
+    // PcrsRequired or the projection above would mis-resolve path's
+    // chunk position.
+    auto q = "MATCH (src:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH path = (src)-[:KNOWS*1..2]->(b:Person) "
+             "WHERE length(path) > 1 "
+             "RETURN length(path) AS len LIMIT 5";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() >= 1);
+    for (size_t i = 0; i < r.size(); i++) {
+        CHECK(r[i].int64_at(0) > 1);
+    }
+}
+
+TEST_CASE("WHERE length(path) = N matches exactly N-hop rows",
+          "[ldbc][filter][path][varlen]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (src:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH path = (src)-[:KNOWS*1..2]->(b:Person) "
+             "WHERE length(path) = 1 "
+             "RETURN length(path) AS len LIMIT 5";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() >= 1);
+    for (size_t i = 0; i < r.size(); i++) {
+        CHECK(r[i].int64_at(0) == 1);
+    }
+}
+
+TEST_CASE("WHERE size(nodes(path)) > N filters path by node count",
+          "[ldbc][filter][path][varlen]") {
+    SKIP_IF_NO_DB();
+    // size(nodes(path)) exercises the same Filter passthrough as
+    // length(path) > N, but with a list-of-list nesting.
+    auto q = "MATCH (src:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH path = (src)-[:KNOWS*1..2]->(b:Person) "
+             "WHERE size(nodes(path)) > 2 "
+             "RETURN length(path) AS len LIMIT 5";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() >= 1);
+    for (size_t i = 0; i < r.size(); i++) {
+        // size(nodes(path)) > 2 means len + 1 > 2, i.e. len >= 2
+        CHECK(r[i].int64_at(0) >= 2);
+    }
+}
+
 TEST_CASE("plain varlen path materialization is inert without path use",
           "[ldbc][filter][path][varlen]") {
     SKIP_IF_NO_DB();


### PR DESCRIPTION
## Follow-up to #256

Stacks on \`fix-issue253-varlen-length-path\` (PR #256). One of the two known
follow-ups from #256:

> \`WHERE length(path) > N\` — Filter creates a DICTIONARY view that loses LIST type.

## Root cause

Filter normally inherits its child's chunk layout (it only selects rows, doesn't reshape columns). The post-op wrapper in \`pTraverseTransformPhysicalPlan\` then resets \`physical_plan_output_colrefs\` to Filter's \`Prpp.PcrsRequired\` — which can be narrower than the actual chunk.

Concretely on \`MATCH path = (a)-[:R*]->(b) WHERE length(path) > N RETURN length(path) ...\`:
- \`CPhysicalVarlenPath\` (no own physical op) leaves child chunk \`[src, edge_tid, path]\` (3 cols) and tracks them in \`physical_plan_output_colrefs\`.
- Filter \`length(path) > N\` requires only \`{path, edge_tid}\` (2 cols).
- After Filter lowering, the wrapper shrinks tracking to 2 cols.
- The \`ComputeScalarColumnar\` above computes its \`BoundReferenceExpression\` index against the shrunk tracking; \`length(path)\` resolves to col 0 (was 2 in the actual chunk) and the runtime sees a \`UBIGINT\` vector where \`path_length\` expected \`UBIGINT[]\` → \`ExprVerifyMismatch\` assert.

## Fix

When Filter doesn't append a follow-up projection (i.e. \`output_cols.size == outer_cols.size\`), its output chunk IS the child's chunk. Re-arm \`preserve_explicit_physical_output_layout\` at end of Filter lowering so the wrapper keeps the child-set tracking. Same pattern \`pTransformEopPhysicalVarlenPath\` uses for the same reason.

12 lines in \`planner_physical.cpp\`.

## Test plan

- [x] 3 new \`[ldbc][filter][path][varlen]\` cases:
  - \`WHERE length(path) > N\`
  - \`WHERE length(path) = N\` (exact match)
  - \`WHERE size(nodes(path)) > N\` (nested list size predicate)
- [x] All 10 \`[ldbc][filter][path][varlen]\` cases pass (PR #256's 7 + 3 new).
- [x] \`ctest\` shows no new regressions (only pre-existing \`list_contains_nested\` / \`reduce with collect result\` fail, same as on \`main\`).
- [ ] CI

## Remaining follow-up

\`WITH length(path) AS L RETURN L\` (ASan crash on intermediate projection) — separate root cause, separate PR.