### PR TITLE
fix(planner+converter): own ORCA serialize buffer + Groups collections (LSan follow-up)

### DIFF
--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -372,6 +372,11 @@ CExpression *Cypher2OrcaConverter::ConvertLiteral(const BoundLiteralExpression &
         mp_, (IMDId *)type_mdid, type_mod, ser_ptr, ser_len,
         val.IsNull(), lint_val, double_val));
     datum->AddRef();
+    // CDatumGenericGPDB's ctor memcpy's the bytes into its own memory
+    // pool — it does not take ownership of the malloc'd buffer.
+    // SerializeValueIntoOrcaBytes documents that the caller is
+    // responsible for free(), so release it now.
+    free(ser_ptr);
 
     CExpression *pexpr = GPOS_NEW(mp_) CExpression(
         mp_, GPOS_NEW(mp_) CScalarConst(mp_, (IDatum *)datum));

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -550,6 +550,18 @@ private:
 		owned_groups.emplace_back(g);
 		return g;
 	}
+
+	// Sole owner of every CypherPhysicalOperatorGroups collection the
+	// pTransform* paths return as a raw pointer. Group entries inside
+	// are self-owned (Groups::owned_groups); this vector owns the
+	// outer Groups shell so caller paths can keep the raw return-pointer
+	// idiom without leaking.
+	vector<unique_ptr<duckdb::CypherPhysicalOperatorGroups>> owned_group_collections;
+	duckdb::CypherPhysicalOperatorGroups *ownGroups() {
+		owned_group_collections.emplace_back(
+		    std::make_unique<duckdb::CypherPhysicalOperatorGroups>());
+		return owned_group_collections.back().get();
+	}
 	std::map<CColRef *, std::string> property_col_to_output_col_names_mapping; 	// actual output col names for property columns
 	// Complex type registry: stores full LogicalType for types that can't be
 	// represented by ORCA's (OID, INT modifier) pair (e.g. STRUCT with named fields).

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -2147,6 +2147,10 @@ turbolynx_state turbolynx_close_property(turbolynx_property *property) {
 		next = property->next;
 		free(property->property_name);
 		free(property->property_sql_type);
+		// label_name is strdup'd in turbolynx_get_label_name_type_from_ccolref
+		// (or the metadata loops in extract_query_metadata); free is a no-op
+		// if it was left NULL by the OTHER branch.
+		free(property->label_name);
 		free(property);
 		property = next;
 	}

