### PR TITLE
test(ic): enable IC10 + IC11 on the mini fixture

### DIFF
--- a/test/query/helpers/ldbc_expected_counts.hpp
+++ b/test/query/helpers/ldbc_expected_counts.hpp
@@ -434,6 +434,55 @@ inline constexpr int64_t     IC12_LAST_PERSON_ID   = 15393162788877LL;
 inline constexpr const char* IC12_LAST_FIRST_NAME  = "Mehmet";
 inline constexpr int64_t     IC12_LAST_REPLY_COUNT = 1;
 
+// IC10 — Anchor = Ali; (city:City) relaxed to (city:Place) because the
+// mini fixture does not split Place into City/Country sub-labels.
+// Birthday window: Nov 21–Dec 21 returns 3 Ali friends on SF0.003.
+// Neo4j-verified, ORDER BY commonInterestScore DESC, toInteger(personId) ASC.
+inline constexpr int64_t IC10_ANCHOR_PERSON_ID = IC1_ANCHOR_PERSON_ID;
+inline constexpr int64_t IC10_NUM_ROWS         = 3;
+struct IcCityScore {
+    int64_t     person_id;
+    const char* first_name;
+    const char* last_name;
+    int64_t     common_interest_score;
+    const char* gender;
+    const char* city_name;
+};
+inline constexpr IcCityScore IC10_RESULTS[] = {
+    {17592186044443LL, "Wojciech",  "Ciesla",     0, "male",   "Katowice"},
+    {13194139533355LL, "Rahul",     "Khan",      -5, "female", "Tiruchirappalli"},
+    { 6597069766702LL, "Alejandro", "Garcia",  -315, "male",   "Chapingo"},
+};
+
+// IC11 — Anchor = Ali; country relaxed to (:Place) (mini fixture does
+// not split Place into Country sub-label). SF1 anchor + 'Laos' yields
+// 0 rows on mini; 'Mexico' is the largest hit and returns 9 rows. The
+// SF1 (:Company) anonymous pattern is widened to (:Organisation) for
+// the same reason.
+// Neo4j-verified, ORDER BY workFrom ASC, toInteger(personId) ASC,
+//                            organizationName DESC.
+inline constexpr int64_t     IC11_ANCHOR_PERSON_ID = IC1_ANCHOR_PERSON_ID;
+inline constexpr const char* IC11_COUNTRY          = "Mexico";
+inline constexpr int64_t     IC11_NUM_ROWS         = 9;
+struct IcJobReferral {
+    int64_t     person_id;
+    const char* first_name;
+    const char* last_name;
+    const char* organization_name;
+    int64_t     work_from_year;
+};
+inline constexpr IcJobReferral IC11_RESULTS[] = {
+    {              32, "Miguel",    "Gonzalez", "Avolar",                       2002},
+    {              32, "Miguel",    "Gonzalez", "Mexicana_de_Aviación",         2003},
+    {              32, "Miguel",    "Gonzalez", "MexicanaLink",                 2003},
+    {              32, "Miguel",    "Gonzalez", "Interjet",                     2003},
+    {              32, "Miguel",    "Gonzalez", "AeroUnion",                    2004},
+    { 6597069766702LL, "Alejandro", "Garcia",   "Aero_California",              2005},
+    { 6597069766702LL, "Alejandro", "Garcia",   "Aladia_Airlines",              2006},
+    { 6597069766702LL, "Alejandro", "Garcia",   "Aeropostal_Cargo_de_México",   2006},
+    { 6597069766702LL, "Alejandro", "Garcia",   "Aeromar",                      2006},
+};
+
 // IC13 — shortestPath((p1)-[:KNOWS*]-(p2)). Endpoints chosen so Ali
 // (= IC anchor, most connected) reaches SAMPLE_PERSON_ID (= 14, Hossein)
 // in 2 KNOWS hops. allShortestPaths-style enumeration is bounded by

