### PR TITLE
fix(execution): IC12 SIGSEGV — gate VLE zero-hop emit on dst-pattern label

### DIFF
--- a/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
+++ b/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
@@ -357,22 +357,30 @@ uint64_t PhysicalVarlenAdjIdxJoin::VarlengthExpand_internal(ExecutionContext& co
 		}
 		state.dfs_it->initialize(*context.client, src_vid, state.adj_col_idxs, adj_col_is_fwds, state.src_partition_ids);
 		if (state.cur_lv >= state.start_lv) {
-			// Cypher zero-length VLE: emit the source vertex itself
-			// unconditionally. The dst-pattern label predicate is
-			// applied by the plan-level filter above us, so guards
-			// on `src_is_terminal` / `dst_partition_ids` (which
-			// reflect edge-schema terminal partitions, not vertex
-			// patterns) only dropped valid rows (#35).
-			addNewPathToOutput(tgt_adj_column, eid_adj_column,
-			                   state.output_idx + num_found_paths,
-			                   state.current_path, src_vid, 0);
-			if (path_col_idx >= 0) {
-				writePathColumnForRow(chunk,
-				                      state.output_idx + num_found_paths,
-				                      src_vid, state.current_path,
-				                      state.current_path_vid);
+			// Cypher zero-length VLE: the source vertex itself is the
+			// length-0 binding only if it also matches the dst vertex
+			// pattern. dst_partition_ids here is the dst pattern's
+			// vertex partitions (set in cypher2orca_converter from
+			// n.GetPartitionIDs(), not the edge schema terminals).
+			// Without this guard, IC12's `(tag:Tag)-[..*0..]->(c:TagClass)`
+			// emits the Tag vid into the c column, after which IdSeek
+			// reads it under the TagClass schema and dereferences
+			// garbage string_t buffers (SEGV at string_t::VerifyNull).
+			uint16_t resolved_src_partition = (uint16_t)(src_vid >> 48);
+			bool zero_hop_dst_ok = dst_partition_ids.empty() ||
+			                       dst_partition_ids.count(resolved_src_partition) > 0;
+			if (zero_hop_dst_ok) {
+				addNewPathToOutput(tgt_adj_column, eid_adj_column,
+				                   state.output_idx + num_found_paths,
+				                   state.current_path, src_vid, 0);
+				if (path_col_idx >= 0) {
+					writePathColumnForRow(chunk,
+					                      state.output_idx + num_found_paths,
+					                      src_vid, state.current_path,
+					                      state.current_path_vid);
+				}
+				if (++num_found_paths == remaining_output) return num_found_paths;
 			}
-			if (++num_found_paths == remaining_output) return num_found_paths;
 		}
 	}
 

--- a/test/query/test_ldbc_ic_correctness.cpp
+++ b/test/query/test_ldbc_ic_correctness.cpp
@@ -743,7 +743,6 @@ TEST_CASE("IC11 job referral", "[ldbc][ic][ic11]") {
 //        multi-hop MATCH, tag.id IN list, ORDER BY DESC/ASC.
 TEST_CASE("IC12 trending posts", "[ldbc][ic][ic12]") {
     SKIP_IF_NO_DB();
-    try {
     auto q = std::string("MATCH (tag:Tag)-[:HAS_TYPE|IS_SUBCLASS_OF*0..]->(baseTagClass:TagClass) "
         "WHERE tag.name = '") + ldbc::IC12_BASE_TAGCLASS + "' OR baseTagClass.name = '" + ldbc::IC12_BASE_TAGCLASS + "' "
         "WITH collect(tag.id) as tags "
@@ -778,10 +777,6 @@ TEST_CASE("IC12 trending posts", "[ldbc][ic][ic12]") {
         } else {
             CHECK(r[i].int64_at(4) < r[i-1].int64_at(4));
         }
-    }
-
-    } catch (const std::exception &e) {
-        WARN("IC12: " << e.what());
     }
 }
 


### PR DESCRIPTION
## What

