### PR TITLE
fix(orca): initialize CColumnDescriptor PropId/NodeId (closes #240)

### DIFF
--- a/src/optimizer/orca/gporca/libgpopt/metadata/CColumnDescriptor.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/metadata/CColumnDescriptor.cpp
@@ -37,7 +37,9 @@ CColumnDescriptor::CColumnDescriptor(CMemoryPool *mp, const IMDType *pmdtype,
 	  m_iAttno(attno),
 	  m_is_nullable(is_nullable),
 	  m_width(ulWidth),
-	  m_is_dist_col(false)
+	  m_is_dist_col(false),
+	  m_prop_id(gpos::ulong_max),
+	  m_node_id(gpos::ulong_max)
 {
 	GPOS_ASSERT(NULL != pmdtype);
 	GPOS_ASSERT(pmdtype->MDId()->IsValid());

--- a/src/planner/planner_physical_scalar.cpp
+++ b/src/planner/planner_physical_scalar.cpp
@@ -170,14 +170,21 @@ unique_ptr<duckdb::Expression> Planner::pTransformScalarIdent(CExpression *scala
 		}
 		const auto target_node_id = target->NodeId();
 		const auto target_prop_id = target->PropId();
+		// Require both NodeId and PropId to be set; if PropId is the
+		// sentinel ulong_max (column descriptor never carried it
+		// through), every candidate with the same NodeId matches the
+		// first column and gives the wrong index — fall through to
+		// name-based strategies instead.
+		if (target_node_id == gpos::ulong_max ||
+		    target_prop_id == gpos::ulong_max) {
+			return gpos::ulong_max;
+		}
 		for (ULONG i = 0; i < cols->Size(); i++) {
 			auto *candidate = (*cols)[i];
 			if (!candidate) {
 				continue;
 			}
-			if (target_node_id != gpos::ulong_max &&
-			    candidate->NodeId() != gpos::ulong_max &&
-			    candidate->NodeId() == target_node_id &&
+			if (candidate->NodeId() == target_node_id &&
 			    candidate->PropId() == target_prop_id) {
 				return i;
 			}

--- a/test/fuzz/oracle/fuzz_oracle_main.cpp
+++ b/test/fuzz/oracle/fuzz_oracle_main.cpp
@@ -204,11 +204,8 @@ TEST_CASE("L3 aggregation agrees with Neo4j",
     run_read_stream(tl_fuzz_oracle::aggregation_gen(), kDefaultSeed);
 }
 
-// Tracked in #240: multi-WITH that drops the bound variable returns
-// zero rows where Neo4j returns the full count — looks like the
-// second WITH drops rows along with columns.
 TEST_CASE("L3 with-chain agrees with Neo4j",
-          "[fuzz][l3][l3.with-chain][!mayfail]") {
+          "[fuzz][l3][l3.with-chain]") {
     run_read_stream(tl_fuzz_oracle::with_chain_gen(), kDefaultSeed);
 }
 


### PR DESCRIPTION
## Problem
multi-PS partition 에서 다음 쿼리가 0 rows 반환 (1 row 기대):

```cypher
MATCH (n:Fz {kind:'Person'}) WITH n WHERE n.age > 25 RETURN n.id
```

`WITH n` 없으면 정상. ORCA 가 WHERE 를 per-PS scan 으로 push-down 하기 때문.

## Root cause
`WITH n` 가 끼면 Filter (age > 25) 가 UnionAll 위에 머무름. 위에서 ColRef 를 child 의 어느 자리에 매핑할지 `pTransformScalarIdent` 가 NodeId + PropId 로 매칭하는데, 매칭 결과가 **id 자리 (0)** 로 잘못 풀려서 Filter 가 `id > 25` 실행 → 다 떨어짐.

추적해보니 ColRef 들의 `PropId` 가 가비지 값 (`6881325`, `1` 등) 이었음. 원인: `src/optimizer/orca/gporca/libgpopt/metadata/CColumnDescriptor.cpp` 의 ctor 가 `m_prop_id` / `m_node_id` 를 **초기화 안 함**. uninitialized memory 가 그대로 ColRef 로 흘러들어감.

## Fix
1. `CColumnDescriptor` ctor 에 `m_prop_id` / `m_node_id` = `gpos::ulong_max` 초기화 (4 줄).
2. `find_matching_col_by_node_prop` 가 PropId/NodeId 가 sentinel `ulong_max` 면 early-return → name-based strategy 로 자연스럽게 fallthrough.

## Verification
- `l3.with-chain` fuzz `!mayfail` 떼고 green.
- fuzz oracle 11/11, fuzz L2 8/9 (#236), unit catalog/storage/common green, CRUD 164/165 (사전 Bug J 만).

Closes #240