### PR TITLE
fix(#270): route VLE/SP iterators through graph_storage_wrapper

### DIFF
--- a/src/execution/execution/physical_operator/physical_adjidxjoin.cpp
+++ b/src/execution/execution/physical_operator/physical_adjidxjoin.cpp
@@ -70,14 +70,16 @@ OperatorResultType PhysicalAdjIdxJoin::ProcessSemiAntiJoin(
         context.client->graph_storage_wrapper->getAdjListFromVid(
             *state.adj_it, state.adj_col_idxs[state.adj_idx], state.prev_eid,
             src_vid, adj_start, adj_end,
-            (expand_dir == ExpandDirection::BOTH) ? ExpandDirection::OUTGOING : expand_dir);
+            (expand_dir == ExpandDirection::BOTH) ? ExpandDirection::OUTGOING : expand_dir,
+            state.adj_merge_scratch_fwd);
         idx_t adj_size_debug = GetAdjacencyEntryCount(adj_start, adj_end);
         // For BOTH direction, also check backward adj list
         if (expand_dir == ExpandDirection::BOTH) {
             uint64_t *bwd_start, *bwd_end;
             context.client->graph_storage_wrapper->getAdjListFromVid(
                 *state.adj_it_bwd, state.bwd_adj_col_idxs[state.adj_idx], state.prev_eid_bwd,
-                src_vid, bwd_start, bwd_end, ExpandDirection::INCOMING);
+                src_vid, bwd_start, bwd_end, ExpandDirection::INCOMING,
+                state.adj_merge_scratch_bwd);
             adj_size_debug += GetAdjacencyEntryCount(bwd_start, bwd_end);
         }
         const bool predicate_satisfied =
@@ -592,19 +594,23 @@ inline void PhysicalAdjIdxJoin::GetAdjListAndFillRHSOutput(
                                  : state.bwd_adj_col_idxs[state.adj_idx];
 
             context.client->graph_storage_wrapper->getAdjListFromVid(
-                *iter_ptr, col_idx, *prev_ptr, src_vid, adj_start, adj_end, phase_dir);
+                *iter_ptr, col_idx, *prev_ptr, src_vid, adj_start, adj_end, phase_dir,
+                is_fwd ? state.adj_merge_scratch_fwd : state.adj_merge_scratch_bwd);
         } else {
+            auto &scratch = (cur_direction == ExpandDirection::INCOMING)
+                                ? state.adj_merge_scratch_bwd
+                                : state.adj_merge_scratch_fwd;
             // M30: Use per-adj_idx iterators when available
             if (!state.adj_its_multi.empty()) {
                 context.client->graph_storage_wrapper->getAdjListFromVid(
                     *state.adj_its_multi[state.adj_idx],
                     state.adj_col_idxs[state.adj_idx],
                     state.prev_eids_multi[state.adj_idx],
-                    src_vid, adj_start, adj_end, cur_direction);
+                    src_vid, adj_start, adj_end, cur_direction, scratch);
             } else {
                 context.client->graph_storage_wrapper->getAdjListFromVid(
                     *state.adj_it, state.adj_col_idxs[state.adj_idx], state.prev_eid,
-                    src_vid, adj_start, adj_end, cur_direction);
+                    src_vid, adj_start, adj_end, cur_direction, scratch);
             }
         }
     }
@@ -732,7 +738,8 @@ inline void PhysicalAdjIdxJoin::GetAdjListAndFillRHSOutputInto(
         int col_idx = is_fwd ? state.adj_col_idxs[state.adj_idx]
                              : state.bwd_adj_col_idxs[state.adj_idx];
         context.client->graph_storage_wrapper->getAdjListFromVid(
-            *iter_ptr, col_idx, *prev_ptr, src_vid, adj_start, adj_end, phase_dir);
+            *iter_ptr, col_idx, *prev_ptr, src_vid, adj_start, adj_end, phase_dir,
+            is_fwd ? state.adj_merge_scratch_fwd : state.adj_merge_scratch_bwd);
 
         // M26-D: Stateless dedup (same as GetAdjListAndFillRHSOutput)
         // M27-C: per-adj-idx dedup flag
@@ -760,17 +767,20 @@ inline void PhysicalAdjIdxJoin::GetAdjListAndFillRHSOutputInto(
             }
         }
     } else if (!skip_this_adj) {
+        auto &scratch = (cur_direction == ExpandDirection::INCOMING)
+                            ? state.adj_merge_scratch_bwd
+                            : state.adj_merge_scratch_fwd;
         // M30: Use per-adj_idx iterators when available
         if (!state.adj_its_multi.empty()) {
             context.client->graph_storage_wrapper->getAdjListFromVid(
                 *state.adj_its_multi[state.adj_idx],
                 state.adj_col_idxs[state.adj_idx],
                 state.prev_eids_multi[state.adj_idx],
-                src_vid, adj_start, adj_end, cur_direction);
+                src_vid, adj_start, adj_end, cur_direction, scratch);
         } else {
             context.client->graph_storage_wrapper->getAdjListFromVid(
                 *state.adj_it, state.adj_col_idxs[state.adj_idx], state.prev_eid,
-                src_vid, adj_start, adj_end, cur_direction);
+                src_vid, adj_start, adj_end, cur_direction, scratch);
         }
     }
     // When skip_this_adj is true, adj_start/adj_end remain nullptr → adj_size = 0

