### PR TITLE
fix(#236): UNION ALL + ORDER BY end-to-end (planner + executor wiring + dispatch)

### DIFF
--- a/src/execution/execution/cypher_pipeline_executor.cpp
+++ b/src/execution/execution/cypher_pipeline_executor.cpp
@@ -219,9 +219,18 @@ void CypherPipelineExecutor::ExecutePipeline()
         PrintOutputChunk(pipeline->GetSource()->ToString(), source_chunk);
 #endif
 		bool isSourceDataFinished = false;
-		switch (childs.size()) {
-			case 0: { isSourceDataFinished = !pipeline->GetSource()->IsSourceDataRemaining(*local_source_state); break; }
-			case 1: { isSourceDataFinished = !pipeline->GetSource()->IsSourceDataRemaining(*local_source_state, *(childs[0]->local_sink_state)); break; }
+		{
+			// Same dispatch rule as FetchFromSource — see #236.
+			auto *src = pipeline->GetSource();
+			bool non_leaf_source = src->IsSink();
+			if (non_leaf_source && !childs.empty()) {
+				isSourceDataFinished = !src->IsSourceDataRemaining(
+				    *local_source_state, *(childs[0]->local_sink_state));
+			}
+			else {
+				isSourceDataFinished = !src->IsSourceDataRemaining(
+				    *local_source_state);
+			}
 		}
 
 		if (source_chunk.size() > 0) {
@@ -308,20 +317,20 @@ void CypherPipelineExecutor::ExecutePipeline()
 void CypherPipelineExecutor::FetchFromSource(DataChunk &result)
 {
     StartOperator(pipeline->GetReprSource());
-    switch (childs.size()) {
-        // no child pipeline
-        case 0: {
-            pipeline->GetSource()->GetData(*context, result,
-                                           *local_source_state);
-            break;
-        }
-        // single child
-        case 1: {
-            pipeline->GetSource()->GetData(*context, result,
-                                           *local_source_state,
-                                           *(childs[0]->local_sink_state));
-            break;
-        }
+    // Dispatch by source-op shape, not by childs.size(). A multi-child
+    // pipeline (UNION ALL split asymmetrically between a Sort-sink branch
+    // and a plain branch — #236) can be wired with childs[0] populated
+    // for the Sort case while currently sourcing from a leaf op like
+    // NodeScan. Leaf sources (!IsSink) read from their own state; only
+    // non-leaf sources (Sort, HashAgg) read through a child sink_state.
+    auto *src = pipeline->GetSource();
+    bool non_leaf_source = src->IsSink();
+    if (non_leaf_source && !childs.empty()) {
+        src->GetData(*context, result, *local_source_state,
+                     *(childs[0]->local_sink_state));
+    }
+    else {
+        src->GetData(*context, result, *local_source_state);
     }
     EndOperator(pipeline->GetReprSource(), &result);
     pipeline->GetSource()->processed_tuples += result.size();

--- a/src/include/execution/cypher_pipeline.hpp
+++ b/src/include/execution/cypher_pipeline.hpp
@@ -118,6 +118,20 @@ public:
 		return pipeline_id;
 	}
 
+	// Enumerate every op that can appear at the source position. For a
+	// regular singleton pipeline this is just {GetSource()}. For a pipeline
+	// whose first group is multi-child (UNION ALL with asymmetric branches
+	// after a Sort/HashAgg break, etc.), AdvanceGroup flips the active
+	// child at runtime and GetSource() changes — every candidate must be
+	// considered when wiring child executors at build time.
+	void CollectAllPossibleSources(
+	    vector<CypherPhysicalOperator *> &out) const
+	{
+		out.clear();
+		if (operator_groups.groups.empty()) return;
+		CollectSourcesFromGroup(operator_groups.groups[0], out);
+	}
+
 	// members
 	int pipelineLength;
 	//! The unique pipeline id
@@ -126,6 +140,22 @@ public:
 	CypherPhysicalOperatorGroups operator_groups;
 	//! Representative pipeline
 	vector<CypherPhysicalOperator *> repr_operators;
+
+private:
+	static void CollectSourcesFromGroup(CypherPhysicalOperatorGroup *grp,
+	                                    vector<CypherPhysicalOperator *> &out)
+	{
+		if (!grp) return;
+		if (grp->IsSingleton()) {
+			out.push_back(grp->GetOp());
+			return;
+		}
+		for (auto &child_set : grp->childs) {
+			if (!child_set.empty()) {
+				CollectSourcesFromGroup(child_set.front(), out);
+			}
+		}
+	}
 };
 
 } // namespace turbolynx

--- a/src/include/execution/schema_flow_graph.hpp
+++ b/src/include/execution/schema_flow_graph.hpp
@@ -165,6 +165,13 @@ class SchemaFlowGraph {  // for each pipeline
 
     OperatorType GetOperatorType(idx_t operator_idx)
     {
+        // Placeholder SFGs (UNION ALL non-first children with suppressed
+        // generate_sfg) have empty metadata vectors. The pipeline executor
+        // overrides this to UNARY immediately anyway — answer accordingly
+        // instead of indexing into an empty vector.
+        if (!is_sfg_exists || operator_idx >= pipeline_operator_types.size()) {
+            return OperatorType::UNARY;
+        }
         if (pipeline_operator_types[operator_idx] == OperatorType::UNARY) {
             return OperatorType::UNARY;
         } else if (pipeline_operator_types[operator_idx] ==

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -623,7 +623,14 @@ vector<duckdb::CypherPipelineExecutor *> Planner::genPipelineExecutors()
 
     for (auto pipe_idx = 0; pipe_idx < pipelines.size(); pipe_idx++) {
         auto &pipe = pipelines[pipe_idx];
-        duckdb::SchemaFlowGraph *sfg = generate_sfg ? &sfgs[pipe_idx] : nullptr;
+        // Placeholder SFGs (UNION ALL non-first children) carry
+        // is_sfg_exists=false. Treat them the same as the legacy "no SFG"
+        // path so the executor uses the no-SFG constructor and downstream
+        // accessors that don't short-circuit on is_sfg_exists are never
+        // reached.
+        bool pipe_has_sfg = generate_sfg && pipe_idx < (int)sfgs.size() &&
+                            sfgs[pipe_idx].IsSFGExists();
+        duckdb::SchemaFlowGraph *sfg = pipe_has_sfg ? &sfgs[pipe_idx] : nullptr;
 
         // find children and deps - the child/dep ordering matters.
         // must run in ascending order of the vector
@@ -641,11 +648,21 @@ vector<duckdb::CypherPipelineExecutor *> Planner::genPipelineExecutors()
                 pipe->GetIdxOperator(op_idx - 1));
         }
 
-        // find children pipeline
+        // find children pipeline. A pipeline whose first group is
+        // multi-child (UNION ALL with an asymmetric branch — e.g. one
+        // branch breaks at a Sort sink and contributes only the Sort
+        // singleton, the other branch contributes a full chain) flips
+        // its source via AdvanceGroup at runtime, so GetSource() alone
+        // would miss the alternative-state child.
+        vector<duckdb::CypherPhysicalOperator *> candidate_sources;
+        pipe->CollectAllPossibleSources(candidate_sources);
         for (auto &ce : executors) {
             // connect SOURCE with previous SINK
-            if (pipe->GetSource() == ce->pipeline->GetSink()) {
-                child_executors.push_back(ce);
+            for (auto *src : candidate_sources) {
+                if (src == ce->pipeline->GetSink()) {
+                    child_executors.push_back(ce);
+                    break;
+                }
             }
         }
 
@@ -679,7 +696,7 @@ vector<duckdb::CypherPipelineExecutor *> Planner::genPipelineExecutors()
             }
         }
         duckdb::CypherPipelineExecutor *pipe_exec;
-        if (generate_sfg) {
+        if (pipe_has_sfg) {
             pipe_exec = new duckdb::CypherPipelineExecutor(
                 new_ctxt, pipe, *sfg, move(child_executors),
                 move(dep_executors));

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -7131,8 +7131,17 @@ void Planner::pGenerateColumnNames(CColRefArray *columns,
 void Planner::pGenerateSchemaFlowGraph(
     duckdb::CypherPhysicalOperatorGroups &final_pipeline_ops)
 {
-    if (!generate_sfg)
+    // Keep sfgs.size() == pipelines.size() invariant even when generate_sfg
+    // is suppressed (UNION ALL children with i>=1 set restrict_generate_sfg_
+    // for_unionall=true and generate_sfg=false). The caller always pushed a
+    // pipeline before this call; without a paired SFG, downstream
+    // genPipelineExecutors hit `pipelines.size() == sfgs.size()` (#236).
+    // The placeholder is_sfg_exists=false, so runtime code already
+    // short-circuits to the single-schema fallback.
+    if (!generate_sfg) {
+        sfgs.emplace_back();
         return;
+    }
     duckdb::SchemaFlowGraph sfg(final_pipeline_ops.size(),
                                 pipeline_operator_types, num_schemas_of_childs,
                                 pipeline_schemas, other_source_schemas,

--- a/test/fuzz/l2_metamorphic/fuzz_l2_main.cpp
+++ b/test/fuzz/l2_metamorphic/fuzz_l2_main.cpp
@@ -105,11 +105,8 @@ TEST_CASE("optional-not-null preserves multiset",
     run_rewriter(tl_fuzz_l2::optional_not_null_rewriter(), kDefaultSeed);
 }
 
-// `[*1..K]` decomposed via UNION ALL into per-length traversals trips a
-// planner assertion (`pipelines.size() == sfgs.size()` at planner.cpp:620).
-// Tracked in #236; combined form plans fine.
 TEST_CASE("varlen-decomp preserves multiset",
-          "[fuzz][l2][l2.varlen-decomp][!mayfail]") {
+          "[fuzz][l2][l2.varlen-decomp]") {
     run_rewriter(tl_fuzz_l2::varlen_decomp_rewriter(), kDefaultSeed);
 }
 


### PR DESCRIPTION
## Summary
`MATCH ... UNION ALL MATCH ... ORDER BY ...` was failing at three layers, all surfaced by the L2 metamorphic-fuzz `varlen-decomp` rewriter. This PR closes all three so the rewriter is no longer `!mayfail`.

### Layer 1 — planner assertion (the visible #236)
`pTransformEopUnionAll` toggles `generate_sfg=false` for every child after the first. `pipelines.push_back` stayed unconditional in HashAggregate / Sort / BinaryJoin transforms while `sfgs.push_back` was guarded, so the rhs branch grew pipelines without sfgs and `pipelines.size() == sfgs.size()` tripped at planner.cpp:621.

Fix: `pGenerateSchemaFlowGraph` emits a default `is_sfg_exists=false` placeholder when generate_sfg is suppressed. Invariant restored.

### Layer 2 — placeholder SFG indexed by GetOperatorType
Pipeline executor calls `sfg.GetOperatorType(idx)` which reads `pipeline_operator_types[idx]`. The placeholder has empty vectors → out-of-bounds.

Fix: `GetOperatorType` returns UNARY (which the executor overrides to UNARY anyway) when `!is_sfg_exists`. Executor also gates SFG selection on `IsSFGExists()` and routes placeholder pipelines through the no-SFG constructor.

### Layer 3 — multi-source pipeline wiring + leaf-vs-non-leaf dispatch
Sort/HashAgg pipeline breaks inside one UNION ALL branch (but not the other) leave an asymmetric union_group at the source position. `AdvanceGroup` flips the source between a leaf op (NodeScan from the unbroken branch) and the Sort sink (from the broken branch).
- Child-pipeline matching used only the build-time `GetSource()`, so the Sort branch had no `child_executors` and crashed at runtime when AdvanceGroup activated it.
- `FetchFromSource` dispatched 3-arg vs 4-arg `GetData` by `childs.size()`, so a leaf op with a (vestigial-for-this-branch) child got the 4-arg form and hit the "not a source!" default.

Fix:
- `CypherPipeline::CollectAllPossibleSources` enumerates every first-op across the source group's child sets; planner matches all of them when assembling `child_executors`.
- `FetchFromSource` / `IsSourceDataRemaining` dispatch on `src->IsSink()` instead — non-leaf sources (Sort, HashAgg) read through child sink_state; leaf sources (NodeScan, IdSeek, ConstScan) read from their own state regardless of `childs.size()`.

Closes #236.

## Verification
- [x] Repro from the issue body now returns the right sorted multiset:
  - `MATCH (a:Person)-[:ACTED_IN*1..1]->(b:Movie) RETURN a.id, b.id UNION ALL MATCH (a:Person)-[:ACTED_IN*2..2]->(b:Movie) RETURN a.id, b.id ORDER BY a.id, b.id` → executes cleanly.
- [x] Simple UNION ALL + ORDER BY returns the expected duplicated rows in sorted order.
- [x] Unit tests: 223/223 (`./test/unittest`)
- [x] Fuzz oracle: 10/10 + 1 unrelated skip (`l3.with-chain [!mayfail]` for #240, handled by PR #267)
- [x] Fuzz L2: **9/9 all green** — `varlen-decomp` `!mayfail` tag removed.