### PR TITLE
fix(binder): register every label of a multi-label CREATE (closes #238)

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -720,9 +720,6 @@ static void RegisterPropertyOnPartition(PartitionCatalogEntry *part_cat,
     part_cat->num_columns++;
 }
 
-// Canonical join of a sorted label set for partition naming. Mirrors what
-// LookupPartition + AddVertexPartition already do internally (label order is
-// not significant in Cypher), so `:A:B` and `:B:A` resolve to the same name.
 static string JoinLabelSet(const vector<string> &sorted_labels) {
     string out;
     for (size_t i = 0; i < sorted_labels.size(); i++) {
@@ -910,9 +907,7 @@ static idx_t BootstrapEdgePartition(
     return partition_cat->GetOid();
 }
 
-// Look up a vertex partition by EXACT label set; if absent, bootstrap one.
-// `labels_sorted` must be unique + sorted so the canonical partition name
-// matches across `:A:B` / `:B:A` / repeated-label inputs.
+// `labels_sorted` must be unique + sorted (canonical partition name).
 static idx_t ResolveOrBootstrapVertexPartition(
     ClientContext &context, GraphCatalogEntry *gcat, Catalog &catalog,
     const vector<string> &labels_sorted,
@@ -924,9 +919,6 @@ static idx_t ResolveOrBootstrapVertexPartition(
     if (existing) {
         idx_t part_oid = ((PartitionCatalogEntry *)existing)->GetOid();
         if (!props.empty()) {
-            // Register any property keys this CREATE introduces that aren't
-            // already on the existing partition; without this, MATCH on the
-            // new key would fail with "Unknown property".
             vector<string> key_names;
             vector<LogicalType> types;
             key_names.reserve(props.size());
@@ -1022,8 +1014,6 @@ unique_ptr<BoundCreateClause> Binder::BindCreateClause(const CreateClause& creat
         [&](const NodePattern &n, BoundCreateNodeInfo &info) -> uint64_t {
         auto &labels = n.GetLabels();
         if (!labels.empty()) {
-            // Canonicalise: dedup + sort so `:A:B`, `:B:A`, and `:A:B:A`
-            // all resolve to the same partition.
             vector<string> labels_sorted(labels.begin(), labels.end());
             std::sort(labels_sorted.begin(), labels_sorted.end());
             labels_sorted.erase(

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -720,14 +720,28 @@ static void RegisterPropertyOnPartition(PartitionCatalogEntry *part_cat,
     part_cat->num_columns++;
 }
 
+// Canonical join of a sorted label set for partition naming. Mirrors what
+// LookupPartition + AddVertexPartition already do internally (label order is
+// not significant in Cypher), so `:A:B` and `:B:A` resolve to the same name.
+static string JoinLabelSet(const vector<string> &sorted_labels) {
+    string out;
+    for (size_t i = 0; i < sorted_labels.size(); i++) {
+        if (i) out.push_back('_');
+        out += sorted_labels[i];
+    }
+    return out;
+}
+
 static idx_t BootstrapVertexPartition(
     ClientContext &context, GraphCatalogEntry *gcat, Catalog &catalog,
-    const string &label,
+    const vector<string> &labels_sorted,
     const vector<pair<string, Value>> &props) {
 
-    string partition_name = string(DEFAULT_VERTEX_PARTITION_PREFIX) + label;
+    string label_joined = JoinLabelSet(labels_sorted);
+    string partition_name =
+        string(DEFAULT_VERTEX_PARTITION_PREFIX) + label_joined;
     string property_schema_name =
-        string(DEFAULT_VERTEX_PROPERTYSCHEMA_PREFIX) + label;
+        string(DEFAULT_VERTEX_PROPERTYSCHEMA_PREFIX) + label_joined;
 
     // Build property key list — always include the internal _id slot first
     // (PropertyKeyID 0) so downstream ID lookups stay aligned with bulkload.
@@ -752,13 +766,13 @@ static idx_t BootstrapVertexPartition(
         (PropertySchemaCatalogEntry *)catalog.CreatePropertySchema(
             context, &propertyschema_info);
 
-    CreateIndexInfo idx_info(DEFAULT_SCHEMA, label + "_id",
+    CreateIndexInfo idx_info(DEFAULT_SCHEMA, label_joined + "_id",
                              IndexType::PHYSICAL_ID, partition_cat->GetOid(),
                              property_schema_cat->GetOid(), 0, {-1});
     auto *index_cat =
         (IndexCatalogEntry *)catalog.CreateIndex(context, &idx_info);
 
-    vector<string> labels_vec{label};
+    vector<string> labels_vec(labels_sorted);
     gcat->AddVertexPartition(context, new_pid, partition_cat->GetOid(),
                              labels_vec);
 
@@ -896,44 +910,43 @@ static idx_t BootstrapEdgePartition(
     return partition_cat->GetOid();
 }
 
-// Look up a vertex partition by single label; if absent, bootstrap one using
-// the property KV pairs from the CREATE pattern. Returns the partition OID.
+// Look up a vertex partition by EXACT label set; if absent, bootstrap one.
+// `labels_sorted` must be unique + sorted so the canonical partition name
+// matches across `:A:B` / `:B:A` / repeated-label inputs.
 static idx_t ResolveOrBootstrapVertexPartition(
     ClientContext &context, GraphCatalogEntry *gcat, Catalog &catalog,
-    const string &label, const vector<pair<string, Value>> &props) {
-    auto it = gcat->vertexlabel_map.find(label);
-    if (it != gcat->vertexlabel_map.end()) {
-        auto pit = gcat->label_to_partition_index.find(it->second);
-        if (pit != gcat->label_to_partition_index.end() && !pit->second.empty()) {
-            idx_t part_oid = pit->second.front();
+    const vector<string> &labels_sorted,
+    const vector<pair<string, Value>> &props) {
+    string partition_name =
+        string(DEFAULT_VERTEX_PARTITION_PREFIX) + JoinLabelSet(labels_sorted);
+    auto *existing = catalog.GetEntry(context, CatalogType::PARTITION_ENTRY,
+                                      DEFAULT_SCHEMA, partition_name, true);
+    if (existing) {
+        idx_t part_oid = ((PartitionCatalogEntry *)existing)->GetOid();
+        if (!props.empty()) {
             // Register any property keys this CREATE introduces that aren't
-            // already on the existing partition. Without this, the binder of
-            // subsequent MATCH queries cannot resolve `n.<new_prop>` and
-            // throws "Unknown property" — BootstrapVertexPartition does the
-            // same registration implicitly on the first-CREATE path; the
-            // existing-partition fast path never did.
-            if (!props.empty()) {
-                auto *part_cat = (PartitionCatalogEntry *)catalog.GetEntry(
-                    context, DEFAULT_SCHEMA, part_oid, true);
-                vector<string> key_names;
-                vector<LogicalType> types;
-                key_names.reserve(props.size());
-                types.reserve(props.size());
-                for (auto &kv : props) {
-                    key_names.push_back(kv.first);
-                    types.push_back(InferLogicalTypeFromValue(kv.second));
-                }
-                vector<PropertyKeyID> key_ids;
-                gcat->GetPropertyKeyIDs(context, key_names, types, key_ids);
-                for (idx_t i = 0; i < key_ids.size(); i++) {
-                    RegisterPropertyOnPartition(part_cat, key_names[i],
-                                                key_ids[i], types[i]);
-                }
+            // already on the existing partition; without this, MATCH on the
+            // new key would fail with "Unknown property".
+            vector<string> key_names;
+            vector<LogicalType> types;
+            key_names.reserve(props.size());
+            types.reserve(props.size());
+            for (auto &kv : props) {
+                key_names.push_back(kv.first);
+                types.push_back(InferLogicalTypeFromValue(kv.second));
             }
-            return part_oid;
+            vector<PropertyKeyID> key_ids;
+            gcat->GetPropertyKeyIDs(context, key_names, types, key_ids);
+            for (idx_t i = 0; i < key_ids.size(); i++) {
+                RegisterPropertyOnPartition(
+                    (PartitionCatalogEntry *)existing, key_names[i],
+                    key_ids[i], types[i]);
+            }
         }
+        return part_oid;
     }
-    return BootstrapVertexPartition(context, gcat, catalog, label, props);
+    return BootstrapVertexPartition(context, gcat, catalog, labels_sorted,
+                                    props);
 }
 
 // Look up an edge partition by (type, src_label, dst_label); if absent,
@@ -1009,9 +1022,16 @@ unique_ptr<BoundCreateClause> Binder::BindCreateClause(const CreateClause& creat
         [&](const NodePattern &n, BoundCreateNodeInfo &info) -> uint64_t {
         auto &labels = n.GetLabels();
         if (!labels.empty()) {
-            info.label = labels[0];
+            // Canonicalise: dedup + sort so `:A:B`, `:B:A`, and `:A:B:A`
+            // all resolve to the same partition.
+            vector<string> labels_sorted(labels.begin(), labels.end());
+            std::sort(labels_sorted.begin(), labels_sorted.end());
+            labels_sorted.erase(
+                std::unique(labels_sorted.begin(), labels_sorted.end()),
+                labels_sorted.end());
+            info.label = labels_sorted.front();
             idx_t part_oid = ResolveOrBootstrapVertexPartition(
-                *context_, gcat, catalog, info.label, info.properties);
+                *context_, gcat, catalog, labels_sorted, info.properties);
             info.partition_ids.push_back((uint64_t)part_oid);
             return (uint64_t)part_oid;
         }

--- a/test/query/test_ldbc_crud.cpp
+++ b/test/query/test_ldbc_crud.cpp
@@ -3565,7 +3565,6 @@ TEST_CASE("NOT EXISTS with inner WHERE", "[ldbc][crud][expr][exists]") {
     }
 }
 
-// Multi-label CREATE registers every label, not just the first.
 TEST_CASE("CREATE multi-label registers all labels",
           "[crud][bootstrap][empty][multi-label]") {
     ensure_singleton_disconnected();
@@ -3584,10 +3583,8 @@ TEST_CASE("CREATE multi-label registers all labels",
     CHECK(qr.count("MATCH (n:Person) RETURN count(n)") == 1);
     CHECK(qr.count("MATCH (n:Tag) RETURN count(n)") == 1);
     CHECK(qr.count("MATCH (n:Person:Tag) RETURN count(n)") == 1);
-    // Label order in MATCH must not affect matching.
     CHECK(qr.count("MATCH (n:Tag:Person) RETURN count(n)") == 1);
 
-    // Mixed single + multi-label: `:Person:Tag` lands in its own partition.
     qr.run("CREATE (n:Person {id:2, name:'B'})", {});
     qr.run("CREATE (n:Tag {id:3, name:'C'})", {});
     CHECK(qr.count("MATCH (n:Person) RETURN count(n)") == 2);

--- a/test/query/test_ldbc_crud.cpp
+++ b/test/query/test_ldbc_crud.cpp
@@ -3565,6 +3565,36 @@ TEST_CASE("NOT EXISTS with inner WHERE", "[ldbc][crud][expr][exists]") {
     }
 }
 
+// Multi-label CREATE registers every label, not just the first.
+TEST_CASE("CREATE multi-label registers all labels",
+          "[crud][bootstrap][empty][multi-label]") {
+    ensure_singleton_disconnected();
+    struct G { ~G() { ensure_singleton_reconnected(); } } _g;
+    char tmpl[] = "/tmp/tl_multi_lbl_XXXXXX";
+    REQUIRE(mkdtemp(tmpl) != nullptr);
+    std::string ws_path = tmpl;
+    struct W {
+        std::string p;
+        ~W() { if (!p.empty()) std::system(("rm -rf " + p).c_str()); }
+    } _w{ws_path};
+    qtest::QueryRunner qr(ws_path);
+
+    qr.run("CREATE (n:Person:Tag {id:1, name:'A'})", {});
+
+    CHECK(qr.count("MATCH (n:Person) RETURN count(n)") == 1);
+    CHECK(qr.count("MATCH (n:Tag) RETURN count(n)") == 1);
+    CHECK(qr.count("MATCH (n:Person:Tag) RETURN count(n)") == 1);
+    // Label order in MATCH must not affect matching.
+    CHECK(qr.count("MATCH (n:Tag:Person) RETURN count(n)") == 1);
+
+    // Mixed single + multi-label: `:Person:Tag` lands in its own partition.
+    qr.run("CREATE (n:Person {id:2, name:'B'})", {});
+    qr.run("CREATE (n:Tag {id:3, name:'C'})", {});
+    CHECK(qr.count("MATCH (n:Person) RETURN count(n)") == 2);
+    CHECK(qr.count("MATCH (n:Tag) RETURN count(n)") == 2);
+    CHECK(qr.count("MATCH (n:Person:Tag) RETURN count(n)") == 1);
+}
+
 // Neo4j-style schemaless first CREATE: a brand-new workspace with no
 // pre-loaded labels accepts CREATE/MATCH on previously unseen labels and
 // edge types, bootstrapping the partitions on the fly. This is the path a


### PR DESCRIPTION
## Closes #238

`CREATE (n:Person:Tag {id:1})` previously bound only `labels[0]` (`Person`) and silently dropped the rest. `MATCH (n:Tag)` afterwards threw \`Invalid Input Error: There is no vertex with the given label Tag\` even though the node was sitting on disk.

Reproducer (before this PR):
\`\`\`cypher
CREATE (n:Person:Tag {id:1, name:'A'});
MATCH (n:Person) RETURN count(n);   --> 1
MATCH (n:Tag)    RETURN count(n);   --> throws
\`\`\`

## Why the catalog didn't need to change

`GraphCatalogEntry::AddVertexPartition` already accepts a \`vector<string>\` of labels and indexes the partition under each label in \`label_to_partition_index\`. \`LookupPartition\` for vertices takes any subset of labels and returns the intersection. The fix sits entirely in the binder:

| Function | Change |
| --- | --- |
| `resolve_create_node` | Dedup + sort all labels into a canonical set instead of taking `labels[0]`. |
| `ResolveOrBootstrapVertexPartition` | Looks up by canonical partition name (`vps_<sorted_labels>`) so `:A:B`, `:B:A`, and `:A:B:A` resolve to the same partition while `:A` remains a distinct partition. |
| `BootstrapVertexPartition` | Takes the sorted label vector, names the partition / property schema / index by the canonical join, and forwards the full vector to `AddVertexPartition`. |

## Side effects considered

- **Node insert** (\`turbolynx-c.cpp:3742\`) still uses \`partition_ids[0]\`; with this fix \`partition_ids\` carries the single multi-label partition oid, so the existing single-index access is correct.
- **WAL / delta**: untouched, partition oid is the key.
- **MATCH semantics** (\`MATCH (n:Person)\`, \`MATCH (n:Tag)\`, \`MATCH (n:Person:Tag)\`) all return the right rows by the existing catalog intersection path — no planner/converter change needed.
- **Edge partition naming** continues to use the first label of each endpoint as the canonical name (\`eps_<type>@<src_label>@<dst_label>\`). The storage path stays correct because the edge partition still records the right \`src_part_oid\` / \`dst_part_oid\` (which point at the multi-label \`vps_<...>\` partition). Generalising edge-side label-set naming is a separate follow-up.
- **\`MATCH (a),(b) CREATE (a)-[:T]->(b)\`** continues to go through the regex-based fast path in \`turbolynx_compile_query\`; that fast path has its own pre-existing inability to parse multi-label endpoints and reproduces on \`main\` without this branch.

## Verification

Added \`CREATE multi-label registers all labels\` test covering:

| Sequence | Query | Expected | Result |
| --- | --- | --- | --- |
| \`CREATE (n:Person:Tag)\` | \`MATCH (n:Person)\` | 1 | 1 |
| \`CREATE (n:Person:Tag)\` | \`MATCH (n:Tag)\` | 1 | 1 |
| \`CREATE (n:Person:Tag)\` | \`MATCH (n:Person:Tag)\` | 1 | 1 |
| \`CREATE (n:Person:Tag)\` | \`MATCH (n:Tag:Person)\` | 1 | 1 |
| then \`CREATE (n:Person)\`, \`CREATE (n:Tag)\` | \`MATCH (n:Person)\` | 2 | 2 |
|  | \`MATCH (n:Tag)\` | 2 | 2 |
|  | \`MATCH (n:Person:Tag)\` | 1 | 1 |

Full \`[crud]\` suite: **165 / 166** cases pass. The single failure is the pre-existing \`Bug J — unknown property on node returns NULL\` ORCA optimizer error that also fails on \`main\` and has nothing to do with label handling. Unit suites \`[catalog]\` / \`[storage]\` / \`[common]\` green.

## Test plan

- [x] \`./test/query/query_test --ldbc-path /tmp/ldbc-mini "[multi-label]"\` — 8 assertions, all pass
- [x] \`./test/query/query_test --ldbc-path /tmp/ldbc-mini "[crud]"\` — 165 / 166, only Bug J fails (pre-existing)
- [x] \`./test/unittest "[catalog]" "[storage]" "[common]"\` — green
- [ ] CI on PR