--- a/test/query/test_ldbc_ic_correctness.cpp
+++ b/test/query/test_ldbc_ic_correctness.cpp
@@ -636,8 +636,6 @@ TEST_CASE("IC9 recent messages by friends", "[ldbc][ic][ic9]") {
 // IC10–IC11 below stay SF1-only — they need :City / :Country / :Company
 // sub-labels (mini load script does not tag these) and additional date
 // function support. Each becomes mini-ready in a follow-up PR.
-#ifndef TURBOLYNX_LDBC_FIXTURE_MINI
-
 // IC10 — friend recommendation
 // Tests: KNOWS*2..2, NOT pattern expression (anti-edge check),
 //        datetime({epochMillis:}), .month/.day temporal property,
@@ -645,10 +643,15 @@ TEST_CASE("IC9 recent messages by friends", "[ldbc][ic][ic9]") {
 //        OPTIONAL MATCH + collect, arithmetic in RETURN
 TEST_CASE("IC10 friend recommendation", "[ldbc][ic][ic10]") {
     SKIP_IF_NO_DB();
-    try {
-    auto r = qr->run(
-        "MATCH (person:Person {id: 30786325583618})-[:KNOWS*2..2]-(friend), "
-        "      (friend)-[:IS_LOCATED_IN]->(city:City) "
+#ifdef TURBOLYNX_LDBC_FIXTURE_MINI
+    const char* city_label = "Place";  // mini fixture does not split Place
+#else
+    const char* city_label = "City";
+#endif
+    auto q = std::string("MATCH (person:Person {id: ") +
+        std::to_string(ldbc::IC10_ANCHOR_PERSON_ID) +
+        "})-[:KNOWS*2..2]-(friend), "
+        "      (friend)-[:IS_LOCATED_IN]->(city:" + city_label + ") "
         "WHERE NOT friend=person AND "
         "      NOT (friend)-[:KNOWS]-(person) "
         "WITH person, city, friend, datetime({epochMillis: friend.birthday}) AS birthday "
@@ -667,23 +670,21 @@ TEST_CASE("IC10 friend recommendation", "[ldbc][ic][ic10]") {
         "       commonPostCount - (postCount - commonPostCount) AS commonInterestScore, "
         "       friend.gender AS personGender, "
         "       city.name AS personCityName "
-        "ORDER BY commonInterestScore DESC, personId ASC "
-        "LIMIT 10",
+        "ORDER BY commonInterestScore DESC, toInteger(personId) ASC "
+        "LIMIT 10";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::STRING,
          qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::STRING});
-    REQUIRE(r.size() == 10);
+    REQUIRE(r.size() == ldbc::IC10_NUM_ROWS);
 
-    // Neo4j-verified expected values
-    CHECK(r[0].int64_at(0) == 30786325580467LL);
-    CHECK(r[0].str_at(1) == "Michael");
-    CHECK(r[0].str_at(2) == "Taylor");
-    CHECK(r[0].int64_at(3) == 0);  // commonInterestScore
-    CHECK(r[9].int64_at(0) == 4398046514484LL);
-    CHECK(r[9].str_at(1) == "Nikhil");
-    CHECK(r[9].int64_at(3) == -1);
-
-    } catch (const std::exception &e) {
-        WARN("IC10 failed: " << e.what());
+    for (size_t i = 0; i < r.size(); i++) {
+        const auto& exp = ldbc::IC10_RESULTS[i];
+        CHECK(r[i].int64_at(0) == exp.person_id);
+        CHECK(r[i].str_at(1)   == exp.first_name);
+        CHECK(r[i].str_at(2)   == exp.last_name);
+        CHECK(r[i].int64_at(3) == exp.common_interest_score);
+        CHECK(r[i].str_at(4)   == exp.gender);
+        CHECK(r[i].str_at(5)   == exp.city_name);
     }
 }
 
@@ -693,12 +694,20 @@ TEST_CASE("IC10 friend recommendation", "[ldbc][ic][ic10]") {
 //        anonymous node (:Country), ORDER BY ASC/DESC mixed, toInteger in ORDER BY
 TEST_CASE("IC11 job referral", "[ldbc][ic][ic11]") {
     SKIP_IF_NO_DB();
-    try {
-    auto r = qr->run(
-        "MATCH (person:Person {id: 30786325583618})-[:KNOWS*1..2]-(friend:Person) "
+#ifdef TURBOLYNX_LDBC_FIXTURE_MINI
+    const char* company_label = "Organisation";
+    const char* country_label = "Place";
+#else
+    const char* company_label = "Company";
+    const char* country_label = "Country";
+#endif
+    auto q = std::string("MATCH (person:Person {id: ") +
+        std::to_string(ldbc::IC11_ANCHOR_PERSON_ID) +
+        "})-[:KNOWS*1..2]-(friend:Person) "
         "WHERE not(person=friend) "
         "WITH DISTINCT friend "
-        "MATCH (friend)-[workAt:WORK_AT]->(company:Company)-[:IS_LOCATED_IN]->(:Country {name: 'Laos'}) "
+        "MATCH (friend)-[workAt:WORK_AT]->(company:" + company_label +
+        ")-[:IS_LOCATED_IN]->(:" + country_label + " {name: '" + ldbc::IC11_COUNTRY + "'}) "
         "WHERE workAt.workFrom < 2010 "
         "RETURN "
         "  friend.id AS personId, "
@@ -707,34 +716,21 @@ TEST_CASE("IC11 job referral", "[ldbc][ic][ic11]") {
         "  company.name AS organizationName, "
         "  workAt.workFrom AS organizationWorkFromYear "
         "ORDER BY organizationWorkFromYear ASC, toInteger(personId) ASC, organizationName DESC "
-        "LIMIT 10",
+        "LIMIT 10";
+    auto r = qr->run(q.c_str(),
         {qtest::ColType::INT64, qtest::ColType::STRING, qtest::ColType::STRING,
-         qtest::ColType::STRING, qtest::ColType::AUTO});
-    REQUIRE(r.size() == 10);
+         qtest::ColType::STRING, qtest::ColType::INT64});
+    REQUIRE(r.size() == ldbc::IC11_NUM_ROWS);
 
-    // Neo4j-verified expected values
-    CHECK(r[0].int64_at(0) == 6597069767125LL);
-    CHECK(r[0].str_at(1) == "Eve-Mary Thai");
-    CHECK(r[0].str_at(2) == "Pham");
-    CHECK(r[0].str_at(3) == "Lao_Airlines");
-
-    CHECK(r[1].int64_at(0) == 28587302330691LL);
-    CHECK(r[1].str_at(1) == "Atef");
-    CHECK(r[1].str_at(3) == "Lao_Airlines");
-
-    CHECK(r[2].int64_at(0) == 5869LL);
-    CHECK(r[2].str_at(1) == "Cy");
-    CHECK(r[2].str_at(3) == "Lao_Airlines");
-
-    CHECK(r[9].int64_at(0) == 2199023258003LL);
-    CHECK(r[9].str_at(1) == "Ali");
-    CHECK(r[9].str_at(3) == "Lao_Air");
-    } catch (...) {
-        WARN("IC11 skipped in debug build (edge property type issue)");
+    for (size_t i = 0; i < r.size(); i++) {
+        const auto& exp = ldbc::IC11_RESULTS[i];
+        CHECK(r[i].int64_at(0) == exp.person_id);
+        CHECK(r[i].str_at(1)   == exp.first_name);
+        CHECK(r[i].str_at(2)   == exp.last_name);
+        CHECK(r[i].str_at(3)   == exp.organization_name);
+        CHECK(r[i].int64_at(4) == exp.work_from_year);
     }
 }
-
-#endif  // !TURBOLYNX_LDBC_FIXTURE_MINI (IC10-IC11 mini migration deferred)
 
 // IC12 — trending posts.
 // Tags reachable via HAS_TYPE/IS_SUBCLASS_OF hierarchy, friends' comments


### PR DESCRIPTION
## What

IC10 and IC11 were the last \`[ldbc][ic]\` cases gated SF1-only via \`#ifndef TURBOLYNX_LDBC_FIXTURE_MINI\` ever since they were introduced. Both tests also wrapped their bodies in \`try { ... } catch (std::exception&) { WARN(...) }\`, so even on the SF1 build a runtime failure would have shown as a silent pass — the underlying REQUIRE/CHECK never ran.

Migrate both to the committed mini fixture, mirroring how IC3 was migrated:

- **Anchor** → \`IC1_ANCHOR_PERSON_ID\` (Ali, \`2199023255594\`), the most connected Person in mini and the existing IC anchor.
- **Label widening** — the mini loader does not split \`Place\` into \`City\` / \`Country\`, nor \`Organisation\` into \`Company\`. The queries use \`#ifdef TURBOLYNX_LDBC_FIXTURE_MINI\` to pick the right label per build, same pattern as IC3.
- **Expected rows / values** are Neo4j 5 verified against the same fixture \`test/data/ldbc-mini\` (50 Person, 89 KNOWS, 103 WORK_AT, 1460 Place):
  - IC10 — 3 rows: Ali's 2-hop friends born Nov 21 – Dec 21 with a Place.
  - IC11 — 9 rows: Ali's 1..2-hop friends with \`WORK_AT.workFrom < 2010\` at a Mexico-located organisation.
- Anchor / expected constants land in \`ldbc_expected_counts.hpp\` as \`IC10_RESULTS[]\` / \`IC11_RESULTS[]\` structs of the same shape as the existing \`IC9_RESULTS[]\`. SF1-specific assertions are dropped.
- The \`try / WARN catch\` wrappers go away — the queries now run to completion and any regression trips a real test failure.

## Verification

Container build (Linux, Debug + ASan) against \`test/data/ldbc-mini\`:

- \`[ldbc][ic]\` — **18 / 18, 803 assertions** (was 16 / 16, 738; +2 cases, +65 asserts).
- Per-test single runs: \`[ic10]\` 1/1, \`[ic11]\` 1/1, results match the Neo4j-verified \`IC10_RESULTS\` / \`IC11_RESULTS\` tables row-by-row.

## Stack

Stacked on top of #287 (\`fix-ic12-sigsegv-and-wrapper\`). Rebase to main after that merges.

## References

- IC3 mini migration set the label-widening pattern used here.
- IC9 set the \`IC*_RESULTS[]\` struct shape used here.
- The \`#79\` gating umbrella covered IC10/IC11 historically, but their actual blockers (SF1-only ids + sub-label split + no Neo4j-verified mini expected) were independent of the SignalShield work that closed \`#79\`.