### PR TITLE
fix(#236): wire multi-source pipelines + leaf/non-leaf source dispatch (on top of #268)

### DIFF
--- a/src/execution/execution/cypher_pipeline_executor.cpp
+++ b/src/execution/execution/cypher_pipeline_executor.cpp
@@ -164,9 +164,18 @@ void CypherPipelineExecutor::ExecutePipeline()
         PrintOutputChunk(pipeline->GetSource()->ToString(), source_chunk);
 #endif
 		bool isSourceDataFinished = false;
-		switch (childs.size()) {
-			case 0: { isSourceDataFinished = !pipeline->GetSource()->IsSourceDataRemaining(*local_source_state); break; }
-			case 1: { isSourceDataFinished = !pipeline->GetSource()->IsSourceDataRemaining(*local_source_state, *(childs[0]->local_sink_state)); break; }
+		{
+			// Dispatch by source-op shape — see FetchFromSource for #236.
+			auto *src = pipeline->GetSource();
+			bool non_leaf_source = src->IsSink();
+			if (non_leaf_source && !childs.empty()) {
+				isSourceDataFinished = !src->IsSourceDataRemaining(
+				    *local_source_state, *(childs[0]->local_sink_state));
+			}
+			else {
+				isSourceDataFinished = !src->IsSourceDataRemaining(
+				    *local_source_state);
+			}
 		}
 
 		if (source_chunk.size() > 0) {
@@ -248,20 +257,20 @@ void CypherPipelineExecutor::ExecutePipeline()
 void CypherPipelineExecutor::FetchFromSource(DataChunk &result)
 {
     StartOperator(pipeline->GetReprSource());
-    switch (childs.size()) {
-        // no child pipeline
-        case 0: {
-            pipeline->GetSource()->GetData(*context, result,
-                                           *local_source_state);
-            break;
-        }
-        // single child
-        case 1: {
-            pipeline->GetSource()->GetData(*context, result,
-                                           *local_source_state,
-                                           *(childs[0]->local_sink_state));
-            break;
-        }
+    // Dispatch by source-op shape, not by childs.size(). A multi-child
+    // pipeline (UNION ALL split asymmetrically between a Sort-sink branch
+    // and a plain branch — #236) can be wired with childs[0] populated
+    // for the Sort case while currently sourcing from a leaf op like
+    // NodeScan. Leaf sources (!IsSink) read from their own state; only
+    // non-leaf sources (Sort, HashAgg) read through a child sink_state.
+    auto *src = pipeline->GetSource();
+    bool non_leaf_source = src->IsSink();
+    if (non_leaf_source && !childs.empty()) {
+        src->GetData(*context, result, *local_source_state,
+                     *(childs[0]->local_sink_state));
+    }
+    else {
+        src->GetData(*context, result, *local_source_state);
     }
     EndOperator(pipeline->GetReprSource(), &result);
     pipeline->GetSource()->processed_tuples += result.size();

--- a/src/execution/execution/cypher_pipeline_executor.cpp
+++ b/src/execution/execution/cypher_pipeline_executor.cpp
@@ -257,12 +257,10 @@ void CypherPipelineExecutor::ExecutePipeline()
 void CypherPipelineExecutor::FetchFromSource(DataChunk &result)
 {
     StartOperator(pipeline->GetReprSource());
-    // Dispatch by source-op shape, not by childs.size(). A multi-child
-    // pipeline (UNION ALL split asymmetrically between a Sort-sink branch
-    // and a plain branch — #236) can be wired with childs[0] populated
-    // for the Sort case while currently sourcing from a leaf op like
-    // NodeScan. Leaf sources (!IsSink) read from their own state; only
-    // non-leaf sources (Sort, HashAgg) read through a child sink_state.
+    // Dispatch by the current source's shape, not by childs.size():
+    // AdvanceGroup may flip an asymmetric pipeline between a leaf source
+    // and a non-leaf sink-source even while childs[0] stays populated
+    // for the latter (#236).
     auto *src = pipeline->GetSource();
     bool non_leaf_source = src->IsSink();
     if (non_leaf_source && !childs.empty()) {

--- a/src/include/execution/cypher_pipeline.hpp
+++ b/src/include/execution/cypher_pipeline.hpp
@@ -118,6 +118,21 @@ public:
 		return pipeline_id;
 	}
 
+	// Enumerate every op that can appear at the source position. For a
+	// regular singleton pipeline this is just {GetSource()}. For a pipeline
+	// whose first group is multi-child (UNION ALL with asymmetric branches
+	// — one breaks at a Sort/HashAgg sink and contributes only the sink op,
+	// the other contributes a full chain), AdvanceGroup flips the active
+	// child at runtime and GetSource() changes. Every candidate must be
+	// considered when wiring child executors at build time.
+	void CollectAllPossibleSources(
+	    vector<CypherPhysicalOperator *> &out) const
+	{
+		out.clear();
+		if (operator_groups.groups.empty()) return;
+		CollectSourcesFromGroup(operator_groups.groups[0], out);
+	}
+
 	// members
 	int pipelineLength;
 	//! The unique pipeline id
@@ -126,6 +141,22 @@ public:
 	CypherPhysicalOperatorGroups operator_groups;
 	//! Representative pipeline
 	vector<CypherPhysicalOperator *> repr_operators;
+
+private:
+	static void CollectSourcesFromGroup(CypherPhysicalOperatorGroup *grp,
+	                                    vector<CypherPhysicalOperator *> &out)
+	{
+		if (!grp) return;
+		if (grp->IsSingleton()) {
+			out.push_back(grp->GetOp());
+			return;
+		}
+		for (auto &child_set : grp->childs) {
+			if (!child_set.empty()) {
+				CollectSourcesFromGroup(child_set.front(), out);
+			}
+		}
+	}
 };
 
 } // namespace turbolynx

--- a/src/include/execution/cypher_pipeline.hpp
+++ b/src/include/execution/cypher_pipeline.hpp
@@ -118,13 +118,8 @@ public:
 		return pipeline_id;
 	}
 
-	// Enumerate every op that can appear at the source position. For a
-	// regular singleton pipeline this is just {GetSource()}. For a pipeline
-	// whose first group is multi-child (UNION ALL with asymmetric branches
-	// — one breaks at a Sort/HashAgg sink and contributes only the sink op,
-	// the other contributes a full chain), AdvanceGroup flips the active
-	// child at runtime and GetSource() changes. Every candidate must be
-	// considered when wiring child executors at build time.
+	// Every op that can occupy the source position across AdvanceGroup
+	// transitions (#236).
 	void CollectAllPossibleSources(
 	    vector<CypherPhysicalOperator *> &out) const
 	{

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -628,11 +628,20 @@ vector<duckdb::CypherPipelineExecutor *> Planner::genPipelineExecutors()
                 pipe->GetIdxOperator(op_idx - 1));
         }
 
-        // find children pipeline
+        // find children pipeline. A pipeline whose first group is
+        // multi-child (UNION ALL with an asymmetric branch — e.g. one
+        // branch breaks at a Sort sink and contributes only the Sort
+        // singleton, the other branch contributes a full chain) flips
+        // its source via AdvanceGroup at runtime, so GetSource() alone
+        // would miss the alternative-state child.
+        vector<duckdb::CypherPhysicalOperator *> candidate_sources;
+        pipe->CollectAllPossibleSources(candidate_sources);
         for (auto &ce : executors) {
-            // connect SOURCE with previous SINK
-            if (pipe->GetSource() == ce->pipeline->GetSink()) {
-                child_executors.push_back(ce);
+            for (auto *src : candidate_sources) {
+                if (src == ce->pipeline->GetSink()) {
+                    child_executors.push_back(ce);
+                    break;
+                }
             }
         }
 

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -628,12 +628,7 @@ vector<duckdb::CypherPipelineExecutor *> Planner::genPipelineExecutors()
                 pipe->GetIdxOperator(op_idx - 1));
         }
 
-        // find children pipeline. A pipeline whose first group is
-        // multi-child (UNION ALL with an asymmetric branch — e.g. one
-        // branch breaks at a Sort sink and contributes only the Sort
-        // singleton, the other branch contributes a full chain) flips
-        // its source via AdvanceGroup at runtime, so GetSource() alone
-        // would miss the alternative-state child.
+        // Match every possible source (AdvanceGroup may flip it at runtime).
         vector<duckdb::CypherPhysicalOperator *> candidate_sources;
         pipe->CollectAllPossibleSources(candidate_sources);
         for (auto &ce : executors) {

--- a/test/fuzz/l2_metamorphic/fuzz_l2_main.cpp
+++ b/test/fuzz/l2_metamorphic/fuzz_l2_main.cpp
@@ -105,9 +105,8 @@ TEST_CASE("optional-not-null preserves multiset",
     run_rewriter(tl_fuzz_l2::optional_not_null_rewriter(), kDefaultSeed);
 }
 
-// Multi-hop VLE on delta-store nodes SEGVs in PhysicalVarlenAdjIdxJoin (#236).
 TEST_CASE("varlen-decomp preserves multiset",
-          "[fuzz][l2][l2.varlen-decomp][!mayfail]") {
+          "[fuzz][l2][l2.varlen-decomp]") {
     run_rewriter(tl_fuzz_l2::varlen_decomp_rewriter(), kDefaultSeed);
 }
 


### PR DESCRIPTION
## Summary
Sits on top of #268 (SchemaFlowGraph removal). #268 already deletes the visible planner-side `pipelines.size() == sfgs.size()` assertion, but that assertion had been masking two real runtime bugs that surface as soon as the gate is gone:

1. UNION ALL where one branch breaks at a Sort/HashAgg sink and the other contributes a plain chain produces an asymmetric union_group at the final pipeline's source position. `AdvanceGroup` flips the active child at runtime, so the pipeline's source toggles between a leaf op (NodeScan from the unbroken branch) and the Sort sink op (from the broken branch). The executor wired `child_executors` using only the build-time `GetSource()`, so the Sort-source state had no child sink_state and `Sort::GetData` crashed.

2. `FetchFromSource` / `IsSourceDataRemaining` dispatched the 3-arg vs 4-arg variant by `childs.size()`. A leaf op (NodeScan) with a vestigial child (left over for the alternate Sort branch) hit the 4-arg base impl that throws "Calling GetData on a node that is not a source!".

## Fix
- `CypherPipeline::CollectAllPossibleSources` enumerates every first-op across the source group's child sets. Planner matches all of them when assembling `child_executors`.
- `FetchFromSource` / `IsSourceDataRemaining` dispatch on `src->IsSink()` — non-leaf sources (Sort, HashAgg) read through `childs[0]->local_sink_state`; leaf sources (NodeScan, IdSeek, ConstScan) read from their own state regardless of `childs.size()`.

Closes #236 once paired with #268.

## Verification
- [x] Repro from #236 — `MATCH (a:Person)-[:ACTED_IN*1..1]->(b:Movie) ... UNION ALL ... *2..2 ... ORDER BY ...` — executes cleanly.
- [x] Simple UNION ALL + ORDER BY returns duplicated rows in sorted order.
- [x] Unit tests: 223/223 (`./test/unittest`)
- [x] Fuzz oracle: 11/11 (l3.with-chain no longer skipped post-#267 cherry-pick on #268's base)
- [x] Fuzz L2: **9/9 — `varlen-decomp` `!mayfail` tag removed**

## Ordering
- Merge **#268 first**, then this PR.
- This branch is cut directly off `refactor-remove-sfg`; PR #271 (the earlier #236 PR on main) is superseded and should be closed.