### PR TITLE
fix(merge): bootstrap label on empty workspace + drop 3 stale !mayfail tags (closes #241)

### DIFF
--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -3291,32 +3291,52 @@ static turbolynx_num_rows executeMerge(int64_t conn_id, const string &query,
         return TURBOLYNX_ERROR;
     }
 
-    // Step 1: MATCH check — use the full property map so MERGE is rejected
-    // for a partial match (issue #12). Cypher's map pattern is conjunctive,
-    // so `props_str` reproduces the user's intent verbatim.
-    string match_q = "MATCH (" + var + ":" + label + " {" + props_str + "}) RETURN count(" + var + ") AS cnt";
-    auto* match_prep = turbolynx_prepare(conn_id, const_cast<char*>(match_q.c_str()));
-    if (!match_prep) return TURBOLYNX_ERROR;
-    turbolynx_resultset_wrapper* match_result = nullptr;
-    auto match_rows = turbolynx_execute(conn_id, match_prep, &match_result);
-
+    // On an empty-bootstrap workspace the label is not yet registered;
+    // the MATCH probe below would throw "no vertex with the given label".
+    // Treat absent label as cnt=0 and skip straight to CREATE.
     int64_t cnt = 0;
-    if (match_result && match_result->result_set && match_result->result_set->result) {
-        auto *res = match_result->result_set->result;
-        duckdb::Vector* vec = reinterpret_cast<duckdb::Vector*>(res->__internal_data);
-        spdlog::info("[MERGE] result col0 type={}", vec->GetType().ToString());
-        // Read count value directly
-        if (vec->GetType().id() == duckdb::LogicalTypeId::BIGINT) {
-            cnt = ((int64_t*)vec->GetData())[0];
-        } else if (vec->GetType().id() == duckdb::LogicalTypeId::UBIGINT) {
-            cnt = (int64_t)((uint64_t*)vec->GetData())[0];
-        } else {
-            cnt = turbolynx_get_int64(match_result, 0);
+    bool label_known = true;
+    if (auto *h = get_handle(conn_id)) {
+        auto &catalog = h->database->instance->GetCatalog();
+        auto *gcat = (duckdb::GraphCatalogEntry *)catalog.GetEntry(
+            *h->client, duckdb::CatalogType::GRAPH_ENTRY,
+            DEFAULT_SCHEMA, DEFAULT_GRAPH, true);
+        if (gcat) {
+            label_known = gcat->vertexlabel_map.find(label)
+                          != gcat->vertexlabel_map.end();
         }
     }
-    spdlog::info("[MERGE] match_q='{}' cnt={} rows={}", match_q, cnt, match_rows);
-    if (match_result) turbolynx_close_resultset(match_result);
-    turbolynx_close_prepared_statement(match_prep);
+
+    string match_q = "MATCH (" + var + ":" + label + " {" + props_str + "}) RETURN count(" + var + ") AS cnt";
+    turbolynx_prepared_statement* match_prep = nullptr;
+    if (label_known) {
+        // Use the full property map so MERGE is rejected for a partial match
+        // (issue #12). Cypher's map pattern is conjunctive, so `props_str`
+        // reproduces the user's intent verbatim.
+        match_prep = turbolynx_prepare(conn_id, const_cast<char*>(match_q.c_str()));
+        if (!match_prep) return TURBOLYNX_ERROR;
+    }
+    turbolynx_num_rows match_rows = 0;
+    if (match_prep) {
+        turbolynx_resultset_wrapper* match_result = nullptr;
+        match_rows = turbolynx_execute(conn_id, match_prep, &match_result);
+        if (match_result && match_result->result_set && match_result->result_set->result) {
+            auto *res = match_result->result_set->result;
+            duckdb::Vector* vec = reinterpret_cast<duckdb::Vector*>(res->__internal_data);
+            spdlog::info("[MERGE] result col0 type={}", vec->GetType().ToString());
+            if (vec->GetType().id() == duckdb::LogicalTypeId::BIGINT) {
+                cnt = ((int64_t*)vec->GetData())[0];
+            } else if (vec->GetType().id() == duckdb::LogicalTypeId::UBIGINT) {
+                cnt = (int64_t)((uint64_t*)vec->GetData())[0];
+            } else {
+                cnt = turbolynx_get_int64(match_result, 0);
+            }
+        }
+        if (match_result) turbolynx_close_resultset(match_result);
+        turbolynx_close_prepared_statement(match_prep);
+    }
+    spdlog::info("[MERGE] match_q='{}' cnt={} rows={} label_known={}",
+                 match_q, cnt, match_rows, label_known);
 
     // Step 2: CREATE if not exists
     if (cnt == 0) {

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -3291,9 +3291,7 @@ static turbolynx_num_rows executeMerge(int64_t conn_id, const string &query,
         return TURBOLYNX_ERROR;
     }
 
-    // On an empty-bootstrap workspace the label is not yet registered;
-    // the MATCH probe below would throw "no vertex with the given label".
-    // Treat absent label as cnt=0 and skip straight to CREATE.
+    // Skip the MATCH probe if the label is unregistered; CREATE bootstraps it.
     int64_t cnt = 0;
     bool label_known = true;
     if (auto *h = get_handle(conn_id)) {

--- a/test/fuzz/l2_metamorphic/fuzz_l2_main.cpp
+++ b/test/fuzz/l2_metamorphic/fuzz_l2_main.cpp
@@ -100,26 +100,14 @@ TEST_CASE("collect-count preserves multiset",
     run_rewriter(tl_fuzz_l2::collect_count_rewriter(), kDefaultSeed);
 }
 
-// ---------------------------------------------------------------------
-// Tests below currently surface real planner bugs; the rewriters are
-// kept registered so the failures stay visible, but Catch2's `!mayfail`
-// tag prevents them from turning the gate red.  Remove the tag when
-// the underlying bug lands a fix.
-// ---------------------------------------------------------------------
-
-// `OPTIONAL MATCH (a:P)-[r:T]->(b:M) WHERE r IS NOT NULL` returns
-// a *garbage* `a.id` for some rows while the equivalent plain MATCH
-// returns the correct id.  Looks like a projection / column-mapping
-// regression in the OPTIONAL + post-filter combination.
 TEST_CASE("optional-not-null preserves multiset",
-          "[fuzz][l2][l2.optional-not-null][!mayfail]") {
+          "[fuzz][l2][l2.optional-not-null]") {
     run_rewriter(tl_fuzz_l2::optional_not_null_rewriter(), kDefaultSeed);
 }
 
-// `[*1..K]` decomposed via UNION ALL into per-length traversals
-// triggers a planner assertion (`pipelines.size() == sfgs.size()` at
-// planner.cpp:620).  The combined form plans fine, so the regression
-// lives in the UNION-of-varlen planning path.
+// `[*1..K]` decomposed via UNION ALL into per-length traversals trips a
+// planner assertion (`pipelines.size() == sfgs.size()` at planner.cpp:620).
+// Tracked in #236; combined form plans fine.
 TEST_CASE("varlen-decomp preserves multiset",
           "[fuzz][l2][l2.varlen-decomp][!mayfail]") {
     run_rewriter(tl_fuzz_l2::varlen_decomp_rewriter(), kDefaultSeed);

--- a/test/fuzz/oracle/fuzz_oracle_main.cpp
+++ b/test/fuzz/oracle/fuzz_oracle_main.cpp
@@ -105,15 +105,8 @@ TEST_CASE("L4 create-node-stream agrees with Neo4j",
     run_op_stream(tl_fuzz_oracle::create_node_stream_gen(), kDefaultSeed);
 }
 
-// Currently surfaces a real silent-data divergence: after
-// `MATCH (a:Fz {id:1}), (b:Fz {id:2}) CREATE (a)-[:KNOWS]->(b)`
-// (one logical edge), TurboLynx reports
-// `MATCH (:Fz)-[r:KNOWS]->(:Fz) RETURN count(r)` = 2 while Neo4j
-// reports 1.  Looks like the forward+backward CSR representation is
-// being counted twice when both endpoints share a (multi-partition?)
-// label scope.  `!mayfail` while the underlying bug is open.
 TEST_CASE("L4 create-edge-stream agrees with Neo4j",
-          "[fuzz][l4][l4.create-edge-stream][!mayfail]") {
+          "[fuzz][l4][l4.create-edge-stream]") {
     run_op_stream(tl_fuzz_oracle::create_edge_stream_gen(), kDefaultSeed);
 }
 
@@ -127,13 +120,8 @@ TEST_CASE("L4 create-then-detach-delete agrees with Neo4j",
     run_op_stream(tl_fuzz_oracle::create_then_detach_delete_gen(), kDefaultSeed);
 }
 
-// MERGE on an empty-bootstrap workspace throws because the label
-// has not been registered yet — the subsequent probe `MATCH (n:Fz)
-// …` errors with "There is no vertex with the given label Fz".
-// Pure CREATE works fine on the same empty workspace, so this is
-// MERGE-specific.  `!mayfail` while the underlying bug is open.
 TEST_CASE("L4 merge-stream agrees with Neo4j",
-          "[fuzz][l4][l4.merge-stream][!mayfail]") {
+          "[fuzz][l4][l4.merge-stream]") {
     run_op_stream(tl_fuzz_oracle::merge_stream_gen(), kDefaultSeed);
 }
 
@@ -206,15 +194,8 @@ TEST_CASE("L3 match-by-id agrees with Neo4j",
     run_read_stream(tl_fuzz_oracle::match_by_id_gen(), kDefaultSeed);
 }
 
-// Surfaces a labelled-anchor reverse-direction matching bug:
-// `MATCH (b:Fz)<-[:KNOWS]-(a:Fz {id:10})` returns the predecessor in
-// the KNOWS ring (9) in addition to the correct successor (1).  When
-// both endpoints share a label scope (here `:Fz`) the LEFT arrow
-// degenerates into bidirectional matching.  Closely related to the
-// already-filed #234 (unlabeled MPV case) but the labeled path is a
-// separate code branch.  `!mayfail` while the underlying bug is open.
 TEST_CASE("L3 traverse-1hop agrees with Neo4j",
-          "[fuzz][l3][l3.traverse-1hop][!mayfail]") {
+          "[fuzz][l3][l3.traverse-1hop]") {
     run_read_stream(tl_fuzz_oracle::traverse_1hop_gen(), kDefaultSeed);
 }
 
@@ -223,11 +204,9 @@ TEST_CASE("L3 aggregation agrees with Neo4j",
     run_read_stream(tl_fuzz_oracle::aggregation_gen(), kDefaultSeed);
 }
 
-// Surfaces a multi-WITH scope regression: the chain
-// `MATCH … WITH n, n.age AS age WHERE age>25 WITH n.id AS id RETURN id`
-// returns zero rows where Neo4j returns nine.  Dropping the bound
-// variable in the second WITH apparently loses every row, not just the
-// columns.  `!mayfail` while the underlying bug is open.
+// Tracked in #240: multi-WITH that drops the bound variable returns
+// zero rows where Neo4j returns the full count — looks like the
+// second WITH drops rows along with columns.
 TEST_CASE("L3 with-chain agrees with Neo4j",
           "[fuzz][l3][l3.with-chain][!mayfail]") {
     run_read_stream(tl_fuzz_oracle::with_chain_gen(), kDefaultSeed);


### PR DESCRIPTION
## Problem
On an empty-bootstrap workspace (no labels registered yet), `MERGE (n:Fz {id:1})` throws:

```
Invalid Input Error: There is no vertex with the given label Fz
```

`executeMerge` always issues a MATCH-count probe first, and the catalog rejects an unknown label before CREATE can bootstrap it. Pure `CREATE (n:Fz …)` works fine because the binder's bootstrap path registers the label on demand.

## Fix
Before the probe, look up the label in `gcat->vertexlabel_map`. If absent, skip the probe (`cnt = 0`) and fall straight through to the CREATE branch — CREATE's bootstrap path then registers the label, partition, schema, and index. When the label is known, the original probe (full conjunctive map pattern from #12) runs unchanged.

## Bonus: stale `!mayfail` sweep
Re-running the `!mayfail` fuzz cases, three were silently green since unrelated fixes landed. Dropping the tag so future regressions actually break the gate:

- `l2.optional-not-null`
- `l4.create-edge-stream` — closed by #255 (KNOWS shadow direction)
- `l3.traverse-1hop` — same shadow fix

Still red, kept tagged: `l2.varlen-decomp` (#236), `l3.with-chain` (#240).

Closes #241