### PR TITLE
fix(#245): refresh CypherPipeline repr cache on AdvanceGroup

### DIFF
--- a/src/include/execution/cypher_pipeline.hpp
+++ b/src/include/execution/cypher_pipeline.hpp
@@ -23,6 +23,15 @@ public:
 	CypherPipeline(CypherPhysicalOperatorGroups& groups, idx_t pipeline_id = 0) : pipeline_id(pipeline_id) {
 		operator_groups = groups;
 		pipelineLength = groups.size();
+		RebuildReprOperators();
+	}
+
+	// repr_operators caches [source, op_1, …, op_{N-2}, sink] for the
+	// currently-selected child of every group. Must be rebuilt whenever
+	// AdvanceGroup() flips a multi-child group: a child can have a
+	// different operator count, so pipelineLength changes and the cache
+	// would otherwise be sized for the previous child.
+	void RebuildReprOperators() {
 		repr_operators = GetOperators();
 		repr_operators.insert(repr_operators.begin(), GetSource());
 		repr_operators.push_back(GetSink());
@@ -67,6 +76,7 @@ public:
 	bool AdvanceGroup() {
 		bool result = operator_groups.AdvanceGroup();
 		pipelineLength = operator_groups.size();
+		RebuildReprOperators();
 		return result;
 	}
 

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -1747,6 +1747,33 @@ TEST_CASE("bare pattern comprehension returns the projected friend list",
     CHECK(!r[0].is_null_at(0));
 }
 
+TEST_CASE("BOTH-direction pattern comprehension collects via UnionAll subplan",
+          "[ldbc][filter][listcomp][patterncomp]") {
+    SKIP_IF_NO_DB();
+    // The undirected pattern lowers the edge under a CPhysicalSerialUnionAll
+    // (forward + backward CSR), which makes the inner GbAgg(collect)'s
+    // pipeline have a different operator count per UnionAll arm. The
+    // CypherPipeline must rebuild its repr_operators cache when
+    // AdvanceGroup() flips the active child — otherwise GetReprSink reads
+    // past the cache and ASan flags a heap-buffer-overflow.
+    auto q = std::string("MATCH (p:Person {id: ") + sample_person_id_str() +
+             "}) RETURN [(p)-[:KNOWS]-(f) | f.firstName] AS friends";
+    auto r = qr->run(q.c_str(), {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(!r[0].is_null_at(0));
+}
+
+TEST_CASE("BOTH pattern comprehension with WHERE narrows by predicate",
+          "[ldbc][filter][listcomp][patterncomp]") {
+    SKIP_IF_NO_DB();
+    auto q = std::string("MATCH (p:Person {id: ") + sample_person_id_str() +
+             "}) RETURN [(p)-[:KNOWS]-(f) WHERE f.gender = 'female' | "
+             "f.firstName] AS girls";
+    auto r = qr->run(q.c_str(), {qtest::ColType::AUTO});
+    REQUIRE(r.size() == 1);
+    CHECK(!r[0].is_null_at(0));
+}
+
 // Cypher zero-length variable-length paths: `*0..N` must emit the
 // source vertex as the length-0 binding whenever the destination
 // pattern accepts it. Pre-fix the loader gated zero-hop emission on a


### PR DESCRIPTION
## Closes #245

\`MATCH (p:Person {firstName: 'Hossein'}) RETURN [(p)-[:KNOWS]-(f) | f.firstName] AS friends\` — the BOTH-direction pattern comprehension deferred during #244 (PR-1.2) — crashed with an ASan \`heap-buffer-overflow\` inside \`CypherPipeline::GetReprSink\` (cypher_pipeline.hpp:52).

## Root cause

\`CPhysicalSerialUnionAll\` wraps the forward + backward CSR of a BOTH-direction edge, so the inner \`GbAgg(collect)\` over the union has a different operator count per UnionAll arm. The pipeline executor uses \`AdvanceGroup()\` to flip the active child of a grouped operator while iterating, and that advance updates \`CypherPipeline::pipelineLength\` to \`operator_groups.size()\`.

\`CypherPipeline\` also caches a flat operator vector \`repr_operators\` (\`[source, op_1, …, op_{N-2}, sink]\`) — populated once in the ctor. \`AdvanceGroup\` never refreshed it. After the advance, \`pipelineLength\` was \`N_new\` but \`repr_operators.size() == N_old\`. For the BOTH-edge plan \`N_new > N_old\`, so \`GetReprSink()\` (\`repr_operators[pipelineLength - 1]\`) read past the cache.

ORCA optimization succeeds; the bug is purely on the turbolynx execution side. The 32-byte buffer in the ASan report = 4 ptrs (initial pipelineLength), the OOB read is at byte offset 32 (i.e. element 4), so the post-advance pipelineLength was 5.

## Fix

Hoist the cache fill into \`RebuildReprOperators()\` and call it from both the ctor and \`AdvanceGroup()\` so the cache stays in sync with the active group selection.

10 lines in \`cypher_pipeline.hpp\`.

## Test plan

- [x] 2 new \`[ldbc][filter][listcomp][patterncomp]\` cases:
  - \`[(p)-[:KNOWS]-(f) | f.firstName]\` — the original #245 repro.
  - \`[(p)-[:KNOWS]-(f) WHERE f.gender = 'female' | f.firstName]\` — covers WHERE under the same UnionAll shape.
- [x] All 10 \`[patterncomp]\` cases pass.
- [x] \`[ldbc][filter]\` / \`[ldbc][traversal]\` / \`[ldbc][ic]\` regression: pre-existing \`reduce with collect result\` and IC3 fails remain (same on \`main\`); no new regressions.
- [ ] CI

## Closes #184?

Probably. The known shape gaps for general pattern comprehension are covered now:

| Shape | Status |
|---|---|
| OUT / IN | OK (#244) |
| WHERE / label-typed end | OK (#244) |
| Varlen quantifier | OK (#246) |
| Path binding + length/nodes/relationships | OK (#247, #248, #253) |
| BOTH | this PR |

Leaving #184 close to maintainers' call.