### PR TITLE
fix(planner/execution/converter): plug per-query memory leaks across the plan tree

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -539,7 +539,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanQueryPart(
                 mp_, GPOS_NEW(mp_) CLogicalConstTableGet(
                     mp_, pdrgpcoldesc, pdrgpdrgpdatum));
             turbolynx::LogicalSchema empty_schema;
-            cur_plan = new turbolynx::LogicalPlan(pexprCTG, empty_schema);
+            cur_plan = ownPlan(pexprCTG, empty_schema);
         }
         // WHERE before projection if it references a var the projection drops.
         bool where_before = false;
@@ -797,7 +797,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanUnwindClause(
                 mp_, pdrgpcoldesc, pdrgpdrgpdatum));
 
         turbolynx::LogicalSchema empty_schema;
-        prev_plan = new turbolynx::LogicalPlan(pexprCTG, empty_schema);
+        prev_plan = ownPlan(pexprCTG, empty_schema);
     }
 
     // Convert the UNWIND expression to an ORCA scalar
@@ -1523,7 +1523,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
 
             turbolynx::LogicalSchema schema;
             GenerateNodeSchema(node, used_col_idx, colrefs, schema);
-            return new turbolynx::LogicalPlan(plan_expr, schema);
+            return ownPlan(plan_expr, schema);
         };
 
     D_ASSERT(qgc.GetNumQueryGraphs() > 0);
@@ -1799,7 +1799,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                         GPOS_NEW(mp_) CLogicalUnionAll(
                             mp_, output_colrefs, input_colrefs),
                         children);
-                    return new turbolynx::LogicalPlan(
+                    return ownPlan(
                         union_expr, *edge_first->getSchema());
                 };
 
@@ -2054,7 +2054,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                         MaybeWrapVarlenPath(lhs_plan, qg, *qedge);
                     } else {
                         // Unbound LHS: the per-partition A→R result replaces lhs_plan.
-                        lhs_plan = new turbolynx::LogicalPlan(ar_result, first_combined_schema);
+                        lhs_plan = ownPlan(ar_result, first_combined_schema);
                     }
                     // edge_plan is consumed; don't use it below
 
@@ -3622,7 +3622,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanNodeScan(const BoundNodeExpres
     turbolynx::LogicalSchema schema;
     GenerateNodeSchema(node, used_col_idx, colrefs, schema);
 
-    turbolynx::LogicalPlan *plan = new turbolynx::LogicalPlan(plan_expr, schema);
+    turbolynx::LogicalPlan *plan = ownPlan(plan_expr, schema);
     D_ASSERT(!plan->getSchema()->isEmpty());
     return plan;
 }
@@ -3697,7 +3697,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanEdgeScan(const BoundRelExpress
     turbolynx::LogicalSchema schema;
     GenerateEdgeSchema(rel, used_col_idx, colrefs, schema);
 
-    turbolynx::LogicalPlan *plan = new turbolynx::LogicalPlan(plan_expr, schema);
+    turbolynx::LogicalPlan *plan = ownPlan(plan_expr, schema);
     D_ASSERT(!plan->getSchema()->isEmpty());
     return plan;
 }
@@ -3742,7 +3742,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanEdgeScanSinglePartition(
     turbolynx::LogicalSchema schema;
     GenerateEdgeSchema(rel, used_col_idx, colrefs, schema);
 
-    turbolynx::LogicalPlan *plan = new turbolynx::LogicalPlan(plan_expr, schema);
+    turbolynx::LogicalPlan *plan = ownPlan(plan_expr, schema);
     D_ASSERT(!plan->getSchema()->isEmpty());
     return plan;
 }
@@ -3927,7 +3927,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanPathGet(const BoundRelExpressi
     CExpression *path_expr = GPOS_NEW(mp_) CExpression(mp_, pop);
     path_output_cols->AddRef();
 
-    turbolynx::LogicalPlan *plan = new turbolynx::LogicalPlan(path_expr, schema);
+    turbolynx::LogicalPlan *plan = ownPlan(path_expr, schema);
     D_ASSERT(!plan->getSchema()->isEmpty());
     return plan;
 }

--- a/src/execution/execution/cypher_pipeline_executor.cpp
+++ b/src/execution/execution/cypher_pipeline_executor.cpp
@@ -94,6 +94,10 @@ CypherPipelineExecutor::~CypherPipelineExecutor() {
 	for (auto &op_state : local_operator_states) {
 		op_state.reset();
 	}
+	// context is heap-allocated per executor in Planner::genPipelineExecutors
+	// and is not shared with any other executor (each pipeline gets its own
+	// `new ExecutionContext`). pipeline is owned by the Planner, not by us.
+	delete context;
 }
 
 void CypherPipelineExecutor::ReinitializePipeline()

--- a/src/execution/execution/physical_operator/physical_id_seek.cpp
+++ b/src/execution/execution/physical_operator/physical_id_seek.cpp
@@ -46,6 +46,12 @@ class IdSeekState : public OperatorState {
         materialized_sel.Initialize();
     }
 
