### PR TITLE
fix: bump ORCA worker stack to 8 MB under sanitizers

### DIFF
--- a/src/include/optimizer/orca/gporca/libgpos/gpos/task/CWorkerPoolManager.h
+++ b/src/include/optimizer/orca/gporca/libgpos/gpos/task/CWorkerPoolManager.h
@@ -23,7 +23,19 @@
 #include "gpos/task/CWorker.h"
 
 #define GPOS_WORKERPOOL_HT_SIZE (1024)		 // number of buckets in hash tables
+
+// ORCA's stack-check pre-empts deep recursion against this budget.
+// AddressSanitizer (esp. gcc's) inflates every frame several-fold via
+// shadow-memory bookkeeping, so the 500 KB Release budget trips on
+// otherwise trivial queries (`UNWIND [1,2] AS x …`, `MATCH (n:Person)
+// RETURN count(n)` — both major=1 minor=4 "Out of stack space"). Give
+// ASan builds the standard 8 MB Linux thread budget; Release stays
+// unchanged.
+#ifdef ENABLE_SANITIZER_FLAG
+#define GPOS_WORKER_STACK_SIZE (8 * 1024 * 1024)  // 8 MB under ASan
+#else
 #define GPOS_WORKER_STACK_SIZE (500 * 1024)	 // max worker stack size
+#endif
 
 namespace gpos
 {


### PR DESCRIPTION
## What

The new ASan CI lane (#252) surfaced ORCA \`major=1 minor=4 \"Out of stack space\"\` failures on basic queries:

- \`RETURN '\$value' AS literal, \$value AS actual\` (test_capi_prepared_statement.cpp:139)
- \`UNWIND [1, 2] AS x RETURN x ORDER BY x\` (test_capi_prepared_statement.cpp:174)
- \`MATCH (n:Person) RETURN count(n) AS cnt\` (the 8 test_smoke_cli.cpp cases)

## Root cause

\`GPOS_WORKER_STACK_SIZE\` was hard-coded at 500 KB. AddressSanitizer (gcc's flavour especially) inflates every stack frame multifold for its shadow-memory bookkeeping, so the same ORCA recursion that lives comfortably in 500 KB at Release overflows under ASan. Confirmed by reproducing inside the project's Ubuntu repro container — same \"Out of stack space\" before the bump, gone after.

## Fix

Bump \`GPOS_WORKER_STACK_SIZE\` to 8 MB (Linux's default thread stack budget) **only when \`ENABLE_SANITIZER_FLAG\` is set**. Release builds keep the original 500 KB.

\`ENABLE_SANITIZER_FLAG\` is defined in \`CMakeLists.txt\` L148-151 whenever \`ENABLE_SANITIZER=ON\` or \`ENABLE_UBSAN=ON\` is set with \`CMAKE_BUILD_TYPE=Debug\` — exactly the configuration the new \`build-sanitize\` CI job uses.

12 lines in \`CWorkerPoolManager.h\`.

## Test plan

Reproduced inside \`turbolynx-ubuntu-repro\` (the project's local Ubuntu container) with the same \`-DENABLE_SANITIZER=ON -DCMAKE_BUILD_TYPE=Debug\` recipe the CI lane uses:

- [x] \`build-ubuntu-asan/test/unittest \"[common][capi][prepared]\"\`: 5/5 pass (was 3/5).
- [x] \`build-ubuntu-asan/test/bulkload/bulkload_test \"[bulkload][smoke][cli]\"\`: 8/8 pass (was 0/8).
- [x] Release \`./build-portable/test/...\`: no change (the new branch is gated behind \`ENABLE_SANITIZER_FLAG\`).
- [ ] CI Build & Sanitize lane shows these tests as pass.

## Remaining ASan failures (out of scope)

\`turbolynx_common\` / \`turbolynx_all\` still flag the \`list_contains nested ScalarFunction honours dict selection on value\` case — that's the \`BoundFunctionExpression\` empty-name assert; PR #261 fixes it independently.

## Why 8 MB

8 MB is Linux's default per-thread stack budget (\`ulimit -s\`). It's also DuckDB's and PostgreSQL's worker default. Plenty of headroom for ORCA's deepest realistic recursion, even with gcc-ASan's overhead. Tested on the actual failing queries; no further \"Out of stack space\" trips.