### PR TITLE
test: set name on BoundFunctionExpression unit test builds

### DIFF
--- a/test/common/test_list_contains_nested.cpp
+++ b/test/common/test_list_contains_nested.cpp
@@ -218,7 +218,12 @@ TEST_CASE("list_contains nested ScalarFunction honours dict selection on value",
     vector<unique_ptr<Expression>> children;
     children.push_back(make_unique<BoundReferenceExpression>(list_type, 0));
     children.push_back(make_unique<BoundReferenceExpression>(struct_type, 1));
+    // ListContainsFun::GetFunction returns a ScalarFunction without a name
+    // (the name is normally set when registering aliases via AddFunction).
+    // BoundFunctionExpression's ctor asserts !function.name.empty(), so set
+    // one of the registered aliases explicitly here.
     auto fn = ListContainsFun::GetFunction();
+    fn.name = "list_contains";
     fn.arguments = {list_type, struct_type};
     fn.return_type = LogicalType::BOOLEAN;
     auto expr = make_unique<BoundFunctionExpression>(LogicalType::BOOLEAN, fn,


### PR DESCRIPTION
## What

Surfaced by the new ASan CI lane (#252). \`list_contains nested ScalarFunction honours dict selection on value\` (\`test/common/test_list_contains_nested.cpp:177\`) trips \`BoundFunctionExpression\`'s \`D_ASSERT(!function.name.empty())\` in Debug+ASan builds. Affects all 3 unit-test ctest groups (\`turbolynx_common\` / \`turbolynx_all\` / \`turbolynx_smoke\` shared the same case).

## Root cause

\`ListContainsFun::GetFunction()\` uses \`ScalarFunction\`'s **unnamed** constructor. The name is normally written in by \`BuiltinFunctions::AddFunction({\"list_contains\", \"array_contains\", \"list_has\", \"array_has\"}, GetFunction())\` when the function is registered — so direct callers from test code that skip the registry end up with an empty \`name\`. \`BoundFunctionExpression\`'s ctor then asserts.

## Fix

Set \`fn.name = \"list_contains\"\` alongside the existing \`fn.arguments\` / \`fn.return_type\` adjustments. No production code touched — every other path goes through \`AddFunction\` which already sets the name.

5 lines in the test file.

## Test plan

- [x] \`./test/unittest \"[issue-47]\"\` 3/3 pass.
- [x] \`ctest --output-on-failure\` on \`build-asan\`: 27/27 pass (was 26/27 on \`main\` because of this assert).
- [ ] CI Build & Sanitize lane shows the case as pass.

## Out of scope

\`test_capi_prepared_statement.cpp:139, 174\` and the eight \`test_smoke_cli.cpp\` cases also surfaced on the Linux ASan lane but do **not** repro under local macOS ASan — Linux-specific. Tracked as separate follow-ups.