### PR TITLE
fix(common): initialize VectorCache nested metadata for empty caches (#290)

### DIFF
--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -118,11 +118,17 @@ public:
 
 private:
 	void Initialize() {
-		if (cache_size == 0) return;
 		auto internal_type = type.InternalType();
+		// Only the data buffer is gated by cache_size — the auxiliary
+		// list/struct metadata must be set up even for empty caches
+		// because ResetFromCache dereferences it unconditionally
+		// (issue #290: cache_size == 0 left auxiliary == nullptr and
+		// crashed the LIST branch on the very next dereference).
 		switch (internal_type) {
 		case PhysicalType::ADJLIST: {
-			owned_data = shared_ptr<data_t[]>(new data_t[cache_size * GetTypeIdSize(internal_type)]);
+			if (cache_size > 0) {
+				owned_data = shared_ptr<data_t[]>(new data_t[cache_size * GetTypeIdSize(internal_type)]);
+			}
 			LogicalType child_type = LogicalType::UBIGINT;
 			child_caches.push_back(make_buffer<VectorCacheBuffer>(child_type));
 			auto child_vector = make_unique<Vector>(child_type, false, false);
@@ -131,7 +137,9 @@ private:
 		}
 		case PhysicalType::LIST: {
 			// memory for the list offsets
-			owned_data = shared_ptr<data_t[]>(new data_t[cache_size * GetTypeIdSize(internal_type)]);
+			if (cache_size > 0) {
+				owned_data = shared_ptr<data_t[]>(new data_t[cache_size * GetTypeIdSize(internal_type)]);
+			}
 			// child data of the list
 			if (!type.AuxInfo()) {
 				type = LogicalType::LIST(LogicalType::UBIGINT);
@@ -152,7 +160,7 @@ private:
 			break;
 		}
 		default:
-			if (GetTypeIdSize(internal_type) > 0) {
+			if (cache_size > 0 && GetTypeIdSize(internal_type) > 0) {
 				owned_data = shared_ptr<data_t[]>(new data_t[cache_size * GetTypeIdSize(internal_type)]);
 			}
 			break;

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -248,7 +248,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::Convert(const BoundRegularQuery &q
     }
 
     // Return plan with the first query's schema (column names).
-    return GPOS_NEW(mp_) turbolynx::LogicalPlan(union_expr, *first_schema);
+    return ownPlan(union_expr, *first_schema);
 }
 
 // ============================================================

--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -1514,7 +1514,7 @@ CExpression *Cypher2OrcaConverter::ConvertExistsSubquery(
         inner_expr->AddRef();
         CExpression *select_expr = CUtils::PexprLogicalSelect(mp_, inner_expr, corr_pred);
 
-        inner_plan = GPOS_NEW(mp_) turbolynx::LogicalPlan(
+        inner_plan = ownPlan(
             select_expr, *inner_plan->getSchema());
     } else {
         corr_preds->Release();
@@ -1597,7 +1597,7 @@ CExpression *Cypher2OrcaConverter::ConvertPatternComprehension(
         auto *inner_expr = inner_plan->getPlanExpr();
         inner_expr->AddRef();
         CExpression *select_expr = CUtils::PexprLogicalSelect(mp_, inner_expr, corr_pred);
-        inner_plan = GPOS_NEW(mp_) turbolynx::LogicalPlan(
+        inner_plan = ownPlan(
             select_expr, *inner_plan->getSchema());
     } else {
         corr_preds->Release();
@@ -1649,7 +1649,7 @@ CExpression *Cypher2OrcaConverter::ConvertPatternComprehension(
                     inner_expr_p, proj_list);
                 turbolynx::LogicalSchema new_schema = *inner_plan->getSchema();
                 new_schema.appendColumn(col_alias, pcr);
-                inner_plan = GPOS_NEW(mp_) turbolynx::LogicalPlan(
+                inner_plan = ownPlan(
                     proj_expr, new_schema);
             };
         auto make_var = [](const string &n) -> shared_ptr<BoundExpression> {

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -3386,10 +3386,18 @@ turbolynx_prepared_statement* turbolynx_prepare(int64_t conn_id, turbolynx_query
 		return nullptr;
 	}
 	compile_segv_set = true;
+	turbolynx_prepared_statement* prep_stmt = nullptr;
+	CypherPreparedStatement* cypher_stmt = nullptr;
 	try {
-		auto prep_stmt = (turbolynx_prepared_statement*)malloc(sizeof(turbolynx_prepared_statement));
+		prep_stmt = (turbolynx_prepared_statement*)malloc(sizeof(turbolynx_prepared_statement));
+		prep_stmt->query = nullptr;
+		prep_stmt->plan = nullptr;
+		prep_stmt->property = nullptr;
+		prep_stmt->num_properties = 0;
+		prep_stmt->__internal_prepared_statement = nullptr;
 		// Own the query text: caller may free/mutate their buffer after prepare.
 		char* owned_query = strdup(query);
+		prep_stmt->query = owned_query;
 		auto normalized_query = NormalizeQueryForPrepare(string(owned_query));
 		// Session config: PRAGMA threads = N / SET parallel_threads = N
 		// Apply immediately, return a no-op prepared statement marker.
@@ -3438,7 +3446,7 @@ turbolynx_prepared_statement* turbolynx_prepare(int64_t conn_id, turbolynx_query
 		rewritten = rewriteRemoveToSetNull(rewritten);
 		h->pending_detach_delete = is_detach;
 		prep_stmt->query = owned_query;
-		auto* cypher_stmt = new CypherPreparedStatement(rewritten);
+		cypher_stmt = new CypherPreparedStatement(rewritten);
 		prep_stmt->__internal_prepared_statement = reinterpret_cast<void*>(cypher_stmt);
 		if (cypher_stmt->getNumParams() > 0) {
 			// Parameterized query — defer compilation to execute time
@@ -3462,12 +3470,19 @@ turbolynx_prepared_statement* turbolynx_prepare(int64_t conn_id, turbolynx_query
 	} catch (const std::exception& e) {
 		spdlog::error("[turbolynx_prepare] exception: {}", e.what());
 		set_error(TURBOLYNX_ERROR_INVALID_STATEMENT, e.what());
-		return nullptr;
 	} catch (...) {
 		spdlog::error("[turbolynx_prepare] unknown exception");
 		set_error(TURBOLYNX_ERROR_INVALID_STATEMENT, "Unknown compilation error");
-		return nullptr;
 	}
+	// Release everything the partial-success path may have allocated.
+	if (prep_stmt) {
+		free(prep_stmt->query);
+		free(prep_stmt->plan);
+		turbolynx_close_property(prep_stmt->property);
+		free(prep_stmt);
+	}
+	delete cypher_stmt;
+	return nullptr;
 }
 
 turbolynx_state turbolynx_close_prepared_statement(turbolynx_prepared_statement* prepared_statement) {

--- a/src/optimizer/orca/gporca/libgpopt/base/CUtils.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/base/CUtils.cpp
@@ -749,6 +749,9 @@ CUtils::PexprCmpWithZero(CMemoryPool *mp, CExpression *pexprLeft,
 		void* serialized_literal = (void*)mem_ptr;
 		IDatumGeneric *datum = (IDatumGeneric*) (GPOS_NEW(mp) CDatumGenericGPDB(mp, (IMDId*)type_mdid, 0, serialized_literal, serialized_literal_length, false /*isnull*/, (LINT)0, (CDouble)0.0));
 		datum->AddRef();
+		// CDatumGenericGPDB copies the bytes into the memory pool; the
+		// malloc'd buffer is no longer needed.
+		free(mem_ptr);
 		pexprRight = GPOS_NEW(mp)
 			CExpression(mp, GPOS_NEW(mp) CScalarConst(mp, (IDatum *) datum));
 		pexprRight->AddRef();

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -638,8 +638,12 @@ vector<unique_ptr<duckdb::CypherPipelineExecutor>> Planner::genPipelineExecutors
         auto &pipe = pipelines[pipe_idx];
 
         // find children and deps - the child/dep ordering matters.
-        // must run in ascending order of the vector
-        auto *new_ctxt = new duckdb::ExecutionContext(context);
+        // must run in ascending order of the vector. new_ctxt is held in
+        // a unique_ptr so that an exception out of CypherPipelineExecutor's
+        // ctor below (e.g. GetLocalSourceState() throwing on an invalid
+        // plan) releases the context instead of leaking it; ownership
+        // transfers via .release() once the executor accepts it.
+        auto new_ctxt_owner = std::make_unique<duckdb::ExecutionContext>(context);
         vector<duckdb::CypherPipelineExecutor *>
             child_executors;  // child : pipe's sink == op's source
         std::map<duckdb::CypherPhysicalOperator *,
@@ -694,8 +698,17 @@ vector<unique_ptr<duckdb::CypherPipelineExecutor>> Planner::genPipelineExecutors
                 }
             }
         }
-        executors.push_back(std::make_unique<duckdb::CypherPipelineExecutor>(
-            new_ctxt, pipe, move(child_executors), move(dep_executors)));
+        duckdb::ExecutionContext *ctx_raw = new_ctxt_owner.release();
+        try {
+            executors.push_back(std::make_unique<duckdb::CypherPipelineExecutor>(
+                ctx_raw, pipe, move(child_executors), move(dep_executors)));
+        } catch (...) {
+            // CypherPipelineExecutor's ctor (GetLocalSourceState etc.) threw
+            // before it adopted the context — release the raw pointer
+            // ourselves so the partial construction doesn't leak.
+            delete ctx_raw;
+            throw;
+        }
     }
 
     return executors;

--- a/test/query/helpers/query_runner.hpp
+++ b/test/query/helpers/query_runner.hpp
@@ -110,6 +110,7 @@ public:
             char *errmsg = nullptr;
             turbolynx_get_last_error(&errmsg);
             std::string msg = errmsg ? errmsg : query;
+            turbolynx_close_prepared_statement(prep);
             throw std::runtime_error(msg);
         }
 


### PR DESCRIPTION
## What

Two follow-ups stacked into a single PR:

### 1. Empty LIST cache SEGV — closes #290

\`VectorCacheBuffer::Initialize\` had \`if (cache_size == 0) return;\` at the top, so a LIST cache constructed with capacity 0 left \`auxiliary == nullptr\` and \`child_caches\` empty. The very next \`ResetFromCache\` call dereferenced \`result.auxiliary\`, segfaulting deep in \`VectorCacheBuffer::ResetFromCache\` (vector_cache.cpp:65).

\`PhysicalProduceResults::Sink\` tripped on this every time the pattern-comprehension \`[(p)<-[…] WHERE p.id = X | 1.0]\` query (\`[ldbc][filter]\` "pattern comprehension with WHERE") ran, because the input chunk arrived empty (size 0). \`SignalShield\` caught the SEGV and turned it into a clean exception, but \`siglongjmp\` leaves the stack unwound — so the abandoned plan tree + executor state stayed pinned and showed up as ~1.5 MB of leaked memory on the filter step.

Drop the early return. Gate only the data-buffer allocation on \`cache_size > 0\`; the auxiliary list/struct metadata is set up unconditionally so \`ResetFromCache\` can dereference it safely on empty caches.

### 2. Drive every remaining LSan step to zero

A handful of small leaks were still left after the first commit. Hunting them one by one drove every \`[ldbc]\` / \`[tpch]\` / \`[types]\` ASan step to **0 bytes leaked**:

- **converter**: the remaining 4 raw \`GPOS_NEW(mp_) LogicalPlan(...)\` sites in \`cypher2orca_scalar.cpp\` and \`cypher2orca_converter.cpp\` went through \`ownPlan\` like the rest. GPOS_NEW allocates from an ORCA memory pool that does not run C++ destructors, so the embedded \`LogicalSchema\`'s vector/set/map storage leaked per query.

- **capi (turbolynx_prepare)**: the partial-success path leaked the \`turbolynx_prepared_statement\` struct, the strdup'd query text, the new \`CypherPreparedStatement\` and the strdup'd plan whenever any step after the malloc threw. Hoist \`prep_stmt\` + \`cypher_stmt\` to scope above the try, zero-init pointer fields up front, and add a single cleanup tail that runs on either catch.

- **test helper (QueryRunner::run)**: threw on \`TURBOLYNX_ERROR\` without closing the successfully-prepared statement, leaking its plan string, query string and metadata. Add the close call before the throw.

- **planner (genPipelineExecutors)**: the per-pipeline \`new ExecutionContext(context)\` leaked if \`CypherPipelineExecutor\`'s ctor (\`GetLocalSourceState\` on an invalid plan) threw. Move it under a \`unique_ptr\`, \`release()\` only after the executor accepts ownership, and rescue+rethrow on ctor failure.

- **orca (CUtils::PexprCmpWithZero)**: the malloc'd serialized literal buffer leaked once \`CDatumGenericGPDB\`'s ctor memcpy'd it into the memory pool. Add the matching \`free\` — same pattern as \`SerializeValueIntoOrcaBytes\` in PR #291.

## Effect

LSan totals on the mini fixtures (Linux Debug+ASan):

| step              | start of cleanup series | end |
|-------------------|------------------------:|----:|
| [types]           | 354 KB | **0** |
| [tpch]            | 214 KB | **0** |
| [ldbc][count]     | 193 KB | **0** |
| [ldbc][traversal] | 138 KB | **0** |
| [ldbc][is]        | 18.5 MB | **0** |
| [ldbc][ic]        | 280 KB | **0** |
| [ldbc][robustness]| 193 KB | **0** |
| [ldbc][filter]    |  81 KB | **0** |
| [ldbc][func]      | 657 KB | **0** |

Total leaked bytes on a full mini test sweep go from ~20 MB to **0**. The Sanitize CI lane can be flipped to \`detect_leaks=1\` without any suppressions baseline — #276's final phase becomes a straightforward workflow change.

## Stack

Stacked on #291. Rebase to main once that lands.

Closes #290.