\`[ldbc][ic]\` step's \`IC12 trending posts\` was reporting "pass" in CI while the underlying query was SEGV'ing every run. The test wrapped its body in \`try { ... } catch (std::exception&) { WARN(...) }\` and the C API's SignalShield converts the SEGV into an exception, so the wrapper swallowed the failure silently — REQUIRE / CHECK assertions never ran. Visible on every main HEAD CI run since 2026-03-21 (\`2d708f7ed\`, when the test was first added).

## Root cause

The SEGV was inside ORCA-evaluated filter on the multi-hop part of IC12:

\`\`\`
PhysicalIdSeek::doSeekColumnar
  → ExpressionExecutor::SelectExpression / Select(BoundComparisonExpression)
  → Vector::Verify
  → string_t::VerifyNull (string_type.cpp:38)  ← SEGV on garbage pointer
\`\`\`

Bisecting IC12's pattern narrowed it to:

\`\`\`cypher
MATCH (tag:Tag)-[:HAS_TYPE|IS_SUBCLASS_OF*0..]->(c:TagClass)
WHERE c.name = '...'
\`\`\`

The \`*0..\` zero-hop binding emits the source vid into the dst column. The src and dst patterns have **different vertex labels** (Tag vs TagClass), so the Tag vid gets pushed into the c column slot. The next \`PhysicalIdSeek\` then reads that vid under the TagClass PropertySchema layout, returning garbage string_t buffers; the first filter that dereferences \`c.name\` SEGVs.

The unconditional zero-hop emit was introduced by \`c1aea194c\` (#35) to fix IS6 where the previous guard was wrong, but the reasoning there only held because IS6's src vid happened to live in the dst pattern's partition set. For IC12's cross-label case it doesn't.

## Fix

Re-introduce the dst-vertex-pattern partition check, but only for the zero-hop emit (line 359 of \`physical_varlen_adjidxjoin.cpp\`). The N≥1 path already uses the same \`dst_partition_ids\` check at line 450 — same data, same comparison. \`dst_partition_ids\` is populated in \`cypher2orca_converter\` from \`n.GetPartitionIDs()\` (the dst vertex pattern's vertex partitions), not from the edge schema's terminal partitions as #35's commit message described, so the guard does what it's named to do.

Second commit drops the IC12-only \`try/catch + WARN\` wrapper that had been masking the SEGV. With the fix in place IC12's 21 REQUIRE/CHECK assertions all run and all pass; the wrapper would now only hide future regressions.

## Verification

Container build (Linux, Debug + ASan) against \`test/data/ldbc-mini\`:

- \`[ldbc][ic]\` — **16/16, 738 assertions** (was 16/16, 717 assertions — the 21 new asserts are IC12's own REQUIRE/CHECK that now actually run).
- \`[ldbc][is]\` — 7/7, 121 assertions. IS6 is the original reproducer for #35; no regression.
- \`[ldbc][count]\` 30/30, \`[ldbc][traversal]\` 50/50, \`[ldbc][filter]\` 141/141, \`[ldbc][func]\` 17/17, \`[ldbc][robustness]\` 245/245.
- Bisect probes (cross-label \`*0..\` patterns) no longer SEGV in \`build-ubuntu-asan/tools/turbolynx shell\`.

## Out of scope

- IC10 / IC11 carry the same \`try/catch + WARN\` wrapper pattern, but they are gated SF1-only by \`#ifndef TURBOLYNX_LDBC_FIXTURE_MINI\` (issue #79) — never present in the mini binary that CI runs, so no silent-pass impact on CI. They get cleaned up alongside the broader #79 SF1-enablement work.
- The other 20 robustness queries that #79 lists also stay \`#ifndef\`'d. The fix here may incidentally re-enable some of them (same VLE pattern category) — a follow-up will probe and remove the gates where safe.

## References

- #35 — original "emit zero-length VLE path unconditionally" fix (\`c1aea194c\`)
- #79 — Multiple robustness queries SIGSEGV on SF0.003 mini fixture
- IC12 test wrapper introduced in \`2d708f7ed\` (2026-03-21)