### PR TITLE
docs + ci: dbpedia-mini in CI, JSON/CLI/Cypher doc refresh, fuzz + sanitizer testing notes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -211,6 +211,16 @@ jobs:
         # issue) and stays out of the failure count.
         run: ./build-portable/test/query/query_test "[ldbc][crud]" --ldbc-path /tmp/ldbc-mini-ws
 
+      - name: Run [bulkload][dbpedia-mini] regression
+        # Exercises the committed DBpedia mini fixture
+        # (test/data/dbpedia-mini/: ~576 nodes via JSONL + 3 edge types
+        # via CSV). Catches regressions in the schemaless JSON loader,
+        # multi-graphlet clustering, and CSV adjacency build that the
+        # LDBC / TPC-H fixtures don't reach. The bulkload test reads
+        # the data path through `--data-dir`; the fixture sits under
+        # `test/data/dbpedia-mini/` per `datasets.json::local_path`.
+        run: ./build-portable/test/bulkload/bulkload_test "[bulkload][dbpedia-mini]" --data-dir test/data
+
       - name: Build Python wheel
         run: bash tools/pythonpkg/scripts/build_wheel.sh build-portable
 
@@ -376,3 +386,11 @@ jobs:
         env:
           ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
         run: ./build-sanitize/test/query/query_test "[ldbc][crud]" --ldbc-path /tmp/ldbc-mini-ws-asan
+
+      - name: Run [bulkload][dbpedia-mini] under ASan
+        # Same regression as the portable lane, run under ASan so the
+        # schemaless JSON loader and multi-graphlet clustering paths
+        # are exercised under memory checking too.
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=0
+        run: ./build-sanitize/test/bulkload/bulkload_test "[bulkload][dbpedia-mini]" --data-dir test/data

--- a/docs/documentation/client-apis/cli/overview.md
+++ b/docs/documentation/client-apis/cli/overview.md
@@ -37,20 +37,21 @@ TurboLynx >>
 
 ## Shell Options
 
-| Flag | Short | Description |
-|---|---|---|
-| `--workspace <path>` | `-w` | Path to the database directory (required) |
-| `--query <string>` | `-q` | Execute a single query and exit (non-interactive) |
-| `--mode <name>` | `-m` | Set output format at startup (see [Output Formats](output-formats.md)) |
-| `--iterations <n>` | `-i` | Repeat each query N times (benchmarking) |
-| `--warmup` | | Discard the first iteration from timing statistics |
-| `--profile` | | Enable query profiling |
-| `--explain` | | Print the selected physical plan (no execution) |
-| `--compile-only` | `-c` | Parse and plan without executing |
-| `--standalone` | `-S` | Accepted for compatibility; currently has no effect in the native CLI |
-| `--log-level <level>` | `-L` | Logging verbosity (`trace`, `debug`, `info`, `warn`, `error`) |
+| Flag | Short | Long alias | Description |
+|---|---|---|---|
+| `--workspace <path>` | `-w` | `--ws` | Path to the database directory (required) |
+| `--query <string>` | `-q` | `--q` | Execute a single query and exit (non-interactive) |
+| `--query-file <path>` | `-f` | `--qf` | Execute every `;`-terminated query in a file in order, then exit |
+| `--mode <name>` | `-m` | | Set output format at startup (see [Output Formats](output-formats.md)) |
+| `--iterations <n>` | `-i` | | Repeat each query N times (benchmarking) |
+| `--warmup` | | | Discard the first iteration from timing statistics |
+| `--profile` | | | Enable query profiling |
+| `--explain` | | | Print the selected physical plan (no execution) |
+| `--compile-only` | `-c` | | Parse and plan without executing |
+| `--standalone` | `-S` | | Accepted for compatibility; currently has no effect in the native CLI |
+| `--log-level <level>` | `-L` | | Logging verbosity (`trace`, `debug`, `info`, `warn`, `error`) |
 
-> **Running a file of queries.** There is no `--query-file` flag yet. To execute a script of Cypher statements, start the shell and use the [`.read <file>`](dot-commands.md) dot command, which runs each statement in the file in order.
+> **Running a file of queries.** Use `--query-file <path>` (or `-f` / `--qf`) to feed the shell a script of `;`-terminated Cypher statements; each is executed in order and the shell exits when the file ends. The interactive [`.read <file>`](dot-commands.md) dot command does the same thing from inside an open session.
 >
 > **Toggling profile / explain at runtime.** `--profile` can be turned on and off inside an interactive session with [`.profile on`](dot-commands.md) / `.profile off`. Explain mode currently has no dot-command equivalent — to switch in and out of explain, restart the shell with or without `--explain`.
 

