### PR TITLE
docs: trim verbose comments across the LSan cleanup series

### DIFF
--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -119,11 +119,8 @@ public:
 private:
 	void Initialize() {
 		auto internal_type = type.InternalType();
-		// Only the data buffer is gated by cache_size — the auxiliary
-		// list/struct metadata must be set up even for empty caches
-		// because ResetFromCache dereferences it unconditionally
-		// (issue #290: cache_size == 0 left auxiliary == nullptr and
-		// crashed the LIST branch on the very next dereference).
+		// auxiliary must be set up even for empty caches; ResetFromCache
+		// derefs it unconditionally.
 		switch (internal_type) {
 		case PhysicalType::ADJLIST: {
 			if (cache_size > 0) {

--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -372,10 +372,7 @@ CExpression *Cypher2OrcaConverter::ConvertLiteral(const BoundLiteralExpression &
         mp_, (IMDId *)type_mdid, type_mod, ser_ptr, ser_len,
         val.IsNull(), lint_val, double_val));
     datum->AddRef();
-    // CDatumGenericGPDB's ctor memcpy's the bytes into its own memory
-    // pool — it does not take ownership of the malloc'd buffer.
-    // SerializeValueIntoOrcaBytes documents that the caller is
-    // responsible for free(), so release it now.
+    // CDatumGenericGPDB copied the bytes.
     free(ser_ptr);
 
     CExpression *pexpr = GPOS_NEW(mp_) CExpression(

--- a/src/execution/execution/cypher_pipeline_executor.cpp
+++ b/src/execution/execution/cypher_pipeline_executor.cpp
@@ -94,10 +94,7 @@ CypherPipelineExecutor::~CypherPipelineExecutor() {
 	for (auto &op_state : local_operator_states) {
 		op_state.reset();
 	}
-	// context is heap-allocated per executor in Planner::genPipelineExecutors
-	// and is not shared with any other executor (each pipeline gets its own
-	// `new ExecutionContext`). pipeline is owned by the Planner, not by us.
-	delete context;
+	delete context;  // owned per executor; pipeline is owned by Planner.
 }
 
 void CypherPipelineExecutor::ReinitializePipeline()

--- a/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
+++ b/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
@@ -364,15 +364,8 @@ uint64_t PhysicalVarlenAdjIdxJoin::VarlengthExpand_internal(ExecutionContext& co
 		}
 		state.dfs_it->initialize(*context.client, src_vid, state.adj_col_idxs, adj_col_is_fwds, state.src_partition_ids);
 		if (state.cur_lv >= state.start_lv) {
-			// Cypher zero-length VLE: the source vertex itself is the
-			// length-0 binding only if it also matches the dst vertex
-			// pattern. dst_partition_ids here is the dst pattern's
-			// vertex partitions (set in cypher2orca_converter from
-			// n.GetPartitionIDs(), not the edge schema terminals).
-			// Without this guard, IC12's `(tag:Tag)-[..*0..]->(c:TagClass)`
-			// emits the Tag vid into the c column, after which IdSeek
-			// reads it under the TagClass schema and dereferences
-			// garbage string_t buffers (SEGV at string_t::VerifyNull).
+			// Zero-hop emits the src vid into the dst column; only
+			// safe if src's partition is in the dst pattern's set.
 			uint16_t resolved_src_partition = (uint16_t)(src_vid >> 48);
 			bool zero_hop_dst_ok = dst_partition_ids.empty() ||
 			                       dst_partition_ids.count(resolved_src_partition) > 0;

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -382,12 +382,7 @@ private:
 
     bool IsCastingFunction(const string &func_name);
 
-    // Helper: heap-construct a LogicalPlan, take ownership in
-    // owned_logical_plans_, and return the raw pointer for downstream
-    // wiring. Replaces the legacy `new turbolynx::LogicalPlan(args)`
-    // pattern. Cypher2OrcaConverter is the sole owner of every plan
-    // node it produces; downstream consumers (Planner) only read the
-    // tree via the returned pointer and never delete it.
+    // Heap-construct and take ownership. Planner reads but never deletes.
     template <typename... Args>
     turbolynx::LogicalPlan *ownPlan(Args &&...args) {
         auto p = new turbolynx::LogicalPlan(std::forward<Args>(args)...);

--- a/src/include/execution/cypher_physical_operator_group.hpp
+++ b/src/include/execution/cypher_physical_operator_group.hpp
@@ -134,25 +134,20 @@ class CypherPhysicalOperatorGroups {
 public:
     CypherPhysicalOperatorGroups() = default;
 
-    // owned_groups carries unique_ptrs, so the collection is move-only.
-    // CypherPipeline takes the Groups by rvalue and moves out of it.
+    // Move-only: owned_groups carries unique_ptrs.
     CypherPhysicalOperatorGroups(const CypherPhysicalOperatorGroups &) = delete;
     CypherPhysicalOperatorGroups &operator=(const CypherPhysicalOperatorGroups &) = delete;
     CypherPhysicalOperatorGroups(CypherPhysicalOperatorGroups &&) noexcept = default;
     CypherPhysicalOperatorGroups &operator=(CypherPhysicalOperatorGroups &&) noexcept = default;
 
+    // Self-owning: this overload heap-allocates the Group.
     void push_back(CypherPhysicalOperator *op) {
-        // Self-owned: the Group object is heap-allocated here and is
-        // only ever observed through `groups`. Tracked in owned_groups
-        // so ~CypherPhysicalOperatorGroups releases it.
         owned_groups.emplace_back(std::make_unique<CypherPhysicalOperatorGroup>(op));
         groups.push_back(owned_groups.back().get());
     }
 
+    // Externally-owned: caller (Planner::ownGroup or another Groups) keeps it alive.
     void push_back(CypherPhysicalOperatorGroup *group) {
-        // Externally-owned: the caller (Planner::ownGroup or another
-        // Groups instance's owned_groups) keeps the Group alive. We
-        // only borrow the pointer.
         groups.push_back(group);
     }
 
@@ -204,9 +199,7 @@ public:
     }
 
     vector<CypherPhysicalOperatorGroup *> groups;
-    // Backing storage for the Group entries this collection allocated
-    // via push_back(CypherPhysicalOperator*). Externally-pushed Group
-    // pointers (push_back(Group*)) are not tracked here.
+    // Backing storage for push_back(op); push_back(Group*) is not tracked here.
     vector<std::unique_ptr<CypherPhysicalOperatorGroup>> owned_groups;
 };
 

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -520,17 +520,9 @@ private:
 	// used and initialized in each execution
 	duckdb::BoundRegularQuery *bound_regular_query;								// input bound query
 	vector<duckdb::CypherPipeline *> pipelines;									// output plan pipelines
-	// Sole owner of every PhysicalOperator the pTransform* / pGenPhysicalPlan
-	// paths build during plan generation. CypherPhysicalOperatorGroup,
-	// CypherPipeline, and downstream PipelineExecutor reference these as raw
-	// observer pointers — the unique_ptrs here own them. reset() and ~Planner
-	// drop the vector after the pipelines that point into it have already
-	// been deleted, so observer accesses during teardown see live memory.
+	// Plan-tree owners. Group / Pipeline / PipelineExecutor hold raw
+	// observer pointers into these.
 	vector<unique_ptr<duckdb::CypherPhysicalOperator>> owned_operators;
-	// Helper: heap-construct a PhysicalOperator subclass, take ownership in
-	// owned_operators, and return the raw pointer for use in Group /
-	// Pipeline wiring. Replaces the legacy `new duckdb::PhysicalX(args)`
-	// pattern at the pTransform* call sites.
 	template <typename T, typename... Args>
 	T *ownOp(Args &&...args) {
 		auto p = new T(std::forward<Args>(args)...);
@@ -538,11 +530,8 @@ private:
 		return p;
 	}
 
-	// Sole owner of every CypherPhysicalOperatorGroup that the planner
-	// allocates standalone (i.e. not via Groups::push_back(op), which
-	// self-owns). Used for the union_group in pTransformEopUnionAll
-	// and similar paths where a Group is heap-allocated separately
-	// from any Groups collection.
+	// Standalone Groups (e.g. UnionAll's union_group); Groups created
+	// via Groups::push_back(op) are self-owned.
 	vector<unique_ptr<duckdb::CypherPhysicalOperatorGroup>> owned_groups;
 	template <typename... Args>
 	duckdb::CypherPhysicalOperatorGroup *ownGroup(Args &&...args) {
@@ -551,11 +540,7 @@ private:
 		return g;
 	}
 
-	// Sole owner of every CypherPhysicalOperatorGroups collection the
-	// pTransform* paths return as a raw pointer. Group entries inside
-	// are self-owned (Groups::owned_groups); this vector owns the
-	// outer Groups shell so caller paths can keep the raw return-pointer
-	// idiom without leaking.
+	// Outer Groups shells returned by pTransform*.
 	vector<unique_ptr<duckdb::CypherPhysicalOperatorGroups>> owned_group_collections;
 	duckdb::CypherPhysicalOperatorGroups *ownGroups() {
 		owned_group_collections.emplace_back(

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -2147,9 +2147,6 @@ turbolynx_state turbolynx_close_property(turbolynx_property *property) {
 		next = property->next;
 		free(property->property_name);
 		free(property->property_sql_type);
-		// label_name is strdup'd in turbolynx_get_label_name_type_from_ccolref
-		// (or the metadata loops in extract_query_metadata); free is a no-op
-		// if it was left NULL by the OTHER branch.
 		free(property->label_name);
 		free(property);
 		property = next;
@@ -3474,7 +3471,6 @@ turbolynx_prepared_statement* turbolynx_prepare(int64_t conn_id, turbolynx_query
 		spdlog::error("[turbolynx_prepare] unknown exception");
 		set_error(TURBOLYNX_ERROR_INVALID_STATEMENT, "Unknown compilation error");
 	}
-	// Release everything the partial-success path may have allocated.
 	if (prep_stmt) {
 		free(prep_stmt->query);
 		free(prep_stmt->plan);
@@ -4574,10 +4570,7 @@ int64_t turbolynx_execute_raw(int64_t conn_id,
 
         auto& query_results = *(executors.back()->context->query_results);
         out_col_names = h->planner->getQueryOutputColNames();
-        // Copy the sink schema before any path that may RefreshCatalogAndPlanner
-        // (ApplyPendingSetMutations / ApplyPendingDeleteMutations both can,
-        // and reset() drops owned_operators — which includes the sink op
-        // whose `schema` we'd otherwise hold a dangling reference into).
+        // ApplyPending* below may reset the planner; copy before the sink dangles.
         out_schema = executors.back()->pipeline->GetSink()->schema;
 
         if (!h->pending_set_items.empty()) {

--- a/src/optimizer/orca/gpopt/translate/CTranslatorTBGPPToDXL.cpp
+++ b/src/optimizer/orca/gpopt/translate/CTranslatorTBGPPToDXL.cpp
@@ -2654,11 +2654,8 @@ CTranslatorTBGPPToDXL::RetrieveColStats(CMemoryPool *mp,
 
 	// histogram values extracted from the pg_statistic tuple for a given column
 	AttStatsSlot hist_slot{};
-	// GetHistogramInfo populates hist_slot.values / .freq_values with raw
-	// `new Datum[...]` allocations (tbgppdbwrappers.cpp:142,148). AttStatsSlot
-	// is a plain C struct with no destructor, and this function has many
-	// return paths — without a scope guard each early return leaks the two
-	// arrays.
+	// AttStatsSlot is a C struct; release GetHistogramInfo's new[] buffers
+	// on every return path.
 	struct HistSlotGuard {
 		AttStatsSlot &s;
 		~HistSlotGuard() {

--- a/src/optimizer/orca/gporca/libgpopt/base/CUtils.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/base/CUtils.cpp
@@ -749,8 +749,7 @@ CUtils::PexprCmpWithZero(CMemoryPool *mp, CExpression *pexprLeft,
 		void* serialized_literal = (void*)mem_ptr;
 		IDatumGeneric *datum = (IDatumGeneric*) (GPOS_NEW(mp) CDatumGenericGPDB(mp, (IMDId*)type_mdid, 0, serialized_literal, serialized_literal_length, false /*isnull*/, (LINT)0, (CDouble)0.0));
 		datum->AddRef();
-		// CDatumGenericGPDB copies the bytes into the memory pool; the
-		// malloc'd buffer is no longer needed.
+		// CDatumGenericGPDB copied the bytes.
 		free(mem_ptr);
 		pexprRight = GPOS_NEW(mp)
 			CExpression(mp, GPOS_NEW(mp) CScalarConst(mp, (IDatum *) datum));

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -61,9 +61,6 @@ Planner::~Planner()
         // crash; leak them and let the OS reclaim on process exit.
         return;
     }
-    // The last query's pipelines weren't reset()'d before the planner
-    // was destroyed — clean them up too. reset() handles all earlier
-    // queries on this planner.
     for (auto *p : pipelines) delete p;
     pipelines.clear();
     owned_operators.clear();
@@ -91,19 +88,10 @@ void Planner::orcaInit()
 
 void Planner::reset()
 {
-    // reset planner context
     bound_regular_query = nullptr;
-    // CypherPipeline objects are heap-allocated in the various
-    // pTransform* / pGenPhysicalPlan paths and stored as raw pointers
-    // here. clear() alone would drop the pointers but leak the objects;
-    // each query that ran on this planner would accumulate. The pipelines
-    // are owned solely by this vector — pipeline executors hold them as
-    // observer references and do not delete them.
+    // Pipelines first: they observe operators/groups.
     for (auto *p : pipelines) delete p;
     pipelines.clear();
-    // Order matters: pipelines hold raw observer pointers into
-    // owned_operators / owned_groups. Drop pipelines first so their
-    // teardown sees live memory, then release the operators / groups.
     owned_operators.clear();
     owned_groups.clear();
     owned_group_collections.clear();
@@ -637,12 +625,8 @@ vector<unique_ptr<duckdb::CypherPipelineExecutor>> Planner::genPipelineExecutors
     for (auto pipe_idx = 0; pipe_idx < pipelines.size(); pipe_idx++) {
         auto &pipe = pipelines[pipe_idx];
 
-        // find children and deps - the child/dep ordering matters.
-        // must run in ascending order of the vector. new_ctxt is held in
-        // a unique_ptr so that an exception out of CypherPipelineExecutor's
-        // ctor below (e.g. GetLocalSourceState() throwing on an invalid
-        // plan) releases the context instead of leaking it; ownership
-        // transfers via .release() once the executor accepts it.
+        // find children and deps - must run in ascending order of the vector.
+        // Hold new_ctxt in unique_ptr so a throwing executor ctor doesn't leak it.
         auto new_ctxt_owner = std::make_unique<duckdb::ExecutionContext>(context);
         vector<duckdb::CypherPipelineExecutor *>
             child_executors;  // child : pipe's sink == op's source
@@ -703,9 +687,7 @@ vector<unique_ptr<duckdb::CypherPipelineExecutor>> Planner::genPipelineExecutors
             executors.push_back(std::make_unique<duckdb::CypherPipelineExecutor>(
                 ctx_raw, pipe, move(child_executors), move(dep_executors)));
         } catch (...) {
-            // CypherPipelineExecutor's ctor (GetLocalSourceState etc.) threw
-            // before it adopted the context — release the raw pointer
-            // ourselves so the partial construction doesn't leak.
+            // ctor threw before adopting the context.
             delete ctx_raw;
             throw;
         }

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -478,7 +478,6 @@ void Planner::pGenPhysicalPlan(CExpression *orca_plan_root)
     auto *top_result = pTraverseTransformPhysicalPlan(orca_plan_root);
     duckdb::CypherPhysicalOperatorGroups final_pipeline_ops =
         std::move(*top_result);
-    // top_result is owned by Planner::owned_group_collections; no delete.
 
     // Standalone OPTIONAL MATCH wrapper (#203, #204): insert PhysicalOptional
     // between the final piped op and PhysicalProduceResults so a 0-row MATCH
@@ -1906,9 +1905,6 @@ Planner::pTransformEopUnionAll(CExpression *plan_expr)
         CExpression *child_expr = childs->operator[](i);
         auto child_result = pTraverseTransformPhysicalPlan(child_expr);
         union_group->PushBack(child_result->GetGroups());
-        // child_result is owned by Planner::owned_group_collections; the
-        // shared raw Group pointers it hands union_group stay live for
-        // the whole planning step.
     }
 
     result->push_back(union_group);
@@ -7943,8 +7939,7 @@ bool Planner::pIsColEdgeProperty(const CColRef *colref)
         return false;
     }
     const CName &col_name = colref->Name();
-    // Heap-allocated working buffer so wcstok can mutate it; release on
-    // every return path so callers in tight loops don't accumulate it.
+    // wcstok mutates its buffer.
     std::unique_ptr<wchar_t[]> full_col_name(
         new wchar_t[std::wcslen(col_name.Pstr()->GetBuffer()) + 1]);
     std::wcscpy(full_col_name.get(), col_name.Pstr()->GetBuffer());
@@ -8726,8 +8721,7 @@ duckdb::AdjIdxIdIdxs Planner::pGetAdjIdxIdIdxs(CColRefArray *inner_cols, IMDInde
         CColRef *colref = inner_cols->operator[](col_idx);
         CColRefTable *colref_table = (CColRefTable *)colref;
         const CName &col_name = colref_table->Name();
-        // wcstok mutates its buffer, so we need a per-iteration copy that
-        // is also released at the end of each iteration.
+        // wcstok mutates its buffer.
         std::unique_ptr<wchar_t[]> full_col_name(
             new wchar_t[std::wcslen(col_name.Pstr()->GetBuffer()) + 1]);
         std::wcscpy(full_col_name.get(), col_name.Pstr()->GetBuffer());


### PR DESCRIPTION
## What

Review feedback on the leak-cleanup series (#287 → #292): the comments accreted along the way are verbose. Most re-state mechanics already evident from the code or rehash the series' own narrative.

Trim them to the WHYs that aren't obvious from a glance:

- Lifecycle invariants ("Pipelines first: they observe operators/groups.", "ApplyPending* below may reset the planner; copy before the sink dangles.").
- Non-obvious semantics ("Move-only: owned_groups carries unique_ptrs.", "Self-owning" vs "Externally-owned" overloads).
- Decisions a reader is likely to question ("wcstok mutates its buffer.", "CDatumGenericGPDB copied the bytes.").

Everything else — restatements of what the code does, owner / observer narratives, references to specific issues / PRs / commit history — drops.

12 files, −78 lines net, **no behavioural change**.

## Verification

All 9 ASan steps still report 0 bytes leaked on the container baseline:

| step | leak |
|---|---:|
| [types] | 0 |
| [tpch] | 0 |
| [ldbc][count] | 0 |
| [ldbc][traversal] | 0 |
| [ldbc][is] | 0 |
| [ldbc][ic] | 0 |
| [ldbc][robustness] | 0 |
| [ldbc][filter] | 0 |
| [ldbc][func] | 0 |