+    // ExtentIterator is heap-allocated in the constructor and only ever
+    // accessed through ext_it from this state; no other owner exists.
+    ~IdSeekState() {
+        delete ext_it;
+    }
+
     void InitializeSels(size_t num_schemas)
     {
         if (sels.size() == num_schemas) {

--- a/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
+++ b/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
@@ -67,6 +67,13 @@ public:
 		join_sizes.resize(STANDARD_VECTOR_SIZE);
 		// total_join_size.resize(STANDARD_VECTOR_SIZE);
 	}
+
+	// dfs_it / iso_checker are heap-allocated in the constructor with raw
+	// `new`; this state is their sole owner.
+	~VarlenAdjIdxJoinState() {
+		delete dfs_it;
+		delete iso_checker;
+	}
 	//! Called when starting processing for new chunk
 	inline void resetForNewInput() {
 		resetForMoreOutput();

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -382,7 +382,22 @@ private:
 
     bool IsCastingFunction(const string &func_name);
 
+    // Helper: heap-construct a LogicalPlan, take ownership in
+    // owned_logical_plans_, and return the raw pointer for downstream
+    // wiring. Replaces the legacy `new turbolynx::LogicalPlan(args)`
+    // pattern. Cypher2OrcaConverter is the sole owner of every plan
+    // node it produces; downstream consumers (Planner) only read the
+    // tree via the returned pointer and never delete it.
+    template <typename... Args>
+    turbolynx::LogicalPlan *ownPlan(Args &&...args) {
+        auto p = new turbolynx::LogicalPlan(std::forward<Args>(args)...);
+        owned_logical_plans_.emplace_back(p);
+        return p;
+    }
+
 private:
+    std::vector<std::unique_ptr<turbolynx::LogicalPlan>> owned_logical_plans_;
+
     CMemoryPool *mp_;
     duckdb::ClientContext *context_;
     MDProviderTBGPP *provider_;

--- a/src/include/execution/cypher_physical_operator_group.hpp
+++ b/src/include/execution/cypher_physical_operator_group.hpp
@@ -130,15 +130,29 @@ public:
 // This is represented as two CypherPhysicalOperatorGroup
 
 class CypherPhysicalOperatorGroups {
-    
+
 public:
     CypherPhysicalOperatorGroups() = default;
 
+    // owned_groups carries unique_ptrs, so the collection is move-only.
+    // CypherPipeline takes the Groups by rvalue and moves out of it.
+    CypherPhysicalOperatorGroups(const CypherPhysicalOperatorGroups &) = delete;
+    CypherPhysicalOperatorGroups &operator=(const CypherPhysicalOperatorGroups &) = delete;
+    CypherPhysicalOperatorGroups(CypherPhysicalOperatorGroups &&) noexcept = default;
+    CypherPhysicalOperatorGroups &operator=(CypherPhysicalOperatorGroups &&) noexcept = default;
+
     void push_back(CypherPhysicalOperator *op) {
-        groups.push_back(new CypherPhysicalOperatorGroup(op));
+        // Self-owned: the Group object is heap-allocated here and is
+        // only ever observed through `groups`. Tracked in owned_groups
+        // so ~CypherPhysicalOperatorGroups releases it.
+        owned_groups.emplace_back(std::make_unique<CypherPhysicalOperatorGroup>(op));
+        groups.push_back(owned_groups.back().get());
     }
 
     void push_back(CypherPhysicalOperatorGroup *group) {
+        // Externally-owned: the caller (Planner::ownGroup or another
+        // Groups instance's owned_groups) keeps the Group alive. We
+        // only borrow the pointer.
         groups.push_back(group);
     }
 
@@ -190,6 +204,10 @@ public:
     }
 
     vector<CypherPhysicalOperatorGroup *> groups;
+    // Backing storage for the Group entries this collection allocated
+    // via push_back(CypherPhysicalOperator*). Externally-pushed Group
+    // pointers (push_back(Group*)) are not tracked here.
+    vector<std::unique_ptr<CypherPhysicalOperatorGroup>> owned_groups;
 };
 
 

--- a/src/include/execution/cypher_pipeline.hpp
+++ b/src/include/execution/cypher_pipeline.hpp
@@ -20,9 +20,9 @@ class CypherPipeline {
 public:
 	CypherPipeline() {}
 
-	CypherPipeline(CypherPhysicalOperatorGroups& groups, idx_t pipeline_id = 0) : pipeline_id(pipeline_id) {
-		operator_groups = groups;
-		pipelineLength = groups.size();
+	CypherPipeline(CypherPhysicalOperatorGroups &&groups, idx_t pipeline_id = 0)
+	    : operator_groups(std::move(groups)), pipeline_id(pipeline_id) {
+		pipelineLength = operator_groups.size();
 		RebuildReprOperators();
 	}
 

--- a/src/include/execution/physical_operator/physical_adjidxjoin.hpp
+++ b/src/include/execution/physical_operator/physical_adjidxjoin.hpp
@@ -39,6 +39,18 @@ class AdjIdxJoinState : public OperatorState {
         found_match = unique_ptr<bool[]>(new bool[STANDARD_VECTOR_SIZE]);
         resetForNewInput();
     }
+
+    // adj_it / adj_it_bwd are heap-allocated in the constructor and the
+    // multi-iterator vectors are populated by raw `new` in
+    // PhysicalAdjIdxJoin::GetOperatorState (multi-partition path). This
+    // state is their sole owner.
+    ~AdjIdxJoinState()
+    {
+        delete adj_it;
+        delete adj_it_bwd;
+        for (auto *it : adj_its_multi) delete it;
+        for (auto *it : bwd_its_multi) delete it;
+    }
     //! Called when starting processing for new chunk
     inline void resetForNewInput()
     {

--- a/src/include/main/capi/capi_internal.hpp
+++ b/src/include/main/capi/capi_internal.hpp
@@ -33,6 +33,6 @@ namespace duckdb {
 turbolynx_type ConvertCPPTypeToC(const LogicalType &type);
 LogicalTypeId ConvertCTypeToCPP(turbolynx_type c_type);
 idx_t GetCTypeSize(turbolynx_type type);
-std::string generatePostgresStylePlan(std::vector<CypherPipelineExecutor*>& executors, bool is_executed = false);
+std::string generatePostgresStylePlan(std::vector<std::unique_ptr<CypherPipelineExecutor>>& executors, bool is_executed = false);
 
 } // namespace duckdb

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -223,7 +223,7 @@ public:
 	~Planner();
 
 	void execute(duckdb::BoundRegularQuery *bound_query);
-	vector<duckdb::CypherPipelineExecutor *> genPipelineExecutors();
+	vector<unique_ptr<duckdb::CypherPipelineExecutor>> genPipelineExecutors();
 	vector<string> getQueryOutputColNames();
 	vector<OID> getQueryOutputOIDs();
 

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -537,6 +537,19 @@ private:
 		owned_operators.emplace_back(p);
 		return p;
 	}
+
+	// Sole owner of every CypherPhysicalOperatorGroup that the planner
+	// allocates standalone (i.e. not via Groups::push_back(op), which
+	// self-owns). Used for the union_group in pTransformEopUnionAll
+	// and similar paths where a Group is heap-allocated separately
+	// from any Groups collection.
+	vector<unique_ptr<duckdb::CypherPhysicalOperatorGroup>> owned_groups;
+	template <typename... Args>
+	duckdb::CypherPhysicalOperatorGroup *ownGroup(Args &&...args) {
+		auto g = new duckdb::CypherPhysicalOperatorGroup(std::forward<Args>(args)...);
+		owned_groups.emplace_back(g);
+		return g;
+	}
 	std::map<CColRef *, std::string> property_col_to_output_col_names_mapping; 	// actual output col names for property columns
 	// Complex type registry: stores full LogicalType for types that can't be
 	// represented by ORCA's (OID, INT modifier) pair (e.g. STRUCT with named fields).

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -520,6 +520,23 @@ private:
 	// used and initialized in each execution
 	duckdb::BoundRegularQuery *bound_regular_query;								// input bound query
 	vector<duckdb::CypherPipeline *> pipelines;									// output plan pipelines
+	// Sole owner of every PhysicalOperator the pTransform* / pGenPhysicalPlan
+	// paths build during plan generation. CypherPhysicalOperatorGroup,
+	// CypherPipeline, and downstream PipelineExecutor reference these as raw
+	// observer pointers — the unique_ptrs here own them. reset() and ~Planner
+	// drop the vector after the pipelines that point into it have already
+	// been deleted, so observer accesses during teardown see live memory.
+	vector<unique_ptr<duckdb::CypherPhysicalOperator>> owned_operators;
+	// Helper: heap-construct a PhysicalOperator subclass, take ownership in
+	// owned_operators, and return the raw pointer for use in Group /
+	// Pipeline wiring. Replaces the legacy `new duckdb::PhysicalX(args)`
+	// pattern at the pTransform* call sites.
+	template <typename T, typename... Args>
+	T *ownOp(Args &&...args) {
+		auto p = new T(std::forward<Args>(args)...);
+		owned_operators.emplace_back(p);
+		return p;
+	}
 	std::map<CColRef *, std::string> property_col_to_output_col_names_mapping; 	// actual output col names for property columns
 	// Complex type registry: stores full LogicalType for types that can't be
 	// represented by ORCA's (OID, INT modifier) pair (e.g. STRUCT with named fields).

--- a/src/main/capi/helper-c.cpp
+++ b/src/main/capi/helper-c.cpp
@@ -211,7 +211,7 @@ bool hasMatchingOperator(duckdb::CypherPipeline* lhs_pipeline, duckdb::CypherPip
 }
 
 // Main function to generate PostgreSQL-style query plan
-std::string generatePostgresStylePlan(std::vector<CypherPipelineExecutor*>& executors, bool is_executed) {
+std::string generatePostgresStylePlan(std::vector<std::unique_ptr<CypherPipelineExecutor>>& executors, bool is_executed) {
     std::ostringstream oss;
 
     // Step 1: Map parent-child relationships and rhs mappings for binary operators

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -4554,8 +4554,12 @@ int64_t turbolynx_execute_raw(int64_t conn_id,
         }
 
         auto& query_results = *(executors.back()->context->query_results);
-        auto& schema = executors.back()->pipeline->GetSink()->schema;
         out_col_names = h->planner->getQueryOutputColNames();
+        // Copy the sink schema before any path that may RefreshCatalogAndPlanner
+        // (ApplyPendingSetMutations / ApplyPendingDeleteMutations both can,
+        // and reset() drops owned_operators — which includes the sink op
+        // whose `schema` we'd otherwise hold a dangling reference into).
+        out_schema = executors.back()->pipeline->GetSink()->schema;
 
         if (!h->pending_set_items.empty()) {
             ApplyPendingSetMutations(h, query_results, out_col_names);
@@ -4568,8 +4572,6 @@ int64_t turbolynx_execute_raw(int64_t conn_id,
 
         maybeAutoCompact(h);
 
-	        // Copy schema and chunks to output
-	        out_schema = schema;
 	        int64_t total_rows = 0;
 	        for (auto& chunk : query_results) {
 	            if (chunk) { total_rows += chunk->size(); out_chunks.push_back(chunk); }

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -4542,7 +4542,7 @@ int64_t turbolynx_execute_raw(int64_t conn_id,
             set_error(TURBOLYNX_ERROR_INVALID_PLAN, INVALID_PLAN_MSG);
             return -1;
         }
-        for (auto exec : executors) {
+        for (auto &exec : executors) {
             spdlog::debug("[ExecuteCAPI] run pipeline={} source={} sink={}",
                          exec->pipeline->GetPipelineId(),
                          exec->pipeline->GetSource()->ToString(),
@@ -4573,7 +4573,6 @@ int64_t turbolynx_execute_raw(int64_t conn_id,
 	        for (auto& chunk : query_results) {
 	            if (chunk) { total_rows += chunk->size(); out_chunks.push_back(chunk); }
 	        }
-	        for (auto* e : executors) delete e;
 	        h->client->is_executing = false;
 	        return total_rows;
     } catch (const std::exception& e) {

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -3482,6 +3482,7 @@ turbolynx_state turbolynx_close_prepared_statement(turbolynx_prepared_statement*
 
 	turbolynx_close_property(prepared_statement->property);
 	free(prepared_statement->query);
+	free(prepared_statement->plan);
 	free(prepared_statement);
 	return TURBOLYNX_SUCCESS;
 }

--- a/src/optimizer/orca/gpopt/translate/CTranslatorTBGPPToDXL.cpp
+++ b/src/optimizer/orca/gpopt/translate/CTranslatorTBGPPToDXL.cpp
@@ -2646,7 +2646,19 @@ CTranslatorTBGPPToDXL::RetrieveColStats(CMemoryPool *mp,
 	// }
 
 	// histogram values extracted from the pg_statistic tuple for a given column
-	AttStatsSlot hist_slot;
+	AttStatsSlot hist_slot{};
+	// GetHistogramInfo populates hist_slot.values / .freq_values with raw
+	// `new Datum[...]` allocations (tbgppdbwrappers.cpp:142,148). AttStatsSlot
+	// is a plain C struct with no destructor, and this function has many
+	// return paths — without a scope guard each early return leaks the two
+	// arrays.
+	struct HistSlotGuard {
+		AttStatsSlot &s;
+		~HistSlotGuard() {
+			delete[] s.values;
+			delete[] s.freq_values;
+		}
+	} hist_guard{hist_slot};
 
 	// get histogram datums from pg_statistic entry
 	// (void) gpdb::GetAttrStatsSlot(&hist_slot, stats_tup,

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -66,6 +66,7 @@ Planner::~Planner()
     // queries on this planner.
     for (auto *p : pipelines) delete p;
     pipelines.clear();
+    owned_operators.clear();
     CMDCache::Shutdown();
     CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(this->memory_pool);
 }
@@ -98,6 +99,10 @@ void Planner::reset()
     // observer references and do not delete them.
     for (auto *p : pipelines) delete p;
     pipelines.clear();
+    // Order matters: pipelines hold raw observer pointers into
+    // owned_operators. Drop pipelines first so their teardown sees live
+    // memory, then release the operators themselves.
+    owned_operators.clear();
     pruned_key_ids.clear();
     logical_plan_output_col_names.clear();
     logical_plan_output_colrefs.clear();

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -67,6 +67,7 @@ Planner::~Planner()
     for (auto *p : pipelines) delete p;
     pipelines.clear();
     owned_operators.clear();
+    owned_groups.clear();
     CMDCache::Shutdown();
     CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(this->memory_pool);
 }
@@ -100,9 +101,10 @@ void Planner::reset()
     for (auto *p : pipelines) delete p;
     pipelines.clear();
     // Order matters: pipelines hold raw observer pointers into
-    // owned_operators. Drop pipelines first so their teardown sees live
-    // memory, then release the operators themselves.
+    // owned_operators / owned_groups. Drop pipelines first so their
+    // teardown sees live memory, then release the operators / groups.
     owned_operators.clear();
+    owned_groups.clear();
     pruned_key_ids.clear();
     logical_plan_output_col_names.clear();
     logical_plan_output_colrefs.clear();

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -598,16 +598,20 @@ void *Planner::_orcaExec(void *planner_ptr)
     return nullptr;
 }
 
-vector<duckdb::CypherPipelineExecutor *> Planner::genPipelineExecutors()
+vector<unique_ptr<duckdb::CypherPipelineExecutor>> Planner::genPipelineExecutors()
 {
     D_ASSERT(pipelines.size() > 0);
 
     /* inject per-operator-dependencies and per-pipeline dependencies
 		- per-op: CypherPhysicalOperator::children
 		- per-pipeline: child_executors / dep_executors
+
+       The returned vector owns each executor (unique_ptr). The child/dep
+       reference vectors below hold raw observer pointers into the same
+       outer vector — owner remains the outer unique_ptr.
 	*/
 
-    std::vector<duckdb::CypherPipelineExecutor *> executors;
+    std::vector<unique_ptr<duckdb::CypherPipelineExecutor>> executors;
 
     for (auto pipe_idx = 0; pipe_idx < pipelines.size(); pipe_idx++) {
         auto &pipe = pipelines[pipe_idx];
@@ -634,7 +638,7 @@ vector<duckdb::CypherPipelineExecutor *> Planner::genPipelineExecutors()
         for (auto &ce : executors) {
             for (auto *src : candidate_sources) {
                 if (src == ce->pipeline->GetSink()) {
-                    child_executors.push_back(ce);
+                    child_executors.push_back(ce.get());
                     break;
                 }
             }
@@ -648,7 +652,7 @@ vector<duckdb::CypherPipelineExecutor *> Planner::genPipelineExecutors()
                 duckdb::CypherPhysicalOperator *op =
                     pipe->GetOperators()[op_idx];
                 if (op == ce->pipeline->GetSink()) {
-                    dep_executors.insert(std::make_pair(op, ce));
+                    dep_executors.insert(std::make_pair(op, ce.get()));
                     // add previous of ce to children (skip if already present
                     // from intra-pipeline wiring to avoid duplicate children)
                     duckdb::CypherPhysicalOperator *dep_child;
@@ -669,11 +673,8 @@ vector<duckdb::CypherPipelineExecutor *> Planner::genPipelineExecutors()
                 }
             }
         }
-        duckdb::CypherPipelineExecutor *pipe_exec =
-            new duckdb::CypherPipelineExecutor(
-                new_ctxt, pipe, move(child_executors), move(dep_executors));
-
-        executors.push_back(pipe_exec);
+        executors.push_back(std::make_unique<duckdb::CypherPipelineExecutor>(
+            new_ctxt, pipe, move(child_executors), move(dep_executors)));
     }
 
     return executors;

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -61,6 +61,11 @@ Planner::~Planner()
         // crash; leak them and let the OS reclaim on process exit.
         return;
     }
+    // The last query's pipelines weren't reset()'d before the planner
+    // was destroyed — clean them up too. reset() handles all earlier
+    // queries on this planner.
+    for (auto *p : pipelines) delete p;
+    pipelines.clear();
     CMDCache::Shutdown();
     CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(this->memory_pool);
 }
@@ -85,6 +90,13 @@ void Planner::reset()
 {
     // reset planner context
     bound_regular_query = nullptr;
+    // CypherPipeline objects are heap-allocated in the various
+    // pTransform* / pGenPhysicalPlan paths and stored as raw pointers
+    // here. clear() alone would drop the pointers but leak the objects;
+    // each query that ran on this planner would accumulate. The pipelines
+    // are owned solely by this vector — pipeline executors hold them as
+    // observer references and do not delete them.
+    for (auto *p : pipelines) delete p;
     pipelines.clear();
     pruned_key_ids.clear();
     logical_plan_output_col_names.clear();

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -475,8 +475,10 @@ void Planner::pSetExplicitPhysicalOutputLayout(CColRefArray *cols)
 void Planner::pGenPhysicalPlan(CExpression *orca_plan_root)
 {
     duckdb::CypherPhysicalOperator::operator_version = 0;
+    auto *top_result = pTraverseTransformPhysicalPlan(orca_plan_root);
     duckdb::CypherPhysicalOperatorGroups final_pipeline_ops =
-        *pTraverseTransformPhysicalPlan(orca_plan_root);
+        std::move(*top_result);
+    delete top_result;
 
     // Standalone OPTIONAL MATCH wrapper (#203, #204): insert PhysicalOptional
     // between the final piped op and PhysicalProduceResults so a 0-row MATCH
@@ -525,7 +527,7 @@ void Planner::pGenPhysicalPlan(CExpression *orca_plan_root)
 
 
     auto final_pipeline =
-        new duckdb::CypherPipeline(final_pipeline_ops, pipelines.size());
+        new duckdb::CypherPipeline(std::move(final_pipeline_ops), pipelines.size());
 
     pipelines.push_back(final_pipeline);
 
@@ -1895,7 +1897,7 @@ Planner::pTransformEopUnionAll(CExpression *plan_expr)
     auto *mp = this->memory_pool;
 
     duckdb::CypherPhysicalOperatorGroups *result = new duckdb::CypherPhysicalOperatorGroups();
-    duckdb::CypherPhysicalOperatorGroup *union_group = new duckdb::CypherPhysicalOperatorGroup();
+    duckdb::CypherPhysicalOperatorGroup *union_group = ownGroup();
 
     CExpressionArray *childs = plan_expr->PdrgPexpr();
     const ULONG num_childs = childs->Size();
@@ -1904,6 +1906,14 @@ Planner::pTransformEopUnionAll(CExpression *plan_expr)
         CExpression *child_expr = childs->operator[](i);
         auto child_result = pTraverseTransformPhysicalPlan(child_expr);
         union_group->PushBack(child_result->GetGroups());
+        // The shared Group raw pointers in union_group->childs alias into
+        // child_result.owned_groups. Move those unique_ptrs into Planner
+        // so the Group objects outlive child_result (which we drop now).
+        for (auto &g : child_result->owned_groups) {
+            owned_groups.push_back(std::move(g));
+        }
+        child_result->owned_groups.clear();
+        delete child_result;
     }
 
     result->push_back(union_group);
@@ -5907,7 +5917,7 @@ Planner::pTransformEopProjectionColumnar(CExpression *plan_expr)
 //     pGenerateSchemaFlowGraph(*result);
 
 //     // finish pipeline
-//     auto pipeline = new duckdb::CypherPipeline(*result, pipelines.size());
+//     auto pipeline = new duckdb::CypherPipeline(std::move(*result), pipelines.size());
 //     pipelines.push_back(pipeline);
 
 //     // new pipeline
@@ -6218,7 +6228,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopAgg(
     }
     result->push_back(op);
     // finish pipeline
-    auto pipeline = new duckdb::CypherPipeline(*result, pipelines.size());
+    auto pipeline = new duckdb::CypherPipeline(std::move(*result), pipelines.size());
     pipelines.push_back(pipeline);
     // new pipeline
     auto new_result = new duckdb::CypherPhysicalOperatorGroups();
@@ -6459,7 +6469,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopSort(
     result->push_back(op);
 
     // break pipeline
-    auto pipeline = new duckdb::CypherPipeline(*result, pipelines.size());
+    auto pipeline = new duckdb::CypherPipeline(std::move(*result), pipelines.size());
     pipelines.push_back(pipeline);
 
     auto new_result = new duckdb::CypherPhysicalOperatorGroups();
@@ -6567,7 +6577,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopTopNSort(
     result->push_back(op);
 
     // break pipeline
-    auto pipeline = new duckdb::CypherPipeline(*result, pipelines.size());
+    auto pipeline = new duckdb::CypherPipeline(std::move(*result), pipelines.size());
     pipelines.push_back(pipeline);
 
     auto new_result = new duckdb::CypherPhysicalOperatorGroups();
@@ -7832,7 +7842,7 @@ Planner::pBuildSchemaflowGraphForBinaryJoin(
             plan_expr->PdrgPexpr()->operator[](rhs_idx));
     }
     rhs_result->push_back(op);
-    auto pipeline = new duckdb::CypherPipeline(*rhs_result);
+    auto pipeline = new duckdb::CypherPipeline(std::move(*rhs_result));
     pipelines.push_back(pipeline);
 
     // Step 1. schema flow graph

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -486,7 +486,7 @@ void Planner::pGenPhysicalPlan(CExpression *orca_plan_root)
     if (wrap_final_with_optional) {
         duckdb::Schema opt_schema =
             final_pipeline_ops[final_pipeline_ops.size() - 1]->schema;
-        auto *opt_op = new duckdb::PhysicalOptional(opt_schema);
+        auto *opt_op = ownOp<duckdb::PhysicalOptional>(opt_schema);
         final_pipeline_ops.push_back(opt_op);
     }
 
@@ -500,7 +500,7 @@ void Planner::pGenPhysicalPlan(CExpression *orca_plan_root)
     vector<uint64_t> projection_mapping;
     vector<vector<uint64_t>> projection_mappings;
     if (logical_plan_output_colrefs.empty()) {
-        op = new duckdb::PhysicalProduceResults(final_output_schema);
+        op = ownOp<duckdb::PhysicalProduceResults>(final_output_schema);
         final_pipeline_ops.push_back(op);
         D_ASSERT(final_pipeline_ops.size() > 0);
 
@@ -517,7 +517,7 @@ void Planner::pGenPhysicalPlan(CExpression *orca_plan_root)
             }
         }
     }
-    op = new duckdb::PhysicalProduceResults(final_output_schema,
+    op = ownOp<duckdb::PhysicalProduceResults>(final_output_schema,
                                             projection_mappings);
 
     final_pipeline_ops.push_back(op);
@@ -756,7 +756,7 @@ Planner::pTraverseTransformPhysicalPlan(CExpression *plan_expr)
 			}
 			// TODO: extract actual datum values for non-empty ConstTableGet
 
-			auto *op = new duckdb::PhysicalConstScan(ctg_schema, std::move(const_rows));
+			auto *op = ownOp<duckdb::PhysicalConstScan>(ctg_schema, std::move(const_rows));
 			result = new duckdb::CypherPhysicalOperatorGroups();
 			result->push_back(op);
 			break;
@@ -1229,13 +1229,13 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
 
         // Create schemaless PhysicalNodeScan
         if (!do_filter_pushdown) {
-            op = new duckdb::PhysicalNodeScan(local_schemas, tmp_schema, oids,
+            op = ownOp<duckdb::PhysicalNodeScan>(local_schemas, tmp_schema, oids,
                                               output_projection_mapping,
                                               scan_projection_mapping);
         } else if (is_simple_filter) {
             if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                 IMDType::ECmpType::EcmptEq) {
-                op = new duckdb::PhysicalNodeScan(local_schemas, tmp_schema, oids,
+                op = ownOp<duckdb::PhysicalNodeScan>(local_schemas, tmp_schema, oids,
                                                   output_projection_mapping,
                                                   scan_projection_mapping,
                                                   filter_key_idxs, filter_values);
@@ -1263,7 +1263,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
                     }
                     range_values.push_back({l_val, r_val, l_inc, r_inc});
                 }
-                op = new duckdb::PhysicalNodeScan(local_schemas, tmp_schema, oids,
+                op = ownOp<duckdb::PhysicalNodeScan>(local_schemas, tmp_schema, oids,
                                                   output_projection_mapping,
                                                   scan_projection_mapping,
                                                   filter_key_idxs, range_values);
@@ -1273,14 +1273,14 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
             vector<unique_ptr<duckdb::Expression>> filter_exprs;
             filter_exprs.push_back(
                 std::move(pTransformScalarExpr(filter_pred_expr, scan_cols->Pdrgpcr(mp), nullptr)));
-            op = new duckdb::PhysicalNodeScan(local_schemas, tmp_schema, oids,
+            op = ownOp<duckdb::PhysicalNodeScan>(local_schemas, tmp_schema, oids,
                                               output_projection_mapping,
                                               scan_projection_mapping, move(filter_exprs));
         }
     } else {
         // Single-partition: original code path
         if (!do_filter_pushdown) {
-            op = new duckdb::PhysicalNodeScan(tmp_schema, oids,
+            op = ownOp<duckdb::PhysicalNodeScan>(tmp_schema, oids,
                                               output_projection_mapping,
                                               scan_types,
                                               scan_projection_mapping);
@@ -1289,13 +1289,13 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
             if (is_simple_filter) {
                 if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                     IMDType::ECmpType::EcmptEq) {
-                    op = new duckdb::PhysicalNodeScan(
+                    op = ownOp<duckdb::PhysicalNodeScan>(
                         tmp_schema, oids, output_projection_mapping, scan_types,
                         scan_projection_mapping, pred_attr_pos, literal_val);
                 }
                 else if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                         IMDType::ECmpType::EcmptL) {
-                    op = new duckdb::PhysicalNodeScan(
+                    op = ownOp<duckdb::PhysicalNodeScan>(
                         tmp_schema, oids, output_projection_mapping, scan_types,
                         scan_projection_mapping, pred_attr_pos,
                         duckdb::Value::MinimumValue(literal_val.type()), literal_val,
@@ -1303,7 +1303,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
                 }
                 else if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                         IMDType::ECmpType::EcmptLEq) {
-                    op = new duckdb::PhysicalNodeScan(
+                    op = ownOp<duckdb::PhysicalNodeScan>(
                         tmp_schema, oids, output_projection_mapping, scan_types,
                         scan_projection_mapping, pred_attr_pos,
                         duckdb::Value::MinimumValue(literal_val.type()), literal_val,
@@ -1311,14 +1311,14 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
                 }
                 else if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                         IMDType::ECmpType::EcmptG) {
-                    op = new duckdb::PhysicalNodeScan(
+                    op = ownOp<duckdb::PhysicalNodeScan>(
                         tmp_schema, oids, output_projection_mapping, scan_types,
                         scan_projection_mapping, pred_attr_pos, literal_val,
                         duckdb::Value::MaximumValue(literal_val.type()), false, true);
                 }
                 else if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                         IMDType::ECmpType::EcmptGEq) {
-                    op = new duckdb::PhysicalNodeScan(
+                    op = ownOp<duckdb::PhysicalNodeScan>(
                         tmp_schema, oids, output_projection_mapping, scan_types,
                         scan_projection_mapping, pred_attr_pos, literal_val,
                         duckdb::Value::MaximumValue(literal_val.type()), true, true);
@@ -1331,7 +1331,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
                 vector<unique_ptr<duckdb::Expression>> filter_exprs;
                 filter_exprs.push_back(
                     std::move(pTransformScalarExpr(filter_pred_expr, scan_cols->Pdrgpcr(mp), nullptr)));
-                op = new duckdb::PhysicalNodeScan(
+                op = ownOp<duckdb::PhysicalNodeScan>(
                     tmp_schema, oids, output_projection_mapping, scan_types,
                     scan_projection_mapping, move(filter_exprs));
             }
@@ -1471,7 +1471,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
         if (is_simple_filter) {
             if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                 IMDType::ECmpType::EcmptEq) {
-                op = new duckdb::PhysicalNodeScan(
+                op = ownOp<duckdb::PhysicalNodeScan>(
                     local_schemas, global_schema, oids, projection_mappings,
                     scan_projection_mappings, pred_attr_pos_vec,
                     literal_val_vec);
@@ -1483,7 +1483,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
                         {duckdb::Value::MinimumValue(literal_val_vec[i].type()),
                          literal_val_vec[i], true, false});
                 }
-                op = new duckdb::PhysicalNodeScan(
+                op = ownOp<duckdb::PhysicalNodeScan>(
                     local_schemas, global_schema, oids, projection_mappings,
                     scan_projection_mappings, pred_attr_pos_vec,
                     range_filter_values);
@@ -1495,7 +1495,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
                         {duckdb::Value::MinimumValue(literal_val_vec[i].type()),
                          literal_val_vec[i], true, true});
                 }
-                op = new duckdb::PhysicalNodeScan(
+                op = ownOp<duckdb::PhysicalNodeScan>(
                     local_schemas, global_schema, oids, projection_mappings,
                     scan_projection_mappings, pred_attr_pos_vec,
                     range_filter_values);
@@ -1508,7 +1508,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
                          duckdb::Value::MaximumValue(literal_val_vec[i].type()),
                          false, true});
                 }
-                op = new duckdb::PhysicalNodeScan(
+                op = ownOp<duckdb::PhysicalNodeScan>(
                     local_schemas, global_schema, oids, projection_mappings,
                     scan_projection_mappings, pred_attr_pos_vec,
                     range_filter_values);
@@ -1521,7 +1521,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
                          duckdb::Value::MaximumValue(literal_val_vec[i].type()),
                          true, true});
                 }
-                op = new duckdb::PhysicalNodeScan(
+                op = ownOp<duckdb::PhysicalNodeScan>(
                     local_schemas, global_schema, oids, projection_mappings,
                     scan_projection_mappings, pred_attr_pos_vec,
                     range_filter_values);
@@ -1534,12 +1534,12 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
             vector<unique_ptr<duckdb::Expression>> filter_exprs;
             filter_exprs.push_back(
                 std::move(pTransformScalarExpr(filter_pred_expr, scan_cols, nullptr)));
-            op = new duckdb::PhysicalNodeScan(
+            op = ownOp<duckdb::PhysicalNodeScan>(
                 local_schemas, global_schema, oids, projection_mappings,
                 scan_projection_mappings, move(filter_exprs));
         }
     } else {
-        op = new duckdb::PhysicalNodeScan(
+        op = ownOp<duckdb::PhysicalNodeScan>(
             local_schemas, global_schema, oids, projection_mappings,
             scan_projection_mappings);
     }
@@ -1563,7 +1563,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
         pGetProjectionExprs(proj_types, bound_ref_idxs, proj_exprs);
         if (!proj_exprs.empty()) {
             result->push_back(
-                new duckdb::PhysicalProjection(proj_schema, move(proj_exprs)));
+                ownOp<duckdb::PhysicalProjection>(proj_schema, move(proj_exprs)));
         }
     }
 
@@ -1744,7 +1744,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
             auto num_vals = literal_vals.size();
             switch (cmp_type) {
                 case IMDType::ECmpType::EcmptEq:
-                    op = new duckdb::PhysicalNodeScan(
+                    op = ownOp<duckdb::PhysicalNodeScan>(
                         local_schemas, global_schema, oids, projection_mapping,
                         scan_projection_mapping, pred_attr_poss, literal_vals);
                     break;
@@ -1754,7 +1754,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
                             {duckdb::Value::MinimumValue(
                                  literal_vals[i].type()),
                              literal_vals[i], true, false});
-                    op = new duckdb::PhysicalNodeScan(
+                    op = ownOp<duckdb::PhysicalNodeScan>(
                         local_schemas, global_schema, oids, projection_mapping,
                         scan_projection_mapping, pred_attr_poss,
                         range_filter_values);
@@ -1765,7 +1765,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
                             {duckdb::Value::MinimumValue(
                                  literal_vals[i].type()),
                              literal_vals[i], true, true});
-                    op = new duckdb::PhysicalNodeScan(
+                    op = ownOp<duckdb::PhysicalNodeScan>(
                         local_schemas, global_schema, oids, projection_mapping,
                         scan_projection_mapping, pred_attr_poss,
                         range_filter_values);
@@ -1777,7 +1777,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
                              duckdb::Value::MaximumValue(
                                  literal_vals[i].type()),
                              false, true});
-                    op = new duckdb::PhysicalNodeScan(
+                    op = ownOp<duckdb::PhysicalNodeScan>(
                         local_schemas, global_schema, oids, projection_mapping,
                         scan_projection_mapping, pred_attr_poss,
                         range_filter_values);
@@ -1789,7 +1789,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
                              duckdb::Value::MaximumValue(
                                  literal_vals[i].type()),
                              true, true});
-                    op = new duckdb::PhysicalNodeScan(
+                    op = ownOp<duckdb::PhysicalNodeScan>(
                         local_schemas, global_schema, oids, projection_mapping,
                         scan_projection_mapping, pred_attr_poss,
                         range_filter_values);
@@ -1817,7 +1817,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
             filter_exprs.push_back(std::move(repr_filter_expr));
 
             duckdb::CypherPhysicalOperator *scan_cypher_op =
-                new duckdb::PhysicalNodeScan(
+                ownOp<duckdb::PhysicalNodeScan>(
                     local_schemas, global_schema, oids, projection_mapping,
                     scan_projection_mapping, move(filter_exprs));
             if (!oids.empty()) scan_cypher_op->display_name = pResolvePartitionName(oids[0]);
@@ -1868,7 +1868,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
             if (!proj_exprs.empty()) {
                 D_ASSERT(proj_exprs.size() == proj_op_output_types.size());
                 duckdb::CypherPhysicalOperator *proj_op =
-                    new duckdb::PhysicalProjection(proj_op_output_union_schema,
+                    ownOp<duckdb::PhysicalProjection>(proj_op_output_union_schema,
                                                    std::move(proj_exprs));
                 result->push_back(proj_op);
             }
@@ -1878,7 +1878,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
         }
     }
     else {
-        duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalNodeScan(
+        duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalNodeScan>(
             local_schemas, global_schema, oids, projection_mapping,
             scan_projection_mapping);
         if (!oids.empty()) op->display_name = pResolvePartitionName(oids[0]);
@@ -2377,7 +2377,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
         D_ASSERT(edge_id_col_idx != std::numeric_limits<uint32_t>::max());
     }
     auto *duckdb_adjidx_op =
-        new duckdb::PhysicalAdjIdxJoin(
+        ownOp<duckdb::PhysicalAdjIdxJoin>(
             schema_adj, adjidx_obj_id,
             is_left_outer ? duckdb::JoinType::LEFT : duckdb::JoinType::INNER,
             is_adjidxjoin_into, outer_join_key_col_idx, tgt_key_col_idx,
@@ -2679,7 +2679,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
         pGetFilterDuckDBExprs(filter_expr, adj_output_cols, nullptr,
                               adj_output_cols->Size(), filter_duckdb_exprs);
         duckdb::CypherPhysicalOperator *duckdb_filter_op =
-            new duckdb::PhysicalFilter(schema_adj, move(filter_duckdb_exprs));
+            ownOp<duckdb::PhysicalFilter>(schema_adj, move(filter_duckdb_exprs));
         result->push_back(duckdb_filter_op);
 
         // Construct projection
@@ -2693,7 +2693,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
                                     output_types_proj, proj_exprs);
                 if (proj_exprs.size() != 0) {
                     duckdb::CypherPhysicalOperator *duckdb_proj_op =
-                        new duckdb::PhysicalProjection(schema_proj,
+                        ownOp<duckdb::PhysicalProjection>(schema_proj,
                                                        move(proj_exprs));
                     result->push_back(duckdb_proj_op);
                 }
@@ -2843,7 +2843,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
         // Construct IdSeek Operator
         duckdb::CypherPhysicalOperator *duckdb_idseek_op;
         if (!filter_in_seek) {
-            duckdb_idseek_op = new duckdb::PhysicalIdSeek(
+            duckdb_idseek_op = ownOp<duckdb::PhysicalIdSeek>(
                 schema_seek, edge_id_col_idx, seek_obj_ids,
                 output_projection_mappings_seek /* not used */,
                 outer_col_maps_seek, inner_col_maps_seek,
@@ -2877,7 +2877,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
                 }
             }
             // Construct IdSeek Operator for filter
-            duckdb_idseek_op = new duckdb::PhysicalIdSeek(
+            duckdb_idseek_op = ownOp<duckdb::PhysicalIdSeek>(
                 schema_seek, edge_id_col_idx, seek_obj_ids,
                 output_projection_mappings_seek /* not used */,
                 outer_col_maps_seek, inner_col_maps_seek,
@@ -3069,7 +3069,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToVarlenAdjIdxJoin(
     uint64_t upper_bound = pathscan_op->UpperBound();
     uint64_t lower_bound = pathscan_op->LowerBound();
     if (upper_bound == -1) upper_bound = std::numeric_limits<uint64_t>::max();
-    duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalVarlenAdjIdxJoin(
+    duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalVarlenAdjIdxJoin>(
         tmp_schema, path_index_oids, duckdb::JoinType::INNER, sid_col_idx, false,
         lower_bound, upper_bound, outer_col_map,
         inner_col_map, std::move(dst_partition_ids),
@@ -3575,7 +3575,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekNormal(CExpression *plan_e
             if (proj_exprs.size() != 0) {
                 D_ASSERT(proj_exprs.size() == output_cols->Size());
                 duckdb::CypherPhysicalOperator *op =
-                    new duckdb::PhysicalProjection(tmp_schema,
+                    ownOp<duckdb::PhysicalProjection>(tmp_schema,
                                                    std::move(proj_exprs));
                 result->push_back(op);
 
@@ -3859,7 +3859,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekNormal(CExpression *plan_e
         if (has_filter) {
             D_ASSERT(per_schema_filter_exprs.size() == inner_col_maps.size());
             D_ASSERT(filter_col_idxs.size() == inner_col_maps.size());
-            duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalIdSeek(
+            duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalIdSeek>(
                 tmp_schema, sid_col_idx, oids, output_projection_mapping,
                 outer_col_map, inner_col_maps, union_inner_col_map,
                 scan_projection_mapping, scan_types, per_schema_filter_exprs, filter_col_idxs,
@@ -3868,7 +3868,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekNormal(CExpression *plan_e
             result->push_back(op);
         }
         else {
-            duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalIdSeek(
+            duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalIdSeek>(
                 tmp_schema, sid_col_idx, oids, output_projection_mapping,
                 outer_col_map, inner_col_maps, union_inner_col_map,
                 scan_projection_mapping, scan_types, force_output_union, join_type,
@@ -3879,7 +3879,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekNormal(CExpression *plan_e
     }
     else {
         D_ASSERT(false);
-        duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalIdSeek(
+        duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalIdSeek>(
             tmp_schema, sid_col_idx, oids, output_projection_mapping,
             outer_col_map, inner_col_maps, union_inner_col_map,
             scan_projection_mapping, scan_types, false, join_type,
@@ -4184,7 +4184,7 @@ void Planner::
             size_t n_outer = GetActiveTailOperator(result)
                                  ? GetActiveTailOperator(result)->GetNumOutputSchemas()
                                  : 1;
-            duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalIdSeek(
+            duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalIdSeek>(
                 tmp_schema, sid_col_idx, oids, output_projection_mapping,
                 outer_col_map, inner_col_maps, union_inner_col_map,
                 scan_projection_mapping, scan_types, true, join_type,
@@ -4302,7 +4302,7 @@ void Planner::
                                 output_types_proj, proj_exprs);
             if (proj_exprs.size() != 0) {
                 duckdb::CypherPhysicalOperator *duckdb_proj_op =
-                    new duckdb::PhysicalProjection(schema_proj,
+                    ownOp<duckdb::PhysicalProjection>(schema_proj,
                                                     move(proj_exprs));
                 result->push_back(duckdb_proj_op);
             }
@@ -4493,7 +4493,7 @@ void Planner::
         duckdb::Schema schema_condition_filter;
         schema_condition_filter.setStoredTypes(output_types_condition_filter);
         duckdb::CypherPhysicalOperator *duckdb_filter_op =
-            new duckdb::PhysicalFilter(schema_condition_filter, move(condition_filter_duckdb_exprs));
+            ownOp<duckdb::PhysicalFilter>(schema_condition_filter, move(condition_filter_duckdb_exprs));
         result->push_back(duckdb_filter_op);
     }
 
@@ -4505,7 +4505,7 @@ void Planner::
                                    ? GetActiveTailOperator(result)->GetNumOutputSchemas()
                                    : 1;
     if (!do_filter_pushdown) {
-        duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalIdSeek(
+        duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalIdSeek>(
             seek_schema, sid_col_idx, oids, projection_mapping,
             outer_col_map, inner_col_maps, union_inner_col_map,
             scan_projection_mapping, scan_types, false, join_type,
@@ -4519,7 +4519,7 @@ void Planner::
             pGetDuckDBTypesFromColRefs(pushed_filter_output_cols, output_types_filter);
             schema_filter.setStoredTypes(output_types_filter);
             duckdb::CypherPhysicalOperator *duckdb_filter_op =
-                new duckdb::PhysicalFilter(schema_filter, move(pushed_filter_duckdb_exprs));
+                ownOp<duckdb::PhysicalFilter>(schema_filter, move(pushed_filter_duckdb_exprs));
             result->push_back(duckdb_filter_op);
 
             // Construct projection
@@ -4533,7 +4533,7 @@ void Planner::
                                     output_types_proj, proj_exprs);
                 if (proj_exprs.size() != 0) {
                     duckdb::CypherPhysicalOperator *duckdb_proj_op =
-                        new duckdb::PhysicalProjection(schema_proj,
+                        ownOp<duckdb::PhysicalProjection>(schema_proj,
                                                        move(proj_exprs));
                     result->push_back(duckdb_proj_op);
                 }
@@ -4917,7 +4917,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekDSI(CExpression *plan_expr
                                         proj_exprs);
         if (proj_exprs.size() != 0) {
             duckdb::CypherPhysicalOperator *duckdb_proj_op =
-                new duckdb::PhysicalProjection(schema_proj,
+                ownOp<duckdb::PhysicalProjection>(schema_proj,
                                                 move(proj_exprs));
             result->push_back(duckdb_proj_op);
         }
@@ -4943,7 +4943,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekDSI(CExpression *plan_expr
         duckdb::Schema schema_cycle_filter;
         schema_cycle_filter.setStoredTypes(output_types_cycle_filter);
         duckdb::CypherPhysicalOperator *duckdb_filter_op =
-            new duckdb::PhysicalFilter(schema_cycle_filter, move(cycle_filter_duckdb_exprs));
+            ownOp<duckdb::PhysicalFilter>(schema_cycle_filter, move(cycle_filter_duckdb_exprs));
         result->push_back(duckdb_filter_op);
     }
 
@@ -4959,7 +4959,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekDSI(CExpression *plan_expr
                                    ? GetActiveTailOperator(result)->GetNumOutputSchemas()
                                    : 1;
     if (!do_filter_pushdown) {
-        duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalIdSeek(
+        duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalIdSeek>(
             tmp_schema, sid_col_idx, oids, output_projection_mapping,
             outer_col_map, inner_col_maps, union_inner_col_map,
             scan_projection_mapping, scan_types, false, join_type,
@@ -4973,7 +4973,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekDSI(CExpression *plan_expr
             duckdb::Schema schema_filter;
             schema_filter.setStoredTypes(output_types_filter);
             duckdb::CypherPhysicalOperator *duckdb_filter_op =
-                new duckdb::PhysicalFilter(schema_filter, move(filter_duckdb_exprs));
+                ownOp<duckdb::PhysicalFilter>(schema_filter, move(filter_duckdb_exprs));
             result->push_back(duckdb_filter_op);
 
             // Construct projection
@@ -4987,7 +4987,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekDSI(CExpression *plan_expr
                                     output_types_proj, proj_exprs);
                 if (proj_exprs.size() != 0) {
                     duckdb::CypherPhysicalOperator *duckdb_proj_op =
-                        new duckdb::PhysicalProjection(schema_proj,
+                        ownOp<duckdb::PhysicalProjection>(schema_proj,
                                                        move(proj_exprs));
                     result->push_back(duckdb_proj_op);
                 }
@@ -5046,7 +5046,7 @@ void Planner::pTransformEopPhysicalInnerIndexNLJoinToProjectionForUnionAllInner(
 
     // define op
     duckdb::CypherPhysicalOperator *op =
-        new duckdb::PhysicalProjection(proj_schema, move(proj_exprs));
+        ownOp<duckdb::PhysicalProjection>(proj_schema, move(proj_exprs));
     result->push_back(op);
 
     // generate schema flow graph
@@ -5195,7 +5195,7 @@ Planner::pTransformEopPhysicalHashJoinToHashJoin(CExpression *plan_expr)
     duckdb::Schema schema;
     schema.setStoredTypes(hash_output_types);
 
-    duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalHashJoin(
+    duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalHashJoin>(
         schema, move(join_conds), join_type, left_col_map, right_col_map,
         right_build_types, right_build_map);
     pSetExplicitPhysicalOutputLayout(hash_output_cols);
@@ -5300,7 +5300,7 @@ Planner::pTransformEopPhysicalMergeJoinToMergeJoin(CExpression *plan_expr)
         rhs_types.push_back(pConvertTypeOidToLogicalType(type_oid, type_mod));
     }
 
-    duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalPiecewiseMergeJoin(
+    duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalPiecewiseMergeJoin>(
         schema, move(join_conds), join_type, lhs_types, rhs_types, left_col_map,
         right_col_map);
 
@@ -5371,7 +5371,7 @@ Planner::pTransformEopPhysicalInnerNLJoinToCartesianProduct(
     schema.setStoredTypes(types);
 
     duckdb::CypherPhysicalOperator *op =
-        new duckdb::PhysicalCrossProduct(schema, left_col_map, right_col_map);
+        ownOp<duckdb::PhysicalCrossProduct>(schema, left_col_map, right_col_map);
     pSetExplicitPhysicalOutputLayout(physical_output_cols);
     return pBuildSchemaflowGraphForBinaryJoin(plan_expr, op, schema,
                                               lhs_result, rhs_result);
@@ -5449,7 +5449,7 @@ Planner::pTransformEopPhysicalNLJoinToBlockwiseNLJoin(CExpression *plan_expr,
     pShiftFilterPredInnerColumnIndices(join_condition_expr,
                                        actual_outer_cols->Size());
 
-    duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalBlockwiseNLJoin(
+    duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalBlockwiseNLJoin>(
         schema, move(join_condition_expr), join_type, outer_col_map,
         inner_col_map);
 
@@ -5500,7 +5500,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopLimit(
 
 
     duckdb::CypherPhysicalOperator *op =
-        new duckdb::PhysicalTop(tmp_schema, limit, offset);
+        ownOp<duckdb::PhysicalTop>(tmp_schema, limit, offset);
     result->push_back(op);
 
     return result;
@@ -5731,7 +5731,7 @@ Planner::pTransformEopProjectionColumnar(CExpression *plan_expr)
 
 
     duckdb::CypherPhysicalOperator *op =
-        new duckdb::PhysicalProjection(tmp_schema, std::move(proj_exprs));
+        ownOp<duckdb::PhysicalProjection>(tmp_schema, std::move(proj_exprs));
     result->push_back(op);
 
     return result;
@@ -5886,7 +5886,7 @@ Planner::pTransformEopProjectionColumnar(CExpression *plan_expr)
 //         proj_schema.setStoredColumnNames(output_column_names_proj);
 //         pBuildSchemaFlowGraphForUnaryOperator(proj_schema);
 //         duckdb::CypherPhysicalOperator *proj_op =
-//             new duckdb::PhysicalProjection(proj_schema, move(proj_exprs));
+//             ownOp<duckdb::PhysicalProjection>(proj_schema, move(proj_exprs));
 //         result->push_back(proj_op);
 //     }
 
@@ -5894,11 +5894,11 @@ Planner::pTransformEopProjectionColumnar(CExpression *plan_expr)
 
 //     duckdb::CypherPhysicalOperator *op;
 //     if (agg_groups.empty()) {
-//         op = new duckdb::PhysicalHashAggregate(
+//         op = ownOp<duckdb::PhysicalHashAggregate>(
 //             agg_schema, output_projection_mapping, move(agg_exprs));
 //     }
 //     else {
-//         op = new duckdb::PhysicalHashAggregate(
+//         op = ownOp<duckdb::PhysicalHashAggregate>(
 //             agg_schema, output_projection_mapping, move(agg_exprs),
 //             move(agg_groups));
 //     }
@@ -5930,7 +5930,7 @@ Planner::pTransformEopProjectionColumnar(CExpression *plan_expr)
 //         // post_proj_schema.setStoredTypes(post_proj_type);
 //         // pBuildSchemaFlowGraphForUnaryOperator(post_proj_schema);
 //         // duckdb::CypherPhysicalOperator *post_proj_op =
-//         //     new duckdb::PhysicalProjection(post_proj_schema, move(post_proj_exprs));
+//         //     ownOp<duckdb::PhysicalProjection>(post_proj_schema, move(post_proj_exprs));
 //         // new_result->push_back(post_proj_op);
 //     }
 //     return new_result;
@@ -6189,7 +6189,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopAgg(
         duckdb::Schema passthru_schema;
         passthru_schema.setStoredTypes(passthru_types);
         passthru_schema.setStoredColumnNames(passthru_names);
-        auto *proj_op = new duckdb::PhysicalProjection(passthru_schema,
+        auto *proj_op = ownOp<duckdb::PhysicalProjection>(passthru_schema,
                                                         move(passthru_exprs));
         result->push_back(proj_op);
         return result;
@@ -6202,17 +6202,17 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopAgg(
         proj_schema.setStoredTypes(proj_types);
         proj_schema.setStoredColumnNames(output_column_names_proj);
         duckdb::CypherPhysicalOperator *proj_op =
-            new duckdb::PhysicalProjection(proj_schema, move(proj_exprs));
+            ownOp<duckdb::PhysicalProjection>(proj_schema, move(proj_exprs));
         result->push_back(proj_op);
     }
     duckdb::CypherPhysicalOperator *op;
     if (agg_groups.empty()) {
-        op = new duckdb::PhysicalHashAggregate(
+        op = ownOp<duckdb::PhysicalHashAggregate>(
             tmp_schema, output_projection_mapping, move(agg_exprs),
             node_pid_idxs);
     }
     else {
-        op = new duckdb::PhysicalHashAggregate(
+        op = ownOp<duckdb::PhysicalHashAggregate>(
             tmp_schema, output_projection_mapping, move(agg_exprs),
             move(agg_groups), node_pid_idxs);
     }
@@ -6367,7 +6367,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopPhysicalFilter(
     duckdb::CypherPhysicalOperator *last_op = GetActiveTailOperator(result);
     tmp_schema.setStoredTypes(last_op->GetTypes());
     duckdb::CypherPhysicalOperator *op =
-        new duckdb::PhysicalFilter(tmp_schema, move(filter_exprs));
+        ownOp<duckdb::PhysicalFilter>(tmp_schema, move(filter_exprs));
     result->push_back(op);
 
     // generate schema flow graph for the filter
@@ -6387,7 +6387,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopPhysicalFilter(
         }
         if (proj_exprs.size() != 0) {
             D_ASSERT(proj_exprs.size() == output_cols->Size());
-            duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalProjection(
+            duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalProjection>(
                 output_schema, std::move(proj_exprs));
             result->push_back(op);
 
@@ -6455,7 +6455,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopSort(
 
 
     duckdb::CypherPhysicalOperator *op =
-        new duckdb::PhysicalSort(tmp_schema, move(orders));
+        ownOp<duckdb::PhysicalSort>(tmp_schema, move(orders));
     result->push_back(op);
 
     // break pipeline
@@ -6557,11 +6557,11 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopTopNSort(
 
     duckdb::CypherPhysicalOperator *op;
     if (has_limit) {
-        op = new duckdb::PhysicalTopNSort(tmp_schema, move(orders), limit,
+        op = ownOp<duckdb::PhysicalTopNSort>(tmp_schema, move(orders), limit,
                                           offset);
     }
     else {
-        op = new duckdb::PhysicalSort(tmp_schema, move(orders));
+        op = ownOp<duckdb::PhysicalSort>(tmp_schema, move(orders));
     }
 
     result->push_back(op);
@@ -6659,7 +6659,7 @@ duckdb::CypherPhysicalOperatorGroups* Planner::pTransformEopShortestPath(CExpres
     D_ASSERT(pmdindex != nullptr);
     OID path_index_oid_bwd = CMDIdGPDB::CastMdid(pmdindex->MDId())->Oid();
 
-    duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalShortestPathJoin(schema, path_index_oid_fwd, path_index_oid_bwd,
+    duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalShortestPathJoin>(schema, path_index_oid_fwd, path_index_oid_bwd,
                                                     input_col_map, output_idx, src_id_idx, dest_id_idx, lower_bound, upper_bound);
     result->push_back(op);
 
@@ -6794,7 +6794,7 @@ duckdb::CypherPhysicalOperatorGroups* Planner::pTransformEopAllShortestPath(CExp
     D_ASSERT(pmdindex != nullptr);
     OID path_index_oid_bwd = CMDIdGPDB::CastMdid(pmdindex->MDId())->Oid();
 
-    duckdb::CypherPhysicalOperator *op = new duckdb::PhysicalAllShortestPathJoin(schema, path_index_oid_fwd, path_index_oid_bwd,
+    duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalAllShortestPathJoin>(schema, path_index_oid_fwd, path_index_oid_bwd,
                                                     input_col_map, output_idx, src_id_idx, dest_id_idx, lower_bound, upper_bound);
     result->push_back(op);
 
@@ -9012,7 +9012,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopUnnest(
             }
         }
 
-        auto *op = new duckdb::PhysicalConstScan(scan_schema, std::move(scan_rows));
+        auto *op = ownOp<duckdb::PhysicalConstScan>(scan_schema, std::move(scan_rows));
         auto *result = new duckdb::CypherPhysicalOperatorGroups();
         result->push_back(op);
         return result;
@@ -9061,7 +9061,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopUnnest(
     tmp_schema.setStoredTypes(out_types);
 
     duckdb::CypherPhysicalOperator *op =
-        new duckdb::PhysicalUnwind(tmp_schema, list_col_idx);
+        ownOp<duckdb::PhysicalUnwind>(tmp_schema, list_col_idx);
     result->push_back(op);
 
 

--- a/test/query/helpers/query_runner.hpp
+++ b/test/query/helpers/query_runner.hpp
@@ -149,6 +149,9 @@ public:
                     } else if (ct == ColType::STRING || dtype == TURBOLYNX_TYPE_VARCHAR) {
                         turbolynx_string sv = turbolynx_get_varchar(rw, (idx_t)c);
                         v = std::string(sv.data, sv.size);
+                        // turbolynx_get_varchar mallocs the buffer; the
+                        // caller owns it. Free after copying into v.
+                        free(sv.data);
                     } else if (ct == ColType::UINT64 || dtype == TURBOLYNX_TYPE_UBIGINT) {
                         v = (int64_t)turbolynx_get_uint64(rw, (idx_t)c);
                     } else if (dtype == TURBOLYNX_TYPE_HUGEINT) {


### PR DESCRIPTION
## What

This is the body of #276's Phase-2 cleanup work. With the SignalShield-only ASan lane already running on every PR (#260 / #263), turning LSan on top of it surfaced ~14 MB of leaked memory per single \`query_test\` invocation, dominated by plan-tree and operator-state objects that were heap-allocated with raw \`new\` and never deleted.

11 commits, each one a focused ownership / lifetime fix verified against the LSan baseline on the mini fixtures:

| Commit | What it does |
|--------|--------------|
| \`fix(planner): own pipeline executors via unique_ptr\` | \`genPipelineExecutors\` returns \`vector<unique_ptr<CypherPipelineExecutor>>\`; both call sites stop manually \`delete\`-ing each entry. ~PipelineExecutor now also frees its heap-allocated \`ExecutionContext\`. |
| \`fix(orca): scope-guard histogram buffers in RetrieveColStats\` | The \`AttStatsSlot\`'s \`Datum[]\` arrays leaked on every early return from \`RetrieveColStats\`. Add a stack RAII guard. |
| \`fix(capi): free prepared_statement->plan in close_prepared_statement\` | The \`strdup\`'d plan string was never freed; close now releases it. |
| \`fix(planner): delete owned pipelines in reset() and ~Planner\` | \`Planner::pipelines\` (vector<CypherPipeline*>) was \`clear()\`'d but the pipeline objects themselves were leaking per query. |
| \`fix(planner): centralize PhysicalOperator ownership in Planner\` | 76 \`new duckdb::PhysicalX(...)\` sites in planner_physical.cpp go through a single \`Planner::ownOp<T>(args...)\` helper backed by a \`vector<unique_ptr<CypherPhysicalOperator>>\`. \`Group\` / \`Pipeline\` keep raw observer pointers — only the owner moves. Sole owner across the boundary-shared sink-vs-source ops, no double-free. |
| \`fix(execution): delete IdSeekState's heap-allocated ExtentIterator\` | The state stored \`ext_it = new ExtentIterator(...)\` and had no destructor. |
| \`fix(execution): delete AdjIdxJoinState's owned AdjacencyListIterators\` | \`adj_it\` / \`adj_it_bwd\` and the multi-partition \`adj_its_multi\` / \`bwd_its_multi\` vectors were all raw-\`new\`'d and leaked. |
| \`fix(execution): delete VarlenAdjIdxJoinState's DFSIterator / iso_checker\` | Same pattern, varlen path. |
| \`test(helpers): free turbolynx_get_varchar's malloc'd buffer\` | QueryRunner copied the malloc'd \`char*\` into a \`std::string\` and dropped the C buffer; every VARCHAR column read leaked one malloc. |
| \`fix(converter): centralize LogicalPlan ownership in Cypher2OrcaConverter\` | 9 \`new turbolynx::LogicalPlan(...)\` sites in cypher2orca_converter.cpp go through \`Cypher2OrcaConverter::ownPlan<>()\` backed by a \`vector<unique_ptr<LogicalPlan>>\` — same shape as the Planner work above. |
| \`fix(execution): own CypherPhysicalOperatorGroup objects via unique_ptr\` | The last raw \`new\` site in the plan tree. \`Groups\` gains an \`owned_groups\` backing store, becomes move-only; \`CypherPipeline\` ctor switches to \`Groups&&\`; \`pTransformEopUnionAll\` / \`pGenPhysicalPlan\` transfer the inner unique_ptrs to \`Planner::owned_groups\` so the shared child references stay valid past their parent's deletion. |

## Effect

LSan numbers on the mini fixtures, against the same ASan binary that already runs in CI:

| step          | start    | end       | reduction |
|---------------|---------:|----------:|----------:|
| [types]       | 354 KB   | **3 KB**  | −99% |
| [tpch]        | 214 KB   | 29 KB     | −86% |
| [ldbc][count] | 193 KB   | 12 KB     | −94% |
| [ldbc][traversal] | 138 KB | 37 KB   | −73% |
| **[ldbc][is]** | **18.5 MB** | **4 KB** | **−99.98%** |
| [ldbc][ic]    | 280 KB → 9.8 MB after some exposures | **19 KB** | −93% |
| [ldbc][func]  | 657 KB   | **3 KB**  | −99.5% |
| [ldbc][robustness] | 128 KB | 122 KB | −5% |
| [ldbc][filter] | 81 KB | 1.5 MB | (see below) |

For most steps the per-process LSan total drops from MB to single-digit KB.

## The [ldbc][filter] number

\`[ldbc][filter]\` looks like it grew. Investigated and split out:

- Running each \`[ldbc][filter]\` test individually — leak is 0–2 KB.
- Running the whole step in one process — leak is 1.5 MB.
- 524 KB \`Indirect leak\` chains to \`fillEidToMappingIdx\` → \`PhysicalIdSeek::GetOperatorState\` → \`CypherPipelineExecutor::ReinitializePipeline\` (\`pipeline_executor.cpp:127\`).

This is a **test-suite-level pollution** between cases on the shared singleton \`QueryRunner\`, not a per-query lifetime gap that this PR's per-instance ownership work addresses. The earlier commits previously kept these allocations transitively reachable through the leaked plan tree; once the tree is cleanly released the pollution becomes visible. Filed as a follow-up, tracked off #276.

## Stack

Stacked on top of #287 (\`fix-ic12-sigsegv-and-wrapper\`). Each commit is independently buildable + verified against the LSan baseline at the time it was made; the 11 are easy to bisect if anything regresses.

Rebase to main once #287 lands.

## Verification

- Linux Debug+ASan container build (\`build-ubuntu-asan\`) — no compiler errors, no use-after-free / double-free / heap-overflow reported by ASan across the full sweep.
- Per-step LSan numbers above.
- \`[ldbc][ic]\` is 18 / 18 (including #288's IC10 + IC11 which are stacked on top of this); no functional regression on any other step.

## Out of scope

- The \`[ldbc][filter]\` test-pollution leak chain (see above).
- The remaining \`[ldbc][robustness]\` 122 KB (small, mixed sources — next pass).
- Enabling LSan unconditionally in the workflow (\`detect_leaks=1\`). With this PR landed the residual floor is small enough to make a meaningful \`asan_suppressions.txt\` baseline practical — that's the next follow-up under #276.