### PR TITLE
fix: cap ExpressionExecutor recursion at 128 frames

### DIFF
--- a/src/execution/execution/expression_executor.cpp
+++ b/src/execution/execution/expression_executor.cpp
@@ -183,6 +183,22 @@ void ExpressionExecutor::Execute(const Expression &expr, ExpressionState *state,
 	if (count == 0) {
 		return;
 	}
+	// Each frame here adds a Vector + ExpressionState worth of stack
+	// state. Past ~200 levels (e.g. the [robustness][stress]
+	// `toString(toString(…))` probe) the inner frame's transient
+	// string_t buffer outlives its frame in shadow memory and ASan
+	// flags a stack-use-after-return at string_t::VerifyNull.
+	// Reject early so the rest of the evaluator never sees the
+	// pathologically deep tree.
+	if (expression_depth >= MAX_EXPRESSION_DEPTH) {
+		throw Exception("Expression nesting exceeds MAX_EXPRESSION_DEPTH (" +
+		                std::to_string(MAX_EXPRESSION_DEPTH) + ")");
+	}
+	++expression_depth;
+	struct DepthGuard {
+		ExpressionExecutor &exec;
+		~DepthGuard() { --exec.expression_depth; }
+	} guard{*this};
 	switch (expr.expression_class) {
 	case ExpressionClass::BOUND_BETWEEN:
 		Execute((const BoundBetweenExpression &)expr, state, sel, count, result);

--- a/src/include/execution/expression_executor.hpp
+++ b/src/include/execution/expression_executor.hpp
@@ -139,5 +139,17 @@ protected:
 private:
 	//! The states of the expression executor; this holds any intermediates and temporary states of expressions
 	vector<unique_ptr<ExpressionExecutorState>> states;
+
+	//! Hard cap on nested expression evaluation. Each Execute(Expression&)
+	//! frame keeps a Vector + ExpressionState on the stack; under ASan's
+	//! shadow bookkeeping a frame can also leave a short string_t buffer
+	//! addressable past return, so deep recursion exposes a UAF. 128 is
+	//! orders of magnitude more than any reasonable user expression
+	//! while still fitting comfortably in any stack budget we ship.
+	static constexpr idx_t MAX_EXPRESSION_DEPTH = 128;
+	//! Re-entrancy counter for the depth check. Incremented at the top
+	//! of every Execute(Expression&) call and decremented on the way
+	//! out (including on throw).
+	idx_t expression_depth = 0;
 };
 } // namespace duckdb


### PR DESCRIPTION
## What

\`MATCH (n:Person) RETURN toString(toString(...toString(n.id)...))\` (200 levels) was driving \`ExpressionExecutor::Execute(Expression&)\` deep enough that the inner frame's transient \`string_t\` buffer outlived its frame in ASan's stack shadow. ASan flagged a \`stack-use-after-return\` at \`string_t::VerifyNull\` (\`string_type.cpp:38\`), surfaced via \`Vector::Verify\` → \`ExpressionExecutor::Verify\` on the way back up.

[ldbc][robustness][stress] \`Deeply nested function calls\` (\`test_ldbc_robustness.cpp:703\`) reproduces it deterministically under the ASan CI lane introduced in #260.

## Root cause vs. fix

The 200-level call stack each carries a \`Vector\` + \`ExpressionState\` on it. Under ASan's shadow bookkeeping a frame is several times Release size, so an inner frame's transient short-string \`string_t\` (inline 12-byte buffer) is reachable past return when the next inner frame writes into the same shadow region. Tracking down which frame's buffer is the one ASan flags and extending its lifetime, or rewriting Execute into an iterative dispatch, are both broad changes and not what the test is trying to exercise.

The test's intent is graceful failure on pathologically deep input — it wraps the run in \`EXPECT_GRACEFUL_FAILURE\` which only needs the path to throw. Cap \`Execute(Expression&)\` re-entry at 128 frames and throw before the deep call chain gets built. A stack-allocated RAII \`DepthGuard\` resets the counter on every exit (including throw).

128 is two orders of magnitude past anything a real user expression hits, and ≤ 128 × ~1.5 KB-per-frame fits comfortably even inside the ORCA worker's 500 KB Release stack budget.

28 lines (\`expression_executor.cpp\` + \`expression_executor.hpp\`).

## Verification

- [x] Ubuntu Debug+ASan container: [ldbc][robustness][stress] \`Deeply nested function calls\` passes (\`EXPECT_GRACEFUL_FAILURE\` catches the depth-limit \`throw\`).
- [ ] CI Build & Sanitize lane shows the case as pass (will land green after this PR + the [robustness] step is flipped back to blocking in #263 follow-up).

## Out of scope

The two other ASan-only failures the promotion run surfaced (\`RETURN expression without alias\` suite-only SIGABRT in \`[ldbc][robustness]\`, \`SET new property creates schema-evolved node version\` SIGABRT in \`[ldbc][crud]\`) are unrelated lifecycle bugs in different subsystems. Tracked as separate follow-ups. \`#263\` keeps those two steps non-blocking until they land.