### PR TITLE
fix(crud): grow seeded NDV vector for schema-evolved PS

### DIFF
--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -879,6 +879,21 @@ static void SeedPropertySchemaStatsFromSource(
         auto *dst_ndvs = target_ps->GetNDVs();
         if (src_ndvs && dst_ndvs) {
             *dst_ndvs = *src_ndvs;
+            // NDV vector layout: ndvs[0] = ID NDV, ndvs[1..N] = property
+            // NDVs (PS-local order). For label-evolved partitions source
+            // and target share the same schema width so the copy is
+            // sufficient; for schema-evolved PS (SET introduces a new
+            // property) target is wider by one column and the borrowed
+            // NDV vector leaves the new property's slot missing. Grow
+            // the vector to match the target schema; the new column's
+            // NDV is seeded to 1 (the single SET-evolving row carries
+            // one distinct value). Maintaining this NDV as more rows
+            // adopt the evolved schema is a separate concern.
+            auto *target_keys = target_ps->GetKeys();
+            size_t required = (target_keys ? target_keys->size() : 0) + 1;
+            if (dst_ndvs->size() < required) {
+                dst_ndvs->resize(required, 1);
+            }
         }
         target_ps->offset_infos = representative->offset_infos;
         target_ps->frequency_values = representative->frequency_values;


### PR DESCRIPTION
## What

\`SeedPropertySchemaStatsFromSource\` (added in \`01231db00\`, 2026-04-20) seeds a freshly created PS with the source partition's stats so ORCA does not mark it \`num_rows=0 / is_dummy_stats=true\`. The same helper is wired into both \`EnsureVertexPartitionForLabels\` (**label-evolved**: \`SET n:Label\`) and \`EnsureExactNodePropertySchema\` (**schema-evolved**: \`SET n.newProp = ...\`).

The NDV vector layout is PS-local:
- \`ndvs[0]\` = ID column NDV
- \`ndvs[1..N]\` = property NDVs, in PS schema order

For label-evolved targets the schema width matches the source, so the verbatim \`*dst = *src\` copy is sufficient. For schema-evolved targets the new PS is wider by exactly one property (the SET-introduced key); the copied vector has no slot for it. ORCA, asking \`GetNDV(target_ps, attno_of_new_prop)\` during the next \`MATCH ... RETURN n.<newProp>\` (which triggers \`RetrieveColStats\` in stats derivation), reads one element past the buffer. Release tolerated the OOB read; ASan flags it as \`heap-buffer-overflow\` and aborts.

## The fix

Resize the seeded NDV vector to \`property_count + 1\` (the +1 reserving the ID slot at index 0). New slots default to NDV=1 — the single row that triggered the schema evolution carries one distinct value for the new column. Label-evolved paths are unaffected: the widths match and the resize is a no-op.

15 lines, single function.

## Why this is the right shape

- The NDV layout invariant (\`size == property_count + 1\`) is restored, so existing \`GetNDV\` logic stays simple and contract-correct — no defensive bounds checks at the read site.
- Both \`SeedPropertySchemaStatsFromSource\` use cases (label-evolved, schema-evolved) end up with a size-consistent vector; the schema-evolved case was the implicit gap.

## Out of scope (follow-up)

How the new column's NDV should be **maintained** as more rows adopt the evolved schema — i.e. when subsequent SETs add the same property to other rows, when checkpoint recomputes statistics, when \`ANALYZE\`-equivalent paths re-derive distribution — is a separate design question. The current seed value (1) is correct only for the moment the schema-evolved PS is created. Tracked separately so the OOB / CI lane is unblocked first.

## Verification

- [x] \`./build-asan/test/query/query_test "SET new property creates schema-evolved node version"\` — passes (4 assertions).
- [x] \`./build-asan/test/query/query_test "[ldbc][crud]"\` — 147 / 147 cases, 439 assertions, no ASan reports.
- [ ] CI Sanitize lane confirms the \`[ldbc][crud]\` step turns green.

## Floor items still outstanding

Independent of this PR:
- \`[ldbc][robustness]\` \`property filter on edge\` (test_ldbc_robustness.cpp:1103) — pre-existing ASan-only SIGABRT, surfaced after #264 fixed the line-703 abort that was masking it.
- \`[ldbc][robustness]\` \`RETURN expression without alias\` (suite-only state pollution).

Both kept non-blocking via \`continue-on-error\` until their own PRs land.