--- a/docs/documentation/client-apis/cli/overview.md
+++ b/docs/documentation/client-apis/cli/overview.md
@@ -51,10 +51,6 @@ TurboLynx >>
 | `--standalone` | `-S` | | Accepted for compatibility; currently has no effect in the native CLI |
 | `--log-level <level>` | `-L` | | Logging verbosity (`trace`, `debug`, `info`, `warn`, `error`) |
 
-> **Running a file of queries.** Use `--query-file <path>` (or `-f` / `--qf`) to feed the shell a script of `;`-terminated Cypher statements; each is executed in order and the shell exits when the file ends. The interactive [`.read <file>`](dot-commands.md) dot command does the same thing from inside an open session.
->
-> **Toggling profile / explain at runtime.** `--profile` can be turned on and off inside an interactive session with [`.profile on`](dot-commands.md) / `.profile off`. Explain mode currently has no dot-command equivalent — to switch in and out of explain, restart the shell with or without `--explain`.
-
 ### Join Order Options
 
 | Flag | Description |

--- a/docs/documentation/cypher/overview.md
+++ b/docs/documentation/cypher/overview.md
@@ -16,12 +16,12 @@ TurboLynx's query language is Cypher, as defined by the [openCypher](https://ope
 | `ORDER BY` | ✅ | Ascending / descending sort |
 | `LIMIT` | ✅ | Limit result count |
 | `SKIP` | ✅ | Skip N results |