--- a/src/function/scalar/check_edge_exists.cpp
+++ b/src/function/scalar/check_edge_exists.cpp
@@ -24,6 +24,7 @@ struct AdjScanCache {
     vector<uint16_t> src_partition_ids;
     mutable vector<AdjacencyListIterator *> iters;
     mutable vector<ExtentID> prev_eids;
+    mutable vector<std::vector<uint64_t>> merge_scratchs;
     mutable bool iters_initialized = false;
 
     ~AdjScanCache() {
@@ -39,6 +40,7 @@ struct AdjScanCache {
         for (size_t i = 0; i < adj_col_idxs.size(); i++) {
             iters.push_back(new AdjacencyListIterator());
             prev_eids.push_back((ExtentID)-1);
+            merge_scratchs.emplace_back();
         }
         iters_initialized = true;
     }
@@ -122,7 +124,8 @@ static bool AdjListContains(iTbgppGraphStorageWrapper *graph_storage, AdjScanCac
     auto &prev_eid = cache.prev_eids[cache_idx];
 
     graph_storage->getAdjListFromVid(iter, cache.adj_col_idxs[cache_idx], prev_eid, src_vid,
-                                     start_ptr, end_ptr, expand_dir);
+                                     start_ptr, end_ptr, expand_dir,
+                                     cache.merge_scratchs[cache_idx]);
     if (!start_ptr || !end_ptr) {
         return false;
     }
@@ -157,7 +160,8 @@ static void CollectAdjNeighbors(iTbgppGraphStorageWrapper *graph_storage, AdjSca
     auto &prev_eid = cache.prev_eids[cache_idx];
 
     graph_storage->getAdjListFromVid(iter, cache.adj_col_idxs[cache_idx], prev_eid, vid,
-                                     start_ptr, end_ptr, expand_dir);
+                                     start_ptr, end_ptr, expand_dir,
+                                     cache.merge_scratchs[cache_idx]);
     if (!start_ptr || !end_ptr) {
         return;
     }

--- a/src/function/scalar/path_weight.cpp
+++ b/src/function/scalar/path_weight.cpp
@@ -201,14 +201,15 @@ static const vector<int> *FindAdjColsForVid(
 static void FetchAdjList(iTbgppGraphStorageWrapper &graph_storage,
                          AdjacencyListIterator &adj_iter, ExtentID &prev_eid,
                          int &prev_adj_col, int adj_col_idx, uint64_t vid,
-                         uint64_t *&start_ptr, uint64_t *&end_ptr) {
+                         uint64_t *&start_ptr, uint64_t *&end_ptr,
+                         std::vector<uint64_t> &scratch_buf) {
     if (adj_col_idx != prev_adj_col) {
         prev_eid = (ExtentID)-1;
         prev_adj_col = adj_col_idx;
     }
     graph_storage.getAdjListFromVid(adj_iter, adj_col_idx, prev_eid, vid,
                                     start_ptr, end_ptr,
-                                    ExpandDirection::OUTGOING);
+                                    ExpandDirection::OUTGOING, scratch_buf);
 }
 
 static unique_ptr<FunctionData> UnsupportedPathWeightBind(
@@ -279,6 +280,9 @@ static void PathWeightFunction(DataChunk &args, ExpressionState &state,
     int hop1_prev_adj_col = -1;
     int hop2_prev_adj_col = -1;
     int hop3_prev_adj_col = -1;
+    // Per-hop scratch buffers — hop1's pointers stay live across hop2/hop3
+    // fetches in the nested loop, so they cannot share a buffer.
+    std::vector<uint64_t> hop1_scratch, hop2_scratch, hop3_scratch;
 
     for (idx_t row = 0; row < count; row++) {
         auto path_value = path_vec.GetValue(row);
@@ -309,7 +313,7 @@ static void PathWeightFunction(DataChunk &args, ExpressionState &state,
                     uint64_t *hop1_end = nullptr;
                     FetchAdjList(*bind_data.graph_storage, hop1_iter,
                                  hop1_prev_eid, hop1_prev_adj_col, hop1_col,
-                                 src, hop1_start, hop1_end);
+                                 src, hop1_start, hop1_end, hop1_scratch);
                     if (!hop1_start) {
                         continue;
                     }
@@ -326,7 +330,8 @@ static void PathWeightFunction(DataChunk &args, ExpressionState &state,
                             uint64_t *hop2_end = nullptr;
                             FetchAdjList(*bind_data.graph_storage, hop2_iter,
                                          hop2_prev_eid, hop2_prev_adj_col,
-                                         hop2_col, mid1, hop2_start, hop2_end);
+                                         hop2_col, mid1, hop2_start, hop2_end,
+                                         hop2_scratch);
                             if (!hop2_start) {
                                 continue;
                             }
@@ -352,7 +357,8 @@ static void PathWeightFunction(DataChunk &args, ExpressionState &state,
                                     FetchAdjList(*bind_data.graph_storage,
                                                  hop3_iter, hop3_prev_eid,
                                                  hop3_prev_adj_col, hop3_col,
-                                                 mid2, hop3_start, hop3_end);
+                                                 mid2, hop3_start, hop3_end,
+                                                 hop3_scratch);
                                     if (!hop3_start) {
                                         continue;
                                     }

--- a/src/include/execution/physical_operator/physical_adjidxjoin.hpp
+++ b/src/include/execution/physical_operator/physical_adjidxjoin.hpp
@@ -64,6 +64,9 @@ class AdjIdxJoinState : public OperatorState {
     AdjacencyListIterator *adj_it_bwd;  // backward (used only for BOTH)
     ExtentID prev_eid;
     ExtentID prev_eid_bwd;
+    // Caller-owned scratch buffers for wrapper.getAdjListFromVid base+delta merge.
+    std::vector<uint64_t> adj_merge_scratch_fwd;
+    std::vector<uint64_t> adj_merge_scratch_bwd;
     BothPhase both_phase = BothPhase::FORWARD;
 
     // input -> output col mapping information

--- a/src/include/execution/physical_operator/physical_adjidxjoin.hpp
+++ b/src/include/execution/physical_operator/physical_adjidxjoin.hpp
@@ -64,7 +64,6 @@ class AdjIdxJoinState : public OperatorState {
     AdjacencyListIterator *adj_it_bwd;  // backward (used only for BOTH)
     ExtentID prev_eid;
     ExtentID prev_eid_bwd;
-    // Caller-owned scratch buffers for wrapper.getAdjListFromVid base+delta merge.
     std::vector<uint64_t> adj_merge_scratch_fwd;
     std::vector<uint64_t> adj_merge_scratch_bwd;
     BothPhase both_phase = BothPhase::FORWARD;

--- a/src/include/storage/extent/adjlist_iterator.hpp
+++ b/src/include/storage/extent/adjlist_iterator.hpp
@@ -88,12 +88,16 @@ private:
     // Per level, per adj_col
     vector<vector<std::pair<uint64_t *, uint64_t *>>> offsets_per_lv_per_col;
     vector<vector<idx_t>> cursor_per_lv_per_col;
-    // Per (level, adj_col) buffer used by MergeAdjListWithDelta to
-    // hold a base+delta-merged adjacency list. The offsets stored in
-    // offsets_per_lv_per_col may point into these buffers, so each
-    // level needs its own (other levels' buffers may be touched on
-    // backtrack, but only after the previous setup recurses out).
+    // Per (level, adj_col) scratch buffer passed to
+    // graph_storage_wrapper.getAdjListFromVid for base+delta merge. The
+    // pointers stored in offsets_per_lv_per_col may point into these
+    // buffers, so each (level, adj_col) needs its own — siblings at the
+    // same level get fetched without overwriting an ancestor's list.
     vector<vector<std::vector<uint64_t>>> delta_merge_bufs_per_lv_per_col;
+    // Per (level, adj_col) prev-eid cache for the wrapper — lets it skip
+    // re-initializing an iterator that's already positioned at the right
+    // disk extent.
+    vector<vector<ExtentID>> prev_eid_per_lv_per_col;
 
     // Per level
     vector<int> adj_col_cursor_per_level;
@@ -121,6 +125,7 @@ private:
     std::shared_ptr<ExtentIterator> ext_it = nullptr;
     std::shared_ptr<EidBufPtrMap> eid_to_bufptr_idx_map;
     std::vector<uint64_t> delta_merge_buf;
+    ExtentID prev_eid_ = std::numeric_limits<ExtentID>::max();
 
     bool enqueueNeighbors(ClientContext &context, NodeID node_id, Level node_level, std::queue<std::pair<NodeID, Level>>& queue);
 };
@@ -158,6 +163,8 @@ private:
     std::shared_ptr<EidBufPtrMap> eid_to_bufptr_idx_map_backward;
     std::vector<uint64_t> delta_merge_buf_fwd;
     std::vector<uint64_t> delta_merge_buf_bwd;
+    ExtentID prev_eid_fwd_ = std::numeric_limits<ExtentID>::max();
+    ExtentID prev_eid_bwd_ = std::numeric_limits<ExtentID>::max();
 
     bool biDirectionalSearch(ClientContext &context);
     bool enqueueNeighbors(ClientContext &context, NodeID current_node, Level node_level, std::queue<std::pair<NodeID, Level>>& queue, bool is_forward);
@@ -202,6 +209,8 @@ private:
     std::shared_ptr<EidBufPtrMap> eid_to_bufptr_idx_map_backward;
     std::vector<uint64_t> delta_merge_buf_fwd;
     std::vector<uint64_t> delta_merge_buf_bwd;
+    ExtentID prev_eid_fwd_ = std::numeric_limits<ExtentID>::max();
+    ExtentID prev_eid_bwd_ = std::numeric_limits<ExtentID>::max();
 
     bool biDirectionalSearch(ClientContext &context);
     bool enqueueNeighbors(ClientContext &context, NodeID current_node, Level node_level, std::queue<std::pair<NodeID, Level>> &queue, bool is_forward);

--- a/src/include/storage/extent/adjlist_iterator.hpp
+++ b/src/include/storage/extent/adjlist_iterator.hpp
@@ -88,15 +88,9 @@ private:
     // Per level, per adj_col
     vector<vector<std::pair<uint64_t *, uint64_t *>>> offsets_per_lv_per_col;
     vector<vector<idx_t>> cursor_per_lv_per_col;
-    // Per (level, adj_col) scratch buffer passed to
-    // graph_storage_wrapper.getAdjListFromVid for base+delta merge. The
-    // pointers stored in offsets_per_lv_per_col may point into these
-    // buffers, so each (level, adj_col) needs its own — siblings at the
-    // same level get fetched without overwriting an ancestor's list.
+    // pointers in offsets_per_lv_per_col may alias into these buffers,
+    // so each (level, adj_col) needs its own.
     vector<vector<std::vector<uint64_t>>> delta_merge_bufs_per_lv_per_col;
-    // Per (level, adj_col) prev-eid cache for the wrapper — lets it skip
-    // re-initializing an iterator that's already positioned at the right
-    // disk extent.
     vector<vector<ExtentID>> prev_eid_per_lv_per_col;
 
     // Per level

--- a/src/include/storage/graph_storage_wrapper.hpp
+++ b/src/include/storage/graph_storage_wrapper.hpp
@@ -63,8 +63,6 @@ struct IndexSeekScratch {
 	idx_t boundary_position_cursor = 0;
 	idx_t tmp_vec_cursor = 0;
 	std::unordered_set<ExtentID> seen_eids;
-	//! Temporary buffer for merging base CSR + delta edges in getAdjListFromVid
-	vector<uint64_t> adj_merge_buf;
 	vector<ExtentID> base_target_eids;
 	vector<idx_t> base_mapping_idxs;
 
@@ -171,11 +169,16 @@ public:
                     vector<LogicalType> &adjColTypes);
  uint16_t getAdjListSrcPartitionId(idx_t index_cat_oid);
  uint16_t getNodePartitionId(uint64_t vid);
+ //! `scratch_buf` is caller-owned. When base CSR + AdjListDelta need to be
+ //! merged, the returned (start_ptr, end_ptr) point into this buffer, so the
+ //! caller must keep it alive — and not call this method again with the same
+ //! buffer — until the pointers are consumed.
  StoreAPIResult getAdjListFromVid(AdjacencyListIterator &adj_iter,
                                   int adjColIdx, ExtentID &prev_eid,
                                   uint64_t vid, uint64_t *&start_ptr,
                                   uint64_t *&end_ptr,
-                                  ExpandDirection expand_dir);
+                                  ExpandDirection expand_dir,
+                                  std::vector<uint64_t> &scratch_buf);
 
  void fillEidToMappingIdx(vector<uint64_t> &oids,
                           vector<vector<uint64_t>> &scan_projection_mapping,
@@ -189,8 +192,6 @@ private:
 	ClientContext &client;
 	//! Default scratch — used by sequential paths that pass GetDefaultScratch()
 	IndexSeekScratch default_scratch_;
-	//! Mutex protecting default_scratch_'s adj_merge_buf during getAdjListFromVid
-	std::mutex adj_merge_buf_mutex_;
 	//! OIDs + projection from last InitializeScan (for UpdateSegment merge in doScan)
 	vector<idx_t> last_scan_oids_;
 	vector<vector<uint64_t>> last_scan_projection_;

--- a/src/storage/extent/adjlist_iterator.cpp
+++ b/src/storage/extent/adjlist_iterator.cpp
@@ -12,6 +12,7 @@
 #include "common/constants.hpp"
 #include "common/typedef.hpp"
 #include "storage/delta_store.hpp"
+#include "storage/graph_storage_wrapper.hpp"
 #include "catalog/catalog_entry/graph_catalog_entry.hpp"
 #include "catalog/catalog_entry/index_catalog_entry.hpp"
 
@@ -26,137 +27,6 @@ namespace duckdb {
 }
 namespace turbolynx {
 using namespace duckdb;
-
-// Find the edge partition whose adj_delta should be consulted for a given
-// (adj_col_idx, expand_direction, vertex_partition_id). Mirrors the static
-// helper of the same name in graph_storage_wrapper.cpp; kept local here so
-// the in-execution iterators don't need to plumb the wrapper instance.
-static uint16_t ResolveAdjDeltaPartitionIdLocal(
-    duckdb::ClientContext &client, int adjColIdx,
-    ExpandDirection expand_dir, uint16_t vertex_part_id) {
-    auto &catalog = client.db->GetCatalog();
-    auto *gcat = (GraphCatalogEntry *)catalog.GetEntry(
-        client, duckdb::CatalogType::GRAPH_ENTRY, DEFAULT_SCHEMA,
-        DEFAULT_GRAPH, true);
-    if (!gcat) return std::numeric_limits<uint16_t>::max();
-
-    auto *ep_oids = gcat->GetEdgePartitionOids();
-    if (!ep_oids) return std::numeric_limits<uint16_t>::max();
-
-    for (auto ep_oid : *ep_oids) {
-        auto *ep = (PartitionCatalogEntry *)catalog.GetEntry(
-            client, DEFAULT_SCHEMA, ep_oid, true);
-        if (!ep) continue;
-        auto *src_part = (PartitionCatalogEntry *)catalog.GetEntry(
-            client, DEFAULT_SCHEMA, ep->GetSrcPartOid(), true);
-        auto *dst_part = (PartitionCatalogEntry *)catalog.GetEntry(
-            client, DEFAULT_SCHEMA, ep->GetDstPartOid(), true);
-        auto *idx_ids = ep->GetAdjIndexOidVec();
-        if (!idx_ids) continue;
-        for (auto idx_oid : *idx_ids) {
-            auto *idx_cat = (IndexCatalogEntry *)catalog.GetEntry(
-                client, DEFAULT_SCHEMA, idx_oid, true);
-            if (!idx_cat || idx_cat->GetAdjColIdx() != (idx_t)adjColIdx) continue;
-            bool matches_dir =
-                (expand_dir == ExpandDirection::OUTGOING &&
-                 idx_cat->GetIndexType() == IndexType::FORWARD_CSR) ||
-                (expand_dir == ExpandDirection::INCOMING &&
-                 idx_cat->GetIndexType() == IndexType::BACKWARD_CSR);
-            if (!matches_dir) continue;
-            if (expand_dir == ExpandDirection::OUTGOING &&
-                !(src_part && src_part->GetPartitionID() == vertex_part_id)) continue;
-            if (expand_dir == ExpandDirection::INCOMING &&
-                !(dst_part && dst_part->GetPartitionID() == vertex_part_id)) continue;
-            return ep->GetPartitionID();
-        }
-    }
-    return std::numeric_limits<uint16_t>::max();
-}
-
-// Merge a base CSR adj-list (start_ptr/end_ptr; nullable for in-memory
-// extents) with the AdjListDelta entries for `vid`. On return, *out_start
-// / *out_end either point into `merge_buf` (when delta touched the list)
-// or pass through the base pointers unchanged. Caller owns `merge_buf`
-// for the lifetime of the held offsets.
-static void MergeAdjListWithDelta(
-    duckdb::ClientContext &context, uint64_t vid, int adjColIdx,
-    ExpandDirection expand_dir, uint16_t vertex_part_id,
-    uint64_t *base_start, uint64_t *base_end,
-    std::vector<uint64_t> &merge_buf,
-    uint64_t **out_start, uint64_t **out_end) {
-    *out_start = base_start;
-    *out_end = base_end;
-    if (!context.db) return;
-
-    auto &delta_store = context.db->delta_store;
-    // Fast path: when no edge has ever been written to AdjListDelta (the
-    // overwhelmingly common case on bulkload-only graphs like LDBC), skip
-    // both the catalog walk in ResolveAdjDeltaPartitionIdLocal and the
-    // map lookup. ResolveAdjDeltaPartitionIdLocal iterates every edge
-    // partition + its adj indexes — fine when the delta is hot, but
-    // accumulates to a multi-second overhead per VLE / shortestPath
-    // traversal step on partitions with many adj indexes.
-    const auto &adj_deltas = delta_store.adj_deltas_exposed();
-    if (adj_deltas.empty()) return;
-
-    uint16_t edge_part_id = ResolveAdjDeltaPartitionIdLocal(
-        context, adjColIdx, expand_dir, vertex_part_id);
-    if (edge_part_id == std::numeric_limits<uint16_t>::max()) return;
-
-    auto adj_it = adj_deltas.find(edge_part_id);
-    if (adj_it == adj_deltas.end()) return;
-
-    const auto &adj_delta = adj_it->second;
-    uint64_t delta_key = delta_store.ResolveLogicalId(vid);
-    const auto *inserted = adj_delta.GetInserted(delta_key);
-    const auto *deleted = adj_delta.GetDeleted(delta_key);
-    bool has_inserted = inserted && !inserted->empty();
-    bool has_deleted = deleted && !deleted->empty();
-    if (!has_inserted && !has_deleted) return;
-
-    auto delta_entry_matches_dir = [&](const EdgeEntry &entry) {
-        return expand_dir == ExpandDirection::OUTGOING
-                   ? !entry.is_backward
-                   : entry.is_backward;
-    };
-
-    idx_t total = 0;
-    for (uint64_t *p = base_start; p && p < base_end; p += 2) {
-        if (deleted && deleted->count(p[1]) > 0) continue;
-        total++;
-    }
-    if (inserted) {
-        for (auto &entry : *inserted) {
-            if (!delta_entry_matches_dir(entry)) continue;
-            if (deleted && deleted->count(entry.edge_id) > 0) continue;
-            total++;
-        }
-    }
-
-    if (total == 0) {
-        *out_start = nullptr;
-        *out_end = nullptr;
-        return;
-    }
-
-    merge_buf.resize(total * 2);
-    idx_t cursor = 0;
-    for (uint64_t *p = base_start; p && p < base_end; p += 2) {
-        if (deleted && deleted->count(p[1]) > 0) continue;
-        merge_buf[cursor++] = p[0];
-        merge_buf[cursor++] = p[1];
-    }
-    if (inserted) {
-        for (auto &entry : *inserted) {
-            if (!delta_entry_matches_dir(entry)) continue;
-            if (deleted && deleted->count(entry.edge_id) > 0) continue;
-            merge_buf[cursor++] = entry.dst_vid;
-            merge_buf[cursor++] = entry.edge_id;
-        }
-    }
-    *out_start = merge_buf.data();
-    *out_end = merge_buf.data() + cursor;
-}
 
 bool AdjacencyListIterator::Initialize(duckdb::ClientContext &context, int adjColIdx, ExtentID target_eid, bool is_fwd) {
     if (is_initialized && target_eid == cur_eid) return true;
@@ -269,52 +139,28 @@ void DFSIterator::initialize(duckdb::ClientContext &context, uint64_t src_id,
 }
 
 void DFSIterator::setupAdjListsForNode(duckdb::ClientContext &context, int lv, uint64_t src_id) {
-    // src_id can be either a real physical_id (high 32 bits = extent ID) or
-    // a synthetic logical_id whose high 32 bits look like 0x7F000000 — the
-    // synthetic-LID prefix, not a valid extent ID. Resolve to the current
-    // physical_id first so the IsInMemoryExtent / disk-catalog lookups
-    // below see real extent IDs. Without this, fresh-bootstrap CREATE nodes
-    // (which only have synthetic LIDs) drove the iterator into the disk
-    // catalog with eid 0x7F000000, missed the IsInMemoryExtent shortcut,
-    // and SEGVed dereferencing the resulting nullptr ExtentCatalogEntry.
-    uint64_t resolved_pid = src_id;
-    if (context.db) {
-        auto &ds = context.db->delta_store;
-        uint64_t pid = ds.ResolvePid(src_id);
-        if (pid != 0) {
-            resolved_pid = pid;
-        }
-    }
-    ExtentID eid = resolved_pid >> 32;
     int n_ac = (int)adjColIdxs.size();
-
     offsets_per_lv_per_col[lv].resize(n_ac, {nullptr, nullptr});
     cursor_per_lv_per_col[lv].resize(n_ac, 0);
     if ((int)delta_merge_bufs_per_lv_per_col.size() <= lv) {
         delta_merge_bufs_per_lv_per_col.resize(lv + 1);
     }
     delta_merge_bufs_per_lv_per_col[lv].resize(n_ac);
+    if ((int)prev_eid_per_lv_per_col.size() <= lv) {
+        prev_eid_per_lv_per_col.resize(lv + 1);
+    }
+    prev_eid_per_lv_per_col[lv].resize(n_ac, std::numeric_limits<ExtentID>::max());
 
-    bool in_memory_node = IsInMemoryExtent(eid);
-    uint16_t vertex_part_id = (uint16_t)(eid >> 16);
-
+    auto &wrapper = *context.graph_storage_wrapper;
     for (int ac = 0; ac < n_ac; ac++) {
-        bool is_fwd = adjColIsFwds[ac];
-        uint64_t *base_start = nullptr;
-        uint64_t *base_end = nullptr;
-        if (!in_memory_node) {
-            bool initialized = adjlist_iters[ac]->Initialize(
-                context, adjColIdxs[ac], eid, is_fwd);
-            adjlist_iters[ac]->getAdjListPtr(resolved_pid, eid,
-                &base_start, &base_end, initialized);
-        }
-        ExpandDirection dir = is_fwd ? ExpandDirection::OUTGOING
-                                     : ExpandDirection::INCOMING;
-        MergeAdjListWithDelta(context, resolved_pid, adjColIdxs[ac],
-            dir, vertex_part_id, base_start, base_end,
-            delta_merge_bufs_per_lv_per_col[lv][ac],
-            &offsets_per_lv_per_col[lv][ac].first,
-            &offsets_per_lv_per_col[lv][ac].second);
+        ExpandDirection dir = adjColIsFwds[ac] ? ExpandDirection::OUTGOING
+                                               : ExpandDirection::INCOMING;
+        uint64_t *start = nullptr;
+        uint64_t *end = nullptr;
+        wrapper.getAdjListFromVid(*adjlist_iters[ac], adjColIdxs[ac],
+            prev_eid_per_lv_per_col[lv][ac], src_id, start, end, dir,
+            delta_merge_bufs_per_lv_per_col[lv][ac]);
+        offsets_per_lv_per_col[lv][ac] = {start, end};
         cursor_per_lv_per_col[lv][ac] = 0;
     }
     adj_col_cursor_per_level[lv] = 0;
@@ -367,19 +213,8 @@ void DFSIterator::changeLevel(duckdb::ClientContext &context, bool traverse_chil
         // Skip adj list setup for terminal nodes (not in src_partition_ids_).
         // Their level entry exists but has no valid adj list data; the caller
         // will detect terminal and immediately call reduceLevel().
-        // Same LID→PID resolution as setupAdjListsForNode — synthetic LIDs
-        // (fresh-bootstrap CREATE) carry the prefix 0x7F00 in the top 16
-        // bits, which never matches any real partition id, so without
-        // resolving we'd mark every freshly-created node terminal and stop
-        // traversing after one hop.
         if (!src_partition_ids_.empty()) {
-            uint64_t resolved = src_id;
-            if (context.db) {
-                auto &ds = context.db->delta_store;
-                uint64_t pid = ds.ResolvePid(src_id);
-                if (pid != 0) resolved = pid;
-            }
-            uint16_t part = (uint16_t)(resolved >> 48);
+            uint16_t part = context.graph_storage_wrapper->getNodePartitionId(src_id);
             if (src_partition_ids_.count(part) == 0) {
                 return; // terminal — do not call setupAdjListsForNode
             }
@@ -439,24 +274,9 @@ void ShortestPathIterator::initialize(duckdb::ClientContext &context, NodeID src
 
 bool ShortestPathIterator::enqueueNeighbors(duckdb::ClientContext &context, NodeID node_id, Level node_level, std::queue<std::pair<NodeID, Level>>& queue) {
     uint64_t *start_ptr = nullptr, *end_ptr = nullptr;
-    // Same LID→PID resolution as DFSIterator / ShortestPathAdvancedIterator.
-    uint64_t resolved_node_pid = node_id;
-    if (context.db) {
-        auto &ds = context.db->delta_store;
-        uint64_t pid = ds.ResolvePid(node_id);
-        if (pid != 0) resolved_node_pid = pid;
-    }
-    ExtentID target_eid = resolved_node_pid >> 32;
-    uint64_t *base_start = nullptr;
-    uint64_t *base_end = nullptr;
-    if (!IsInMemoryExtent(target_eid)) {
-        bool is_initialized = adjlist_iterator->Initialize(context, adjColIdx, target_eid, true);
-        adjlist_iterator->getAdjListPtr(resolved_node_pid, target_eid, &base_start, &base_end, is_initialized);
-    }
-    uint16_t v_pid = (uint16_t)(target_eid >> 16);
-    MergeAdjListWithDelta(context, resolved_node_pid, (int)adjColIdx,
-        ExpandDirection::OUTGOING, v_pid, base_start, base_end,
-        delta_merge_buf, &start_ptr, &end_ptr);
+    context.graph_storage_wrapper->getAdjListFromVid(
+        *adjlist_iterator, (int)adjColIdx, prev_eid_, node_id,
+        start_ptr, end_ptr, ExpandDirection::OUTGOING, delta_merge_buf);
     if (start_ptr == nullptr) return true;
 
     for (uint64_t *ptr = start_ptr; ptr < end_ptr; ptr += 2) {
@@ -612,34 +432,16 @@ bool ShortestPathAdvancedIterator::enqueueNeighbors(duckdb::ClientContext &conte
         {adj_col_idx_bwd, false, adjlist_iterator_backward},
     };
 
-    // Resolve the LID to its physical_id before deriving an extent ID — see
-    // DFSIterator::setupAdjListsForNode for the same fix. Fresh-bootstrap
-    // nodes carry synthetic LIDs prefixed 0x7F00…; without resolution the
-    // shift produces a sentinel-shaped eid that fails IsInMemoryExtent's
-    // (eid & 0xFFFF) >= 0xFF00 test and the iterator dereferences a nullptr
-    // ExtentCatalogEntry on the disk path.
-    uint64_t resolved_node_pid = node_id;
-    if (context.db) {
-        auto &ds = context.db->delta_store;
-        uint64_t pid = ds.ResolvePid(node_id);
-        if (pid != 0) resolved_node_pid = pid;
-    }
     for (auto &scan : scans) {
         uint64_t *start_ptr = nullptr, *end_ptr = nullptr;
-        ExtentID target_eid = resolved_node_pid >> 32;
-        uint64_t *base_start = nullptr;
-        uint64_t *base_end = nullptr;
-        if (!IsInMemoryExtent(target_eid)) {
-            bool is_initialized = scan.iter->Initialize(context, scan.col_idx, target_eid, scan.is_fwd);
-            scan.iter->getAdjListPtr(resolved_node_pid, target_eid, &base_start, &base_end, is_initialized);
-        }
         ExpandDirection dir = scan.is_fwd ? ExpandDirection::OUTGOING
                                           : ExpandDirection::INCOMING;
-        uint16_t v_pid = (uint16_t)(target_eid >> 16);
         std::vector<uint64_t> &merge_buf =
             scan.is_fwd ? delta_merge_buf_fwd : delta_merge_buf_bwd;
-        MergeAdjListWithDelta(context, resolved_node_pid, (int)scan.col_idx,
-            dir, v_pid, base_start, base_end, merge_buf, &start_ptr, &end_ptr);
+        ExtentID &prev = scan.is_fwd ? prev_eid_fwd_ : prev_eid_bwd_;
+        context.graph_storage_wrapper->getAdjListFromVid(
+            *scan.iter, (int)scan.col_idx, prev, node_id,
+            start_ptr, end_ptr, dir, merge_buf);
         if (start_ptr == nullptr) continue;
 
         for (uint64_t *ptr = start_ptr; ptr < end_ptr; ptr += 2) {
@@ -800,30 +602,16 @@ bool AllShortestPathIterator::enqueueNeighbors(duckdb::ClientContext &context, N
         {adj_col_idx_bwd, false, adjlist_iterator_backward},
     };
 
-    // Same LID→PID resolution as DFSIterator / ShortestPathAdvancedIterator.
-    uint64_t resolved_current_pid = current_node;
-    if (context.db) {
-        auto &ds = context.db->delta_store;
-        uint64_t pid = ds.ResolvePid(current_node);
-        if (pid != 0) resolved_current_pid = pid;
-    }
     for (auto &dir : dirs) {
     uint64_t *start_ptr = nullptr, *end_ptr = nullptr;
-    ExtentID target_eid = resolved_current_pid >> 32;
-    uint64_t *base_start = nullptr;
-    uint64_t *base_end = nullptr;
-    if (!IsInMemoryExtent(target_eid)) {
-        bool is_initialized = dir.iter->Initialize(context, dir.col_idx, target_eid, dir.fwd);
-        dir.iter->getAdjListPtr(resolved_current_pid, target_eid, &base_start, &base_end, is_initialized);
-    }
     ExpandDirection expand_dir = dir.fwd ? ExpandDirection::OUTGOING
                                          : ExpandDirection::INCOMING;
-    uint16_t v_pid = (uint16_t)(target_eid >> 16);
     std::vector<uint64_t> &merge_buf =
         dir.fwd ? delta_merge_buf_fwd : delta_merge_buf_bwd;
-    MergeAdjListWithDelta(context, resolved_current_pid, (int)dir.col_idx,
-        expand_dir, v_pid, base_start, base_end, merge_buf,
-        &start_ptr, &end_ptr);
+    ExtentID &prev = dir.fwd ? prev_eid_fwd_ : prev_eid_bwd_;
+    context.graph_storage_wrapper->getAdjListFromVid(
+        *dir.iter, (int)dir.col_idx, prev, current_node,
+        start_ptr, end_ptr, expand_dir, merge_buf);
     if (start_ptr == nullptr) continue;
 
     for (uint64_t *ptr = start_ptr; ptr < end_ptr; ptr += 2) {

--- a/src/storage/graph_storage_wrapper.cpp
+++ b/src/storage/graph_storage_wrapper.cpp
@@ -782,7 +782,7 @@ uint16_t iTbgppGraphStorageWrapper::getNodePartitionId(uint64_t vid) {
 }
 
 StoreAPIResult
-iTbgppGraphStorageWrapper::getAdjListFromVid(AdjacencyListIterator &adj_iter, int adjColIdx, ExtentID &prev_eid, uint64_t vid, uint64_t *&start_ptr, uint64_t *&end_ptr, ExpandDirection expand_dir) {
+iTbgppGraphStorageWrapper::getAdjListFromVid(AdjacencyListIterator &adj_iter, int adjColIdx, ExtentID &prev_eid, uint64_t vid, uint64_t *&start_ptr, uint64_t *&end_ptr, ExpandDirection expand_dir, std::vector<uint64_t> &scratch_buf) {
 	D_ASSERT( expand_dir == ExpandDirection::OUTGOING || expand_dir == ExpandDirection::INCOMING );
 	bool is_initialized = true;
 	auto &delta_store = client.db->delta_store;
@@ -891,8 +891,7 @@ iTbgppGraphStorageWrapper::getAdjListFromVid(AdjacencyListIterator &adj_iter, in
 		return StoreAPIResult::OK;
 	}
 
-	std::lock_guard<std::mutex> guard(adj_merge_buf_mutex_);
-	auto &adj_merge_buf = default_scratch_.adj_merge_buf;
+	auto &adj_merge_buf = scratch_buf;
 	adj_merge_buf.resize(total * 2);
 	idx_t cursor = 0;
 	for (uint64_t *p = start_ptr; p && p < end_ptr; p += 2) {


### PR DESCRIPTION
## Summary
- `MATCH (a)-[:KNOWS*N..M]->(b)` (any `*N..M`, even `*1..1`) SEGV'd on CREATE-only data — VLE / ShortestPath iterators bypassed the storage wrapper and walked the extent catalog directly, so a checkpointed node with disk-PID 0 dereferenced a nullptr.
- AdjIdxJoin already routes through `graph_storage_wrapper.getAdjListFromVid`, which guards in-memory extents and merges the delta. The fix collapses DFSIterator / ShortestPath / ShortestPathAdvanced / AllShortestPath's four parallel adapters into the same wrapper call.
- Wrapper API gains a caller-owned `scratch_buf` so each iterator keeps its own per-(lv,ac) / per-direction merge buffer alive across nested recursion. Dropped `default_scratch_.adj_merge_buf` + its mutex. Net –180 lines (duplicated `ResolveAdjDeltaPartitionIdLocal` + `MergeAdjListWithDelta` deleted).

Closes #270.

Note: #236 (planner UNION ALL assertion on `varlen-decomp`) is a separate issue handled by PR #268 (SFG removal); not addressed here.

## Test plan
- [x] CREATE-only repro now returns the right row (was SEGV):
  - `CREATE (n:Person {id:1})` … `MATCH (a:Person {id:1})-[:KNOWS*2..2]->(b:Person) RETURN a.id, b.id;` → `(1, 3)`
- [x] Same repro across `*1..1`, `*2..2`, `*1..3` — all correct.
- [x] Unit tests: 223/223 (`./test/unittest`)
- [x] Fuzz oracle: 10/10 (`./test/fuzz/oracle/fuzz_oracle`)
- [x] Fuzz L2: 8/8 + 1 unrelated skip (`varlen-decomp [!mayfail]` — tracked in #236, handled by #268)
- [ ] LDBC `[ic5]` / `[ic13]` / `[ic14]` regression (read-only mount on the dev box blocked these — please verify on CI / a writable workspace)