### PR TITLE
fix(#253): see-through shadowed path meta after WITH

### DIFF
--- a/src/include/binder/bind_context.hpp
+++ b/src/include/binder/bind_context.hpp
@@ -96,6 +96,12 @@ public:
     PathMeta GetPathMeta(const string& name) const {
         auto it = path_meta_.find(name);
         if (it != path_meta_.end()) return it->second;
+        // A WITH that drops the path from scope moves its meta to
+        // shadowed_path_meta_. The post-bind sync still needs the
+        // accumulated use_mode so the converter knows to emit the
+        // path-materialization wrap.
+        auto sit = shadowed_path_meta_.find(name);
+        if (sit != shadowed_path_meta_.end()) return sit->second;
         return outer_ ? outer_->GetPathMeta(name) : PathMeta{};
     }
     // Mark a *locally-bound* path as needing node/edge list projection. We

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -715,6 +715,54 @@ TEST_CASE("plain varlen path materialization is inert without path use",
     REQUIRE(r.size() == 1);
 }
 
+TEST_CASE("WITH length(path) AS L survives projection scope narrowing",
+          "[ldbc][filter][path][varlen]") {
+    SKIP_IF_NO_DB();
+    // BindContext::ResetToProjectedScope moves the path's meta into
+    // shadowed_path_meta_ when the WITH drops it from the carried-forward
+    // names. The post-bind sync must still pick the use_mode up so the
+    // converter emits the CLogicalVarlenPath wrap and the schema carries
+    // path through the WITH-defined projection.
+    auto q = "MATCH (src:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH path = (src)-[:KNOWS*1..2]->(b:Person) "
+             "WITH length(path) AS L RETURN L LIMIT 5";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() >= 1);
+    for (size_t i = 0; i < r.size(); i++) {
+        CHECK((r[i].int64_at(0) == 1 || r[i].int64_at(0) == 2));
+    }
+}
+
+TEST_CASE("WITH nodes(path) AS ns survives projection scope narrowing",
+          "[ldbc][filter][path][varlen]") {
+    SKIP_IF_NO_DB();
+    auto q = "MATCH (src:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH path = (src)-[:KNOWS*1..2]->(b:Person) "
+             "WITH nodes(path) AS ns RETURN size(ns) AS sz LIMIT 5";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() >= 1);
+    for (size_t i = 0; i < r.size(); i++) {
+        // size(nodes(path)) == hop + 1 ∈ {2, 3}
+        CHECK((r[i].int64_at(0) == 2 || r[i].int64_at(0) == 3));
+    }
+}
+
+TEST_CASE("WITH length(path) AS L then WHERE on L",
+          "[ldbc][filter][path][varlen]") {
+    SKIP_IF_NO_DB();
+    // The WITH-WHERE filters on L (already a scalar), so the second
+    // query part's Filter operates on a normal int column — exercises
+    // that the wrap's runtime cost only materialized for the first part.
+    auto q = "MATCH (src:Person {id: " + std::to_string(ldbc::SAMPLE_PATH_SRC_ID) + "}) "
+             "MATCH path = (src)-[:KNOWS*1..2]->(b:Person) "
+             "WITH length(path) AS L WHERE L > 1 RETURN L LIMIT 5";
+    auto r = qr->run(q.c_str(), {qtest::ColType::INT64});
+    REQUIRE(r.size() >= 1);
+    for (size_t i = 0; i < r.size(); i++) {
+        CHECK(r[i].int64_at(0) > 1);
+    }
+}
+
 // ============================================================
 // Reduce tests (M3)
 // ============================================================


### PR DESCRIPTION
## Follow-up to #257

Stacks on \`fix-issue253-filter-list-passthrough\` (PR #257). Closes the second known follow-up from #256:

> \`WITH length(path) AS L RETURN L\` — ASan crash on intermediate projection

## Root cause

The crash mode was misleading: ASan reported a heap-use-after-free deep inside \`gpos_exec\` cleanup (a pre-existing destruction-order bug in \`CAutoTaskProxy::~CAutoTaskProxy\` that surfaces whenever \`std::exception\` unwinds through it). The actual error was \`\"Variable 'path' is not defined\"\` thrown from the converter's scalar lookup for the WITH's \`length(path)\` argument.

The path's use_mode never reached \`BoundQueryGraph\`, so the converter skipped the \`CLogicalVarlenPath\` wrap, never appended \`path\` to the schema, and the WITH-side projection failed to resolve the variable.

\`BindContext::ResetToProjectedScope\` (called at the end of \`BindQueryPart\` for a \`WITH\`) moves any path whose name isn't in the carry-forward alias set from \`path_meta_\` to \`shadowed_path_meta_\`. The post-bind sync that copies the accumulated \`use_mode\` back into the \`BoundQueryGraph\` runs after \`BindSingleQuery\` has finished binding every part. By then, the path's meta is in \`shadowed_path_meta_\`, and \`GetPathMeta\` only looked at \`path_meta_\` — so it returned the default \`PathMeta{}\` with \`use_mode = None\`.

## Fix

Make \`GetPathMeta\` fall back to \`shadowed_path_meta_\` after missing in \`path_meta_\`. The semantic is: a path's accumulated use_mode is still the right answer even after the scope dropped its name from the active set — \`MarkPathUseMode\` only ever widens, never narrows, so the shadowed entry is the final word for that path's lifetime.

6 lines in \`bind_context.hpp\`.

## Test plan

- [x] 3 new \`[ldbc][filter][path][varlen]\` cases:
  - \`WITH length(path) AS L RETURN L\`
  - \`WITH nodes(path) AS ns RETURN size(ns)\`
  - \`WITH length(path) AS L WHERE L > 1 RETURN L\` (WITH-WHERE on derived L)
- [x] All 13 \`[ldbc][filter][path][varlen]\` cases pass.
- [x] \`[ldbc][filter]\` regression run: only pre-existing \`reduce with collect result\` fail (same on \`main\`).
- [x] \`ctest\` shows the same pre-existing fails (\`list_contains_nested\`, \`turbolynx_all\`); no new regressions.
- [ ] CI

## Out of scope (latent bug worth flagging)

\`CAutoTaskProxy::~CAutoTaskProxy\` reads the freed \`CTask\` ptr inside the nested \`CAutoSuspendAbort\` whenever \`gpos_exec\` exits via \`std::exception\` unwinding. ASan flagged it consistently while debugging, masked by the actual error every time. Worth a separate PR (\`asa\` should be scoped to drop BEFORE \`DestroyAll\`), but unrelated to #253.