### PR TITLE
ci: drop continue-on-error from [robustness] and [crud] ASan steps

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -345,14 +345,6 @@ jobs:
         run: ./build-sanitize/test/query/query_test "[ldbc][ic]" --ldbc-path /tmp/ldbc-mini-ws-asan
 
       - name: Run LDBC [robustness] under ASan
-        # `[robustness]` is fuzz-style — deliberately throws weird /
-        # deeply nested / overflowing queries at the system. ASan
-        # surfaces two latent bugs on it (deep ExpressionExecutor
-        # recursion's string_t lifetime, suite-only state pollution
-        # on RETURN-without-alias). Fixing those is tracked in
-        # follow-up PRs; until then keep this step non-blocking so
-        # the rest of the categories stay strict.
-        continue-on-error: true
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ./build-sanitize/test/query/query_test "[ldbc][robustness]" --ldbc-path /tmp/ldbc-mini-ws-asan
@@ -368,11 +360,6 @@ jobs:
         run: ./build-sanitize/test/query/query_test "[ldbc][func]" --ldbc-path /tmp/ldbc-mini-ws-asan
 
       - name: Run LDBC [crud] under ASan
-        # `SET new property creates schema-evolved node version`
-        # (test_ldbc_crud.cpp:2839) SIGABRTs under ASan — separate
-        # latent bug in the schema-evolution path. Tracked as a
-        # follow-up PR; keep non-blocking until it lands.
-        continue-on-error: true
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ./build-sanitize/test/query/query_test "[ldbc][crud]" --ldbc-path /tmp/ldbc-mini-ws-asan


### PR DESCRIPTION
## What

\`continue-on-error: true\` was set on the \`Run LDBC [robustness] under ASan\` and \`Run LDBC [crud] under ASan\` steps as placeholders for known floor items. All of those have landed:

| Floor item | Resolution |
|---|---|
| \`[robustness]\` deep ExpressionExecutor recursion (\`Deeply nested function calls\`) | PR #264 |
| \`[robustness]\` suite-only \`RETURN expression without alias\` | side-effect of #268 (SchemaFlowGraph removal) |
| \`[robustness]\` \`property filter on edge\` (test_ldbc_robustness.cpp:1103) | side-effect of #268 (SchemaFlowGraph removal) |
| \`[crud]\` \`SET new property creates schema-evolved node version\` | PR #273 |

Main HEAD's Sanitize lane (run 80476226115) is now green on every ASan step — robustness 245/245, crud 147/147.

This PR removes both \`continue-on-error\` flags so any future regression on either category blocks the PR.

## Verification

- [x] Local: full \`[ldbc][robustness]\` and \`[ldbc][crud]\` pass under \`build-asan/\`.
- [ ] CI on this branch: every Sanitize step green and reported as strict.

## Out of scope

LSan activation (\`detect_leaks=1\`) is tracked separately in #276.