--- a/src/optimizer/orca/gpopt/translate/CTranslatorTBGPPToDXL.cpp
+++ b/src/optimizer/orca/gpopt/translate/CTranslatorTBGPPToDXL.cpp
@@ -259,10 +259,10 @@ CMDName *
 CTranslatorTBGPPToDXL::GetRelName(CMemoryPool *mp, duckdb::PropertySchemaCatalogEntry *rel)
 {
 	GPOS_ASSERT(NULL != rel);
-	CHAR *relname = std::strcpy(new char[rel->GetName().length() + 1], rel->GetName().c_str());
-	// CHAR *relname = const_cast<CHAR *>(rel->GetName().c_str());
+	std::unique_ptr<CHAR[]> relname(
+		std::strcpy(new char[rel->GetName().length() + 1], rel->GetName().c_str()));
 	CWStringDynamic *relname_str =
-		CDXLUtils::CreateDynamicStringFromCharArray(mp, relname);
+		CDXLUtils::CreateDynamicStringFromCharArray(mp, relname.get());
 	CMDName *mdname = GPOS_NEW(mp) CMDName(mp, relname_str);
 	GPOS_DELETE(relname_str);
 	return mdname;
@@ -1833,7 +1833,9 @@ CTranslatorTBGPPToDXL::RetrieveScOp(CMemoryPool *mp, IMDId *mdid)
 
 	// get operator name
 	string name_str = duckdb::GetOpName(op_oid);
-	CHAR *name = std::strcpy(new char[name_str.length() + 1], name_str.c_str()); // TODO avoid copy?
+	std::unique_ptr<CHAR[]> name_buf(
+		std::strcpy(new char[name_str.length() + 1], name_str.c_str()));
+	CHAR *name = name_buf.get();
 
 	if (NULL == name)
 	{
@@ -2023,7 +2025,9 @@ CTranslatorTBGPPToDXL::RetrieveFunc(CMemoryPool *mp, IMDId *mdid)
 
 	// get func name
 	string name_str = scalar_func_cat->GetName();
-	CHAR *name = std::strcpy(new char[name_str.length() + 1], name_str.c_str());
+	std::unique_ptr<CHAR[]> name_buf(
+		std::strcpy(new char[name_str.length() + 1], name_str.c_str()));
+	CHAR *name = name_buf.get();
 
 	if (NULL == name)
 	{
@@ -2108,7 +2112,9 @@ CTranslatorTBGPPToDXL::RetrieveAgg(CMemoryPool *mp, IMDId *mdid)
 
 	// get agg name
 	string name_str = agg_func_cat->GetName();
-	CHAR *name = std::strcpy(new char[name_str.length() + 1], name_str.c_str());
+	std::unique_ptr<CHAR[]> name_buf(
+		std::strcpy(new char[name_str.length() + 1], name_str.c_str()));
+	CHAR *name = name_buf.get();
 
 	if (NULL == name)
 	{
@@ -2299,12 +2305,13 @@ CTranslatorTBGPPToDXL::GetTypeName(CMemoryPool *mp, IMDId *mdid)
 
 	GPOS_ASSERT(InvalidOid != oid_type);
 
-	CHAR *typename_str = std::strcpy(new char[duckdb::GetTypeName(oid_type).length() + 1], duckdb::GetTypeName(oid_type).c_str());
-	//CHAR *typename_str = const_cast<char *>(duckdb::GetTypeName(oid_type).c_str());
+	std::unique_ptr<CHAR[]> typename_str(
+		std::strcpy(new char[duckdb::GetTypeName(oid_type).length() + 1],
+		            duckdb::GetTypeName(oid_type).c_str()));
 	GPOS_ASSERT(NULL != typename_str);
 
 	CWStringDynamic *str_name =
-		CDXLUtils::CreateDynamicStringFromCharArray(mp, typename_str);
+		CDXLUtils::CreateDynamicStringFromCharArray(mp, typename_str.get());
 	CMDName *mdname = GPOS_NEW(mp) CMDName(mp, str_name);
 
 	// cleanup
@@ -2443,10 +2450,10 @@ CTranslatorTBGPPToDXL::RetrieveRelStats(CMemoryPool *mp, IMDId *mdid)
 	GPOS_TRY
 	{
 		// get rel name
-		CHAR *relname = std::strcpy(new char[rel->GetName().length() + 1], rel->GetName().c_str()); // TODO free
-		// CHAR *relname = const_cast<CHAR *>(rel->GetName().c_str());
+		std::unique_ptr<CHAR[]> relname(
+			std::strcpy(new char[rel->GetName().length() + 1], rel->GetName().c_str()));
 		CWStringDynamic *relname_str =
-			CDXLUtils::CreateDynamicStringFromCharArray(mp, relname);
+			CDXLUtils::CreateDynamicStringFromCharArray(mp, relname.get());
 		mdname = GPOS_NEW(mp) CMDName(mp, relname_str);
 		// CMDName ctor created a copy of the string
 		GPOS_DELETE(relname_str);
@@ -3042,7 +3049,9 @@ CTranslatorTBGPPToDXL::RetrieveScCmp(CMemoryPool *mp, IMDId *mdid)
 	}
 
 	string name_str = duckdb::GetOpName(scalar_cmp_oid);
-	CHAR *name = std::strcpy(new char[name_str.length() + 1], name_str.c_str()); // TODO avoid copy?
+	std::unique_ptr<CHAR[]> name_buf(
+		std::strcpy(new char[name_str.length() + 1], name_str.c_str()));
+	CHAR *name = name_buf.get();
 
 	if (NULL == name)
 	{

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -68,6 +68,7 @@ Planner::~Planner()
     pipelines.clear();
     owned_operators.clear();
     owned_groups.clear();
+    owned_group_collections.clear();
     CMDCache::Shutdown();
     CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(this->memory_pool);
 }
@@ -105,6 +106,7 @@ void Planner::reset()
     // teardown sees live memory, then release the operators / groups.
     owned_operators.clear();
     owned_groups.clear();
+    owned_group_collections.clear();
     pruned_key_ids.clear();
     logical_plan_output_col_names.clear();
     logical_plan_output_colrefs.clear();

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -7943,11 +7943,14 @@ bool Planner::pIsColEdgeProperty(const CColRef *colref)
         return false;
     }
     const CName &col_name = colref->Name();
-    wchar_t *full_col_name, *col_only_name, *first_token, *pt;
-    full_col_name = new wchar_t[std::wcslen(col_name.Pstr()->GetBuffer()) + 1];
-    std::wcscpy(full_col_name, col_name.Pstr()->GetBuffer());
-    first_token = std::wcstok(full_col_name, L".", &pt);
-    col_only_name = std::wcstok(NULL, L".", &pt);
+    // Heap-allocated working buffer so wcstok can mutate it; release on
+    // every return path so callers in tight loops don't accumulate it.
+    std::unique_ptr<wchar_t[]> full_col_name(
+        new wchar_t[std::wcslen(col_name.Pstr()->GetBuffer()) + 1]);
+    std::wcscpy(full_col_name.get(), col_name.Pstr()->GetBuffer());
+    wchar_t *pt = nullptr;
+    wchar_t *first_token = std::wcstok(full_col_name.get(), L".", &pt);
+    wchar_t *col_only_name = std::wcstok(NULL, L".", &pt);
 
     // Use column-only part after "." if present; otherwise use the full name (no dot).
     // Columns like "_id", "_sid", "_tid" may appear without a table prefix.
@@ -8723,11 +8726,14 @@ duckdb::AdjIdxIdIdxs Planner::pGetAdjIdxIdIdxs(CColRefArray *inner_cols, IMDInde
         CColRef *colref = inner_cols->operator[](col_idx);
         CColRefTable *colref_table = (CColRefTable *)colref;
         const CName &col_name = colref_table->Name();
-        wchar_t *full_col_name, *col_only_name, *first_token, *pt;
-        full_col_name = new wchar_t[std::wcslen(col_name.Pstr()->GetBuffer()) + 1];
-        std::wcscpy(full_col_name, col_name.Pstr()->GetBuffer());
-        first_token = std::wcstok(full_col_name, L".", &pt);
-        col_only_name = std::wcstok(NULL, L".", &pt);
+        // wcstok mutates its buffer, so we need a per-iteration copy that
+        // is also released at the end of each iteration.
+        std::unique_ptr<wchar_t[]> full_col_name(
+            new wchar_t[std::wcslen(col_name.Pstr()->GetBuffer()) + 1]);
+        std::wcscpy(full_col_name.get(), col_name.Pstr()->GetBuffer());
+        wchar_t *pt = nullptr;
+        wchar_t *first_token = std::wcstok(full_col_name.get(), L".", &pt);
+        wchar_t *col_only_name = std::wcstok(NULL, L".", &pt);
 
         // Use column-only part after "." if present; otherwise use the full name.
         const wchar_t *effective_name = (col_only_name != NULL) ? col_only_name : first_token;

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -478,7 +478,7 @@ void Planner::pGenPhysicalPlan(CExpression *orca_plan_root)
     auto *top_result = pTraverseTransformPhysicalPlan(orca_plan_root);
     duckdb::CypherPhysicalOperatorGroups final_pipeline_ops =
         std::move(*top_result);
-    delete top_result;
+    // top_result is owned by Planner::owned_group_collections; no delete.
 
     // Standalone OPTIONAL MATCH wrapper (#203, #204): insert PhysicalOptional
     // between the final piped op and PhysicalProduceResults so a 0-row MATCH
@@ -759,7 +759,7 @@ Planner::pTraverseTransformPhysicalPlan(CExpression *plan_expr)
 			// TODO: extract actual datum values for non-empty ConstTableGet
 
 			auto *op = ownOp<duckdb::PhysicalConstScan>(ctg_schema, std::move(const_rows));
-			result = new duckdb::CypherPhysicalOperatorGroups();
+			result = ownGroups();
 			result->push_back(op);
 			break;
 		}
@@ -838,7 +838,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
     auto *mp = this->memory_pool;
 
     // leaf node
-    auto result = new duckdb::CypherPhysicalOperatorGroups();
+    auto result = ownGroups();
 
     CExpression *scan_expr = NULL;
     CExpression *filter_expr = NULL;
@@ -1356,7 +1356,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
 
     auto *mp = this->memory_pool;
     duckdb::Catalog &cat_instance = context->db->GetCatalog();
-    auto result = new duckdb::CypherPhysicalOperatorGroups();
+    auto result = ownGroups();
 
     // variables for scan op
     vector<uint64_t> oids;
@@ -1584,7 +1584,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
              COperator::EOperatorId::EopPhysicalSerialUnionAll);
 
     // Result containers for processing projections and schemas
-    auto result = new duckdb::CypherPhysicalOperatorGroups();
+    auto result = ownGroups();
     vector<uint64_t> oids;
     vector<vector<uint64_t>> projection_mapping;
     vector<vector<uint64_t>> scan_projection_mapping;
@@ -1896,7 +1896,7 @@ Planner::pTransformEopUnionAll(CExpression *plan_expr)
 {
     auto *mp = this->memory_pool;
 
-    duckdb::CypherPhysicalOperatorGroups *result = new duckdb::CypherPhysicalOperatorGroups();
+    duckdb::CypherPhysicalOperatorGroups *result = ownGroups();
     duckdb::CypherPhysicalOperatorGroup *union_group = ownGroup();
 
     CExpressionArray *childs = plan_expr->PdrgPexpr();
@@ -1906,14 +1906,9 @@ Planner::pTransformEopUnionAll(CExpression *plan_expr)
         CExpression *child_expr = childs->operator[](i);
         auto child_result = pTraverseTransformPhysicalPlan(child_expr);
         union_group->PushBack(child_result->GetGroups());
-        // The shared Group raw pointers in union_group->childs alias into
-        // child_result.owned_groups. Move those unique_ptrs into Planner
-        // so the Group objects outlive child_result (which we drop now).
-        for (auto &g : child_result->owned_groups) {
-            owned_groups.push_back(std::move(g));
-        }
-        child_result->owned_groups.clear();
-        delete child_result;
+        // child_result is owned by Planner::owned_group_collections; the
+        // shared raw Group pointers it hands union_group stay live for
+        // the whole planning step.
     }
 
     result->push_back(union_group);
@@ -6231,7 +6226,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopAgg(
     auto pipeline = new duckdb::CypherPipeline(std::move(*result), pipelines.size());
     pipelines.push_back(pipeline);
     // new pipeline
-    auto new_result = new duckdb::CypherPhysicalOperatorGroups();
+    auto new_result = ownGroups();
     new_result->push_back(op);
 
     return new_result;
@@ -6472,7 +6467,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopSort(
     auto pipeline = new duckdb::CypherPipeline(std::move(*result), pipelines.size());
     pipelines.push_back(pipeline);
 
-    auto new_result = new duckdb::CypherPhysicalOperatorGroups();
+    auto new_result = ownGroups();
     new_result->push_back(op);
 
 
@@ -6580,7 +6575,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopTopNSort(
     auto pipeline = new duckdb::CypherPipeline(std::move(*result), pipelines.size());
     pipelines.push_back(pipeline);
 
-    auto new_result = new duckdb::CypherPhysicalOperatorGroups();
+    auto new_result = ownGroups();
     new_result->push_back(op);
 
 
@@ -9023,7 +9018,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopUnnest(
         }
 
         auto *op = ownOp<duckdb::PhysicalConstScan>(scan_schema, std::move(scan_rows));
-        auto *result = new duckdb::CypherPhysicalOperatorGroups();
+        auto *result = ownGroups();
         result->push_back(op);
         return result;
     }


### PR DESCRIPTION
## What

Per-query memory leaks that the centralised plan-tree ownership in #289 had not yet captured. Five small commits, each focused.

### 1. `SerializeValueIntoOrcaBytes` malloc never freed

`SerializeValueIntoOrcaBytes` produces a small malloc'd buffer per scalar literal and documents "Caller is responsible for free()". Its single caller (`ConvertLiteral`) hands the buffer into `CDatumGenericGPDB`'s ctor, but the ctor does `GPOS_NEW_ARRAY + memcpy` onto its own memory pool — so the malloc'd region is never taken over. Every literal in every query leaked a few bytes. Add the free.

### 2. `CypherPhysicalOperatorGroups` outer shells leak

PR #289 plugged the Group entries (`Groups::owned_groups`) and the standalone Group case (`Planner::owned_groups + ownGroup`). What still leaked was the outer `CypherPhysicalOperatorGroups` collection that every `pTransform*` returns by raw pointer. The series so far had hacked around it with two ad-hoc `delete child_result` / `delete top_result` calls in `pTransformEopUnionAll` and `pGenPhysicalPlan` — the other 7 callers got nothing and the deletes themselves became dangerous when the move from #289 landed.

Match the surrounding pattern: add `Planner::owned_group_collections` plus `ownGroups()`, route all 9 `new CypherPhysicalOperatorGroups()` sites through it, and remove the ad-hoc deletes. `pTransformEopUnionAll`'s per-child unique_ptr-shuffle disappears with them.

### 3. wcstok scratch buffers in the planner

`Planner::pIsColEdgeProperty` and `Planner::pGetAdjIdxIdIdxs` each `new wchar_t[…]` per CColRef just to feed `std::wcstok`. Both wrapped in `std::unique_ptr<wchar_t[]>`.

### 4. `turbolynx_property::label_name` strdup leak

`turbolynx_get_label_name_type_from_ccolref` `strdup`'s the label name into `turbolynx_property::label_name`, but `turbolynx_close_property` only released `property_name` / `property_sql_type`. Add the `free`. `free(NULL)` covers the no-label branch.

### 5. ORCA name-handling raw `new char[…]` sites

`GetTypeName` / `GetRelName` / `RetrieveScOp` / `RetrieveFunc` / `RetrieveAggregate` / `RetrieveRelStats` / `RetrieveScCmp` all `new char[…]` a working buffer just to call `CDXLUtils::CreateDynamicStringFromCharArray`. CDXLUtils makes its own copy, so each `new`'d buffer leaked at function return. All 7 wrapped in `std::unique_ptr<CHAR[]>`; the pre-existing `// TODO free` / `// TODO avoid copy?` comments are gone.

## Effect

LSan totals on the mini fixtures, Linux Debug+ASan:

| step              | before #291 | after |
|-------------------|------------:|------:|
| [types]           |  17 KB | **0** |
| [tpch]            |  92 KB |  3 KB |
| [ldbc][count]     |  39 KB | **0** |
| [ldbc][traversal] | 171 KB |  7 KB |
| [ldbc][is]        |  17 KB | **0** |
| [ldbc][ic]        |  56 KB | **0** |
| [ldbc][robustness]| 193 KB | 45 KB |
| [ldbc][func]      |  18 KB | **0** |

Five of nine steps now report zero leaked bytes from LSan. The residual `[ldbc][robustness]` 45 KB is mostly LogicalSchema-copy paths in `Cypher2OrcaConverter`'s throw cases — chasing them further turns into a converter-lifecycle audit that's better tracked separately. `[ldbc][filter]` is still dominated by #290 (the pattern-comprehension `[(p)<-[…] WHERE p.id = X | 1.0]` SEGV).

## Stack

Stacked on #289. Rebase to main once that lands.

## Verification

- All ASan steps run clean (no use-after-free / double-free / heap-overflow).
- Functional pass on every step probed.