-<<<<<<< HEAD
-| `CREATE` | 🚧 | Supported through the native mutation path used by the shell, C API, and Python API |
-| `SET` | 🚧 | Supported through the native mutation path used by the shell, C API, and Python API |
-| `DELETE` | 🚧 | Supported through the native mutation path used by the shell, C API, and Python API; `DETACH DELETE` is also available |
-| `MERGE` | 🚧 | Basic single-node `MERGE` is supported in the shell, C API, and Python API; advanced `MERGE` syntax is still partial |
-| `UNION` / `UNION ALL` | 🚧 | Single-query only; multi-query UNION pending |
+| `UNION` / `UNION ALL` | ✅ | Single- and multi-branch UNION (post-#236 fix) |
+| `CREATE` | ✅ | Nodes (single/multi-label) and edges through the mutation path shared by the shell, C API, and Python API |
+| `SET` | ✅ | Property updates and label widening (`SET n:Label`) |
+| `DELETE` / `DETACH DELETE` | ✅ | Node + edge delete; `DETACH DELETE` cascades incident edges |
+| `REMOVE` | ✅ | Property and label removal |
+| `MERGE` | 🚧 | Basic single-node `MERGE` only; full pattern `MERGE` (paths, ON MATCH / ON CREATE) is not implemented |
 
 > **Write queries (CRUD).** `CREATE`, `SET`, `DELETE`, `DETACH DELETE`, `REMOVE`, and basic node `MERGE` execute through the native mutation path shared by the shell, C API, and Python API. Mutation queries print an acknowledgment instead of a rowset, so inspect the updated graph with a follow-up `MATCH` query. Node.js and MCP remain read-only. See [`test/query/test_ldbc_crud.cpp`](https://github.com/turbolynx-dslab/TurboLynx/blob/main/test/query/test_ldbc_crud.cpp), [`test/query/test_ldbc_robustness.cpp`](https://github.com/turbolynx-dslab/TurboLynx/blob/main/test/query/test_ldbc_robustness.cpp), and [`test/bulkload/test_smoke_cli.cpp`](https://github.com/turbolynx-dslab/TurboLynx/blob/main/test/bulkload/test_smoke_cli.cpp) for coverage.
 

--- a/docs/documentation/cypher/overview.md
+++ b/docs/documentation/cypher/overview.md
@@ -63,6 +63,24 @@ RETURN count(friend)
 | IS NULL / IS NOT NULL | `WHERE n.email IS NOT NULL` |
 | CASE expression | `CASE WHEN ... THEN ... ELSE ... END` |
 
+## Pattern Comprehension
+
+A pattern comprehension `[(a)-[r]->(b) WHERE … | <expr>]` evaluates a path pattern against the current row's bindings and projects an expression per match, returning a list. Same shape as Cypher 5 pattern comprehensions.
+
+```cypher
+-- For each Person, collect the firstNames of their friends
+MATCH (p:Person)
+RETURN p.firstName,
+       [(p)-[:KNOWS]->(f:Person) | f.firstName] AS friends;
+
+-- Project a computed value instead of a property
+MATCH (p:Person)
+RETURN p.firstName,
+       [(p)-[:KNOWS]->(f:Person) | f.firstName + ' (' + toString(f.age) + ')'] AS friend_labels;
+```
+
+Path-function comprehensions (`length(p)`, `nodes(p)`, `relationships(p)`) are supported alongside scalar projections.
+
 ## Variable-Length Paths
 
 ```cypher

--- a/docs/documentation/data-import/formats.md
+++ b/docs/documentation/data-import/formats.md
@@ -219,32 +219,40 @@ The backward file is the same data with the ID columns swapped and the rows re-s
 
 ## JSON
 
-TurboLynx parses graph JSON files with [simdjson](https://github.com/simdjson/simdjson).
+TurboLynx parses graph JSON files with [simdjson](https://github.com/simdjson/simdjson). The format is **Neo4j-dump JSONL** — newline-delimited JSON, one object per line, no outer array or wrapper. Only **vertex** files are supported; edges are CSV.
 
-### Top-level structure
+### Per-line structure
 
-A JSON file must be a single object with either a `"vertices"` key (for vertex files) or an `"edges"` key (for edge files), whose value is an array of objects.
-
-**Vertex file:**
+Each line is a single object with two top-level fields:
 
 ```json
-{
-  "vertices": [
-    { "id": 1, "firstName": "Alice", "lastName": "Smith", "age": 30 },
-    { "id": 2, "firstName": "Bob",   "lastName": "Jones", "age": 25 }
-  ]
-}
+{ "labels": ["<label>", "..."], "properties": { "<key>": <value>, ... } }
 ```
 
-**Edge file:**
+- `labels` — non-empty array of strings. The first entry is the vertex label; additional entries are extra labels stored on the node (Neo4j convention).
+- `properties` — object whose keys become property names and whose values become property values. Property keys may be arbitrary strings (including URIs); TurboLynx infers per-key types across the file and stores them in a property schema. Each property may appear or be absent independently across lines (schemaless).
 
-```json
-{
-  "edges": [
-    { "src": 1, "dst": 2, "since": 2020 }
-  ]
-}
+### Example — `person.json`
+
+```jsonl
+{"labels":["Person"],"properties":{"id":1,"firstName":"Alice","lastName":"Smith","age":30,"score":9.5,"joined":"2022-01-15","active":true}}
+{"labels":["Person"],"properties":{"id":2,"firstName":"Bob","lastName":"Jones","age":25,"joined":"2023-06-01","active":false}}
+{"labels":["Person","Employee"],"properties":{"id":3,"firstName":"Carol","email":"carol@example.com","tags":["admin","reviewer"]}}
 ```
+
+Notes on this example:
+- Row 2 omits `score`, row 3 omits `age`/`lastName` — missing properties materialize as NULL in the column.
+- Row 3 carries two labels (`Person` and `Employee`); both are registered on the node.
+- Row 3's `tags` is a JSON array — stored as a LIST column.
+
+### Example — DBpedia (real fixture under `test/data/dbpedia-mini/nodes.json`)
+
+```jsonl
+{"labels":["NODE"],"properties":{"http://dbpedia.org/ontology/abstract":"Laurie Halse Anderson (born October 23, 1961) is an American writer …","http://dbpedia.org/ontology/birthDate":-258508800000,"http://dbpedia.org/property/name":"Laurie Beth Halse Anderson","http://www.w3.org/2000/01/rdf-schema#label":"Laurie Halse Anderson","id":1560,"uri":"http://dbpedia.org/resource/Laurie_Halse_Anderson"}}
+{"labels":["NODE"],"properties":{"http://dbpedia.org/property/name":"Karen Hesse","id":1561,"uri":"http://dbpedia.org/resource/Karen_Hesse"}}
+```
+
+Property keys can be full URIs (RDF data) — TurboLynx treats them as opaque strings.
 
 ### Supported JSON value types
 
@@ -254,8 +262,9 @@ A JSON file must be a single object with either a `"vertices"` key (for vertex f
 | `integer` | INTEGER / BIGINT / UBIGINT |
 | `number` (float) | FLOAT / DOUBLE |
 | `string` | VARCHAR |
+| `array` | LIST of the element type |
 
-> **Note:** `DECIMAL` is not supported in the JSON path.
+> **Note:** `DECIMAL` is not supported in the JSON path. Edge files must be CSV; there is no edge JSON path today.
 
 ### Parser flags
 

--- a/docs/documentation/data-import/import-tool.md
+++ b/docs/documentation/data-import/import-tool.md
@@ -103,7 +103,9 @@ After a successful import, the workspace directory contains:
 |---|---|
 | `store.db` | Main data store (vertex extents, edge adjacency lists, properties) |
 | `catalog.bin` | Schema catalog (vertex labels, edge types, property schemas) |
-| `store.db.meta` | Chunk metadata index |
+| `catalog_version` | Catalog version counter (incremented on each `SaveCatalog`) |
+
+After mutations and the first checkpoint, the workspace gains a `.store_meta` chunk index and (when the WAL is non-empty) a `delta.wal` plus `logical_mappings.bin`.
 
 ---
 

--- a/docs/documentation/development/testing.md
+++ b/docs/documentation/development/testing.md
@@ -120,8 +120,75 @@ ctest --test-dir build-bulkload -L bulkload
 | LDBC SF1 | `[ldbc][sf1]` | 8 labels, ~3.1M vertices | 23 types, all counts verified | — | ✅ |
 | TPC-H SF1 | `[tpch][sf1]` | 7 labels, ~7.9M vertices | 8 types, all counts verified | — | ✅ |
 | DBpedia | `[dbpedia]` | 1 label (NODE), ~77M vertices | 32 types (selected) | `skip_histogram: true` | ✅ |
+| DBpedia mini (committed fixture) | `[bulkload][dbpedia-mini]` | ~576 NODE vertices | 3 edge types | Committed at `test/data/dbpedia-mini/`; CI default | ✅ |
 
 Larger scale factors (LDBC SF10, SF100; TPC-H SF10) are not wired as automated CTest entries due to multi-hour load times. They can be run manually via `bulkload_test` with an appropriate `--data-dir`.
+
+The DBpedia mini fixture is the only bulkload regression that runs in CI by default — it ships with the repo (no `--download` needed) and exercises the schemaless JSONL loader plus three CSV edge types end-to-end. Run locally with:
+
+```bash
+./build-portable/test/bulkload/bulkload_test "[bulkload][dbpedia-mini]" --data-dir test/data
+```
+
+---
+
+## Fuzz Tests
+
+Multi-layer fuzz harness (PR #242) lives under `test/fuzz/`. 35 tests across four layers, each with its own oracle and dependency set. All four are CMake-gated so default builds skip them.
+
+| Layer | Binary | Tag | Oracle | External deps | CMake gate |
+|---|---|---|---|---|---|
+| **L1** crash / sanitizer | `fuzz_l1` | `[fuzz][l1]` | none — a crash *is* the verdict | clang + libFuzzer + ASAN/UBSAN | `BUILD_FUZZ_L1=ON` |
+| **L2** metamorphic | `fuzz_l2` | `[fuzz][l2]` | self (`T(Q) == T(rewrite(Q))`) | none | `BUILD_FUZZ_L2=ON` |
+| **L3** differential vs Neo4j | `fuzz_oracle` | `[fuzz][l3]` | Neo4j 5.24 via `cypher-shell` | Java 17 + Neo4j tarball | `BUILD_FUZZ_ORACLE=ON` |
+| **L4** stateful CRUD | `fuzz_oracle` | `[fuzz][l4]` | Neo4j + internal `FuzzModel` invariants | Java 17 + Neo4j tarball | `BUILD_FUZZ_ORACLE=ON` |
+
+`BUILD_FUZZ_TESTS=ON` turns all three binaries on. Default OFF — no Java/clang/fuzz toolchain is needed for `unittest` and `query_test`.
+
+The first batch of fuzz-found bugs (#236 UNION ALL planner, #238 multi-label CREATE, #240 multi-WITH drops rows, #270 VLE/SP CREATE-only SEGV) are all closed and the harness runs skip-free in CI.
+
+### Run
+
+```bash
+# Configure with fuzz enabled
+cmake -GNinja \
+      -DBUILD_FUZZ_TESTS=ON \
+      -B build-fuzz
+cmake --build build-fuzz
+
+# Per binary
+./build-fuzz/test/fuzz/l1_crash/fuzz_l1 -max_total_time=300
+./build-fuzz/test/fuzz/l2_metamorphic/fuzz_l2 "[fuzz][l2]"
+./build-fuzz/test/fuzz/oracle/fuzz_oracle "[fuzz][l4]" --seed 42 --ops 1000
+
+# All under ctest
+ctest --test-dir build-fuzz -L fuzz --output-on-failure
+```
+
+The CI gates wire the same binaries under PR-level latency budgets (~80 s total). See `PLAN.md` for layer-by-layer detail and the bug-class → layer coverage map.
+
+---
+
+## Sanitizer Lane (CI)
+
+`.github/workflows/build-test.yml` runs a second job, `build-sanitize`, on every PR: a **Debug + ASan** build that re-runs `unittest`, `[types]`, `[tpch]`, and every LDBC suite under `-fsanitize=address`. It is blocking — any new ASan finding holds the PR.
+
+```bash
+cmake -GNinja \
+      -DCMAKE_BUILD_TYPE=Debug \
+      -DENABLE_SANITIZER=ON \
+      -DENABLE_TCMALLOC=OFF \
+      -DBUILD_UNITTESTS=ON \
+      -DTURBOLYNX_LDBC_FIXTURE_MINI=ON \
+      -DTURBOLYNX_TPCH_FIXTURE_MINI=ON \
+      -B build-sanitize
+cmake --build build-sanitize
+
+ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:detect_leaks=0 \
+    ctest --test-dir build-sanitize --output-on-failure
+```
+
+`detect_leaks=0` is temporary while ORCA's `CMemoryPool` teardown leaks get a suppressions file; promoting to `detect_leaks=1` is tracked in #276. UBSan is intentionally off — ORCA has known pre-existing UB patterns that would dominate the signal.
 
 ---
 


### PR DESCRIPTION
Follow-up to #280 — the 5 commits that didn't make it into that merge.

## What's in here
- **CI**: \`bulkload_test [bulkload][dbpedia-mini]\` on both the portable Release and the ASan Debug lanes. Exercises the schemaless JSONL loader + 3 CSV edge types end-to-end, which LDBC/TPC-H don't reach.
- **docs/cypher/overview.md**: resolve a stray \`<<<<<<< HEAD\` conflict marker, refresh the clause-support matrix (CREATE / SET / DELETE / REMOVE / UNION ✅, MERGE 🚧 only basic single-node), add a Pattern Comprehension section.
- **docs/data-import/formats.md**: correct the JSON section — the actual format is Neo4j-dump JSONL (\`{"labels":[...], "properties":{...}}\` per line, vertex-only), not \`{"vertices": [...]}\` / \`{"edges": [...]}\`. Examples expanded.
- **docs/data-import/import-tool.md**: drop the non-existent \`store.db.meta\` from the post-import file list; add \`catalog_version\` and note when \`.store_meta\` / \`delta.wal\` / \`logical_mappings.bin\` appear.
- **docs/client-apis/cli/overview.md**: document the \`--ws\` / \`--q\` / \`--qf\` long aliases that were missing from the table, and the \`--query-file\` flag the page previously said didn't exist. Trim two redundant option-side notes per review.
- **docs/development/testing.md**: add a Fuzz Tests section (L1 / L2 / L3 / L4, PR #242) and a Sanitizer Lane section describing the blocking \`build-sanitize\` CI job (#260/#263). Bulkload table picks up the committed dbpedia-mini fixture row.

## Test plan
- [x] Local \`bulkload_test [bulkload][dbpedia-mini] --data-dir test/data\` passes
- [x] Local repros of the 6 cypher overview examples + the new pattern-comp examples all return rows
- [ ] CI green on this PR