### PR TITLE
ci(#252, #124): add ASan + Debug sanitize job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -297,12 +297,18 @@ jobs:
       - name: Build (sanitize)
         run: cmake --build build-sanitize
 
+      # continue-on-error on every test step so a fail in one category
+      # doesn't cascade-skip the others via the default if: success().
+      # Combined with the job-level continue-on-error, the suite gives
+      # per-category attribution without taking down the rest of the
+      # run on a known pre-existing failure.
       - name: Run unit tests (ctest, ASan)
         # halt_on_error stops on first ASan finding. detect_leaks=0
         # for now — pre-existing leaks in ORCA's CMemoryPool teardown
         # need a suppressions file before LSan can be useful; promoting
         # to detect_leaks=1 is #124's follow-up phase.
         working-directory: build-sanitize
+        continue-on-error: true
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ctest --output-on-failure
@@ -316,56 +322,62 @@ jobs:
       - name: Load LDBC SF0.003 mini fixture (sanitize)
         run: bash scripts/load-ldbc-mini.sh build-sanitize /tmp/ldbc-mini-ws-asan
 
-      # Mirror build-test's category-by-category query runs so any ASan
-      # finding is attributed to a specific category. continue-on-error
-      # at the job level keeps known pre-existing fails off the blocking
-      # path; individual category failures still surface in the job log.
       - name: Run [types] under ASan
+        continue-on-error: true
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ./build-sanitize/test/query/query_test "[types]" --types-path /tmp/types-mini-ws-asan
 
       - name: Run TPC-H [tpch] under ASan
+        continue-on-error: true
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ./build-sanitize/test/query/query_test "[tpch]~[stress]" --tpch-path /tmp/tpch-mini-ws-asan
 
       - name: Run LDBC [count] under ASan
+        continue-on-error: true
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ./build-sanitize/test/query/query_test "[ldbc][count]" --ldbc-path /tmp/ldbc-mini-ws-asan
 
       - name: Run LDBC [traversal] under ASan
+        continue-on-error: true
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ./build-sanitize/test/query/query_test "[ldbc][traversal]" --ldbc-path /tmp/ldbc-mini-ws-asan
 
       - name: Run LDBC [is] under ASan
+        continue-on-error: true
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ./build-sanitize/test/query/query_test "[ldbc][is]" --ldbc-path /tmp/ldbc-mini-ws-asan
 
       - name: Run LDBC [ic] under ASan
+        continue-on-error: true
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ./build-sanitize/test/query/query_test "[ldbc][ic]" --ldbc-path /tmp/ldbc-mini-ws-asan
 
       - name: Run LDBC [robustness] under ASan
+        continue-on-error: true
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ./build-sanitize/test/query/query_test "[ldbc][robustness]" --ldbc-path /tmp/ldbc-mini-ws-asan
 
       - name: Run LDBC [filter] under ASan
+        continue-on-error: true
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ./build-sanitize/test/query/query_test "[ldbc][filter]" --ldbc-path /tmp/ldbc-mini-ws-asan
 
       - name: Run LDBC [func] under ASan
+        continue-on-error: true
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ./build-sanitize/test/query/query_test "[ldbc][func]" --ldbc-path /tmp/ldbc-mini-ws-asan
 
       - name: Run LDBC [crud] under ASan
+        continue-on-error: true
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ./build-sanitize/test/query/query_test "[ldbc][crud]" --ldbc-path /tmp/ldbc-mini-ws-asan

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -222,3 +222,150 @@ jobs:
 
       - name: Run oss-supply-chain pytest
         run: pytest applications/oss-supply-chain/tests -v
+
+  build-sanitize:
+    # ASan + Debug variant that catches the bug class the portable CI
+    # job above can't see: assertions compiled out by Release
+    # (`!function.name.empty()` and similar) and memory errors masked by
+    # the optimizer. continue-on-error stays on until known pre-existing
+    # ASan-only failures are triaged off the floor — flipping to
+    # blocking is a follow-up.
+    name: Build & Sanitize (ASan, ubuntu-latest)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Linux build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake ninja-build build-essential \
+            autoconf automake libtool pkg-config \
+            libnuma-dev
+
+      - name: Install Python build deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pybind11 wheel pytest
+
+      - name: Cache third_party builds (sanitize)
+        uses: actions/cache@v4
+        with:
+          path: |
+            build-sanitize/_deps
+            build-sanitize/oneTBB-src
+            build-sanitize/gp-xerces-src
+            build-sanitize/gp-xerces-build
+            build-sanitize/gp-xerces-install
+            build-sanitize/hwloc-src
+            build-sanitize/hwloc-build
+            build-sanitize/hwloc-install
+          key: ubuntu-latest-thirdparty-sanitize-${{ hashFiles('CMakeLists.txt', 'cmake/**', 'third_party/**/CMakeLists.txt') }}
+          restore-keys: |
+            ubuntu-latest-thirdparty-sanitize-
+
+      - name: Configure CMake (Debug + ASan)
+        # Debug enables D_ASSERT so binder/planner invariant trips
+        # surface here. ENABLE_SANITIZER=ON adds -fsanitize=address.
+        # ENABLE_UBSAN intentionally off — ORCA has well-known
+        # pre-existing UB patterns (see CMakeLists.txt L158-163) that
+        # would dominate the signal.
+        # ENABLE_TCMALLOC=OFF and TURBOLYNX_PORTABLE_DISK_IO=ON match
+        # the portable job; TCMalloc is incompatible with ASan.
+        run: |
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DBUILD_PYTHON=OFF \
+            -DENABLE_SANITIZER=ON \
+            -DTURBOLYNX_PORTABLE_DISK_IO=ON \
+            -DENABLE_TCMALLOC=OFF \
+            -DBUILD_UNITTESTS=ON \
+            -DTBB_TEST=OFF \
+            -DTBB_STRICT=OFF \
+            -DTURBOLYNX_LDBC_FIXTURE_MINI=ON \
+            -DTURBOLYNX_TPCH_FIXTURE_MINI=ON \
+            -DPython3_EXECUTABLE="$(which python)" \
+            -B build-sanitize
+
+      - name: Build (sanitize)
+        run: cmake --build build-sanitize
+
+      - name: Run unit tests (ctest, ASan)
+        # halt_on_error stops on first ASan finding. detect_leaks=0
+        # for now — pre-existing leaks in ORCA's CMemoryPool teardown
+        # need a suppressions file before LSan can be useful; promoting
+        # to detect_leaks=1 is #124's follow-up phase.
+        working-directory: build-sanitize
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
+        run: ctest --output-on-failure
+
+      - name: Load TPC-H SF0.01 mini fixture (sanitize)
+        run: bash scripts/load-tpch-mini.sh build-sanitize /tmp/tpch-mini-ws-asan
+
+      - name: Load types-mini fixture (sanitize)
+        run: bash scripts/load-types-mini.sh build-sanitize /tmp/types-mini-ws-asan
+
+      - name: Load LDBC SF0.003 mini fixture (sanitize)
+        run: bash scripts/load-ldbc-mini.sh build-sanitize /tmp/ldbc-mini-ws-asan
+
+      # Mirror build-test's category-by-category query runs so any ASan
+      # finding is attributed to a specific category. continue-on-error
+      # at the job level keeps known pre-existing fails off the blocking
+      # path; individual category failures still surface in the job log.
+      - name: Run [types] under ASan
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
+        run: ./build-sanitize/test/query/query_test "[types]" --types-path /tmp/types-mini-ws-asan
+
+      - name: Run TPC-H [tpch] under ASan
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
+        run: ./build-sanitize/test/query/query_test "[tpch]~[stress]" --tpch-path /tmp/tpch-mini-ws-asan
+
+      - name: Run LDBC [count] under ASan
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
+        run: ./build-sanitize/test/query/query_test "[ldbc][count]" --ldbc-path /tmp/ldbc-mini-ws-asan
+
+      - name: Run LDBC [traversal] under ASan
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
+        run: ./build-sanitize/test/query/query_test "[ldbc][traversal]" --ldbc-path /tmp/ldbc-mini-ws-asan
+
+      - name: Run LDBC [is] under ASan
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
+        run: ./build-sanitize/test/query/query_test "[ldbc][is]" --ldbc-path /tmp/ldbc-mini-ws-asan
+
+      - name: Run LDBC [ic] under ASan
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
+        run: ./build-sanitize/test/query/query_test "[ldbc][ic]" --ldbc-path /tmp/ldbc-mini-ws-asan
+
+      - name: Run LDBC [robustness] under ASan
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
+        run: ./build-sanitize/test/query/query_test "[ldbc][robustness]" --ldbc-path /tmp/ldbc-mini-ws-asan
+
+      - name: Run LDBC [filter] under ASan
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
+        run: ./build-sanitize/test/query/query_test "[ldbc][filter]" --ldbc-path /tmp/ldbc-mini-ws-asan
+
+      - name: Run LDBC [func] under ASan
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
+        run: ./build-sanitize/test/query/query_test "[ldbc][func]" --ldbc-path /tmp/ldbc-mini-ws-asan
+
+      - name: Run LDBC [crud] under ASan
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
+        run: ./build-sanitize/test/query/query_test "[ldbc][crud]" --ldbc-path /tmp/ldbc-mini-ws-asan


### PR DESCRIPTION
## Closes #252. Partial #124.

The existing CI matrix builds Release on Ubuntu + macOS. \`D_ASSERT\` and ASan instrumentation — the things that catch assertion trips and memory errors — both compile out at Release, so an entire class of bugs that reproduces 100% in local \`build-asan\` never trips on CI. Recent PRs (#249, the #253 path-materialization series, #245) all hit the same local-red / CI-green disparity.

## What's added

A second job, \`Build & Sanitize (ASan, ubuntu-latest)\`, that:

- Configures with \`-DCMAKE_BUILD_TYPE=Debug -DENABLE_SANITIZER=ON\` — matches the local \`build-asan\` recipe.
- Mirrors \`build-test\`'s category-by-category query suite (\`[types]\`, \`[tpch]~[stress]\`, and the eight \`[ldbc]\` categories) so an ASan finding is attributed to a specific category.
- \`continue-on-error: true\` at the job level so the two pre-existing ASan-only failures (\`list_contains_nested\`, \`reduce with collect result\`) and any others that surface don't block PRs. Individual category failures still show up in the job log.
- \`ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:detect_leaks=0\` — stops on the first ASan finding per step. LSan stays off until we land an \`asan_suppressions.txt\` for ORCA's CMemoryPool teardown leaks; that's #124's follow-up phase.
- Own third-party cache key (\`ubuntu-latest-thirdparty-sanitize-...\`) so Release and ASan toolchains don't fight over artifacts.

UBSan deliberately stays off — ORCA's pre-existing UB patterns (uninit bool reads, \`(T*)0x1\` GPOS_OFFSET hack, …) would otherwise dominate every finding. \`CMakeLists.txt\` L158-163 documents the same rationale for the L1 fuzz target.

## macOS coverage

Deferred. LSan isn't implemented on macOS (\"detect_leaks is not supported on this platform\"), and the Linux job catches the same assertion trips at lower runner cost. Worth revisiting if a macOS-specific ASan finding comes up.

## What this PR doesn't do

- Doesn't enable LSan (#124's other ask). That needs a suppressions file for known third-party leaks first.
- Doesn't promote the job to blocking. Stays \`continue-on-error\` until the pre-existing fails are triaged off the floor.

## Test plan

- [x] yaml validates (\`yaml.safe_load\`); 21 steps in the new job.
- [ ] CI run on this PR — verifies the recipe configures and builds, and surfaces the two known pre-existing fails (a useful smoke that \`continue-on-error\` is doing its job).