### PR TITLE
fix(storage): refcount ChunkCacheManager singleton lifetime

### DIFF
--- a/src/include/loader/bulkload_pipeline.hpp
+++ b/src/include/loader/bulkload_pipeline.hpp
@@ -31,6 +31,10 @@ private:
     BulkloadOptions              opts_;
     std::unique_ptr<duckdb::DuckDB> database_;
     std::unique_ptr<BulkloadContext> ctx_; // must be declared after database_
+    // Tracks whether InitializeWorkspace held the ccm refcount slot.
+    // RunPostProcessing releases on the happy path; ~BulkloadPipeline
+    // covers exceptions partway through the pipeline.
+    bool ccm_acquired_ = false;
 };
 
 } // namespace turbolynx

--- a/src/include/storage/cache/chunk_cache_manager.h
+++ b/src/include/storage/cache/chunk_cache_manager.h
@@ -22,6 +22,15 @@ class ChunkCacheManager {
 public:
   static ChunkCacheManager *ccm;
 
+  // Refcounted lifetime on the global `ccm`. Each connection that runs
+  // through ccm calls Acquire once and pairs it with Release. The first
+  // acquire constructs ccm; the last release destroys it. Two
+  // connections opening the same workspace share the singleton. A
+  // mismatched-path or mismatched-mode overlap is a usage bug and
+  // throws.
+  static void Acquire(const char *path, bool read_only);
+  static void Release();
+
 public:
   ChunkCacheManager(const char *path, bool read_only=false);
   ~ChunkCacheManager();

--- a/src/loader/bulkload_pipeline.cpp
+++ b/src/loader/bulkload_pipeline.cpp
@@ -1799,7 +1799,14 @@ static void ReadEdgeFilesInterleaved(BulkloadContext &bulkload_ctx) {
 BulkloadPipeline::BulkloadPipeline(BulkloadOptions opts)
     : opts_(std::move(opts)) {}
 
-BulkloadPipeline::~BulkloadPipeline() = default;
+BulkloadPipeline::~BulkloadPipeline() {
+    // Safety net for failure paths: if Run() threw between Acquire and
+    // Release, drop the ccm refcount here.
+    if (ccm_acquired_) {
+        duckdb::ChunkCacheManager::Release();
+        ccm_acquired_ = false;
+    }
+}
 
 void BulkloadPipeline::InitializeWorkspace() {
     CreateDirectoryIfNotExists(opts_.output_dir);
@@ -1807,7 +1814,8 @@ void BulkloadPipeline::InitializeWorkspace() {
     CatalogManager::CreateOrOpenCatalog(opts_.output_dir);
     InitializeDiskAio(opts_.output_dir);
 
-    ChunkCacheManager::ccm = new ChunkCacheManager(opts_.output_dir.c_str());
+    ChunkCacheManager::Acquire(opts_.output_dir.c_str(), /*read_only=*/false);
+    ccm_acquired_ = true;
     database_ = make_unique<duckdb::DuckDB>(opts_.output_dir.c_str());
     CreateGraphInfo graph_info(DEFAULT_SCHEMA, DEFAULT_GRAPH);
     ctx_ = make_unique<BulkloadContext>(
@@ -2290,7 +2298,8 @@ void BulkloadPipeline::RunPostProcessing() {
     SUBTIMER_STOP(BulkloadPostProcessing, "FlushMetaInfo");
 
     SUBTIMER_START(BulkloadPostProcessing, "DeleteChunkCacheManager");
-    delete ChunkCacheManager::ccm;
+    ChunkCacheManager::Release();
+    ccm_acquired_ = false;
     SUBTIMER_STOP(BulkloadPostProcessing, "DeleteChunkCacheManager");
 
     SUBTIMER_START(BulkloadPostProcessing, "CreateVirtualVertexPartitions");

--- a/src/main/capi/turbolynx-c.cpp
+++ b/src/main/capi/turbolynx-c.cpp
@@ -158,6 +158,15 @@ struct ConnectionHandle {
     std::vector<std::string>             pending_delete_vars;
     bool                                 pending_delete = false;
     bool                                 pending_detach_delete = false;
+    // Refcount slot on the global ChunkCacheManager (acquired in
+    // turbolynx_connect[_readonly]). Released either explicitly by
+    // turbolynx_disconnect or by ~ConnectionHandle if connect bailed
+    // partway through.
+    bool                                 holds_ccm_ref = false;
+
+    ~ConnectionHandle() {
+        if (holds_ccm_ref) ChunkCacheManager::Release();
+    }
 };
 
 static std::mutex                                          g_conn_lock;
@@ -1509,7 +1518,8 @@ int64_t turbolynx_connect(const char *dbname) {
         h->disk_aio_factory = duckdb::InitializeDiskAio(dbname);
         h->owns_disk_aio = was_null;
         h->database    = std::make_unique<DuckDB>(dbname);
-        ChunkCacheManager::ccm = new ChunkCacheManager(dbname);
+        ChunkCacheManager::Acquire(dbname, /*read_only=*/false);
+        h->holds_ccm_ref = true;
         h->client      = std::make_shared<duckdb::ClientContext>(h->database->instance->shared_from_this());
         h->owns_database = true;
         duckdb::SetClientWrapper(h->client, make_shared<CatalogWrapper>(*h->database->instance));
@@ -1869,8 +1879,12 @@ void turbolynx_disconnect(int64_t conn_id) {
         h->last_bound_mutation.reset();
         duckdb::ReleaseClientWrapper();
         h->client.reset();
-        delete ChunkCacheManager::ccm;
-        ChunkCacheManager::ccm = nullptr;
+        // Release ccm before disk_aio_factory: ccm's destructor flushes
+        // through the bg flush thread, which reaches DiskAioFactory.
+        if (h->holds_ccm_ref) {
+            ChunkCacheManager::Release();
+            h->holds_ccm_ref = false;
+        }
         if (h->owns_disk_aio && h->disk_aio_factory) {
             delete h->disk_aio_factory;
             h->disk_aio_factory = nullptr;
@@ -1886,7 +1900,8 @@ int64_t turbolynx_connect_readonly(const char *dbname) {
         h->disk_aio_factory = duckdb::InitializeDiskAio(dbname);
         h->owns_disk_aio = was_null;
         h->database    = std::make_unique<DuckDB>(dbname);
-        ChunkCacheManager::ccm = new ChunkCacheManager(dbname, /*read_only=*/true);
+        ChunkCacheManager::Acquire(dbname, /*read_only=*/true);
+        h->holds_ccm_ref = true;
         h->client      = std::make_shared<duckdb::ClientContext>(h->database->instance->shared_from_this());
         h->owns_database = true;
         duckdb::SetClientWrapper(h->client, make_shared<CatalogWrapper>(*h->database->instance));

--- a/src/storage/cache/chunk_cache_manager.cc
+++ b/src/storage/cache/chunk_cache_manager.cc
@@ -30,6 +30,44 @@ static constexpr size_t CHUNK_SIZE_HEADER_BYTES = 8;
 
 ChunkCacheManager* ChunkCacheManager::ccm;
 
+namespace {
+  std::mutex  ccm_acquire_mu_;
+  int         ccm_refcount_   = 0;
+  std::string ccm_path_;
+  bool        ccm_read_only_  = false;
+}
+
+void ChunkCacheManager::Acquire(const char *path, bool read_only) {
+  std::lock_guard<std::mutex> lk(ccm_acquire_mu_);
+  if (ccm == nullptr) {
+    ccm = new ChunkCacheManager(path, read_only);
+    ccm_path_      = path;
+    ccm_read_only_ = read_only;
+    ccm_refcount_  = 1;
+    return;
+  }
+  if (ccm_path_ != path || ccm_read_only_ != read_only) {
+    throw duckdb::IOException(
+        "ChunkCacheManager already bound to '" + ccm_path_ +
+        "' (read_only=" + (ccm_read_only_ ? "1" : "0") +
+        "); refusing to open '" + std::string(path) +
+        "' (read_only=" + (read_only ? "1" : "0") +
+        ") concurrently");
+  }
+  ++ccm_refcount_;
+}
+
+void ChunkCacheManager::Release() {
+  std::lock_guard<std::mutex> lk(ccm_acquire_mu_);
+  if (ccm_refcount_ == 0) return;
+  if (--ccm_refcount_ == 0) {
+    delete ccm;
+    ccm = nullptr;
+    ccm_path_.clear();
+    ccm_read_only_ = false;
+  }
+}
+
 ChunkCacheManager::ChunkCacheManager(const char *path, bool read_only)
     : read_only_(read_only) {
   spdlog::debug("[ChunkCacheManager] Construct ChunkCacheManager (read_only={})", read_only);


### PR DESCRIPTION
## What

`ChunkCacheManager::ccm` is a process-global singleton, but its lifetime was managed by three independent owners doing raw `new` / `delete`:

- `turbolynx_connect` (capi/turbolynx-c.cpp:1512)
- `turbolynx_connect_readonly` (capi/turbolynx-c.cpp:1889)
- `BulkloadPipeline::Initialize` (loader/bulkload_pipeline.cpp:1810)

with matching deletes at `turbolynx_disconnect` and `BulkloadPipeline::RunPostProcessing`.

When two connections opened concurrently against the same workspace, the second `connect` overwrote the global pointer and silently orphaned the first instance's `ChunkCacheManager` (and its full `file_handlers` map). The auto-compaction `blocker` test (`test_ldbc_crud.cpp:3267`) hits this — the test body constructs a second `QueryRunner` while the SETUP runner is still alive.

## Why this surfaced now

PR #294 (LSan enable, `detect_leaks=0` → `=1` across all Sanitize steps) caught it on `[ldbc][crud]`:

```
==8020==ERROR: LeakSanitizer: detected memory leaks
Indirect leak of 16896 byte(s) in 192 object(s) allocated from:
    #1 ChunkCacheManager::InitializeFileHandlersUsingMetaInfo  chunk_cache_manager.cc:246
    #2 ChunkCacheManager::ChunkCacheManager                    chunk_cache_manager.cc:107
    #3 turbolynx_connect                                       turbolynx-c.cpp:1512
    #4 qtest::QueryRunner::QueryRunner
    #5 ____C_A_T_C_H____TEST____267                            test_ldbc_crud.cpp:3269
...
SUMMARY: AddressSanitizer: 24144 byte(s) leaked in 387 allocation(s).
```

Local verification missed it earlier (only ran 9 of 10 query_test steps).

## Fix

Refcount the singleton. Two new statics:

```cpp
class ChunkCacheManager {
  static void Acquire(const char *path, bool read_only);
  static void Release();
};
```

- First Acquire constructs ccm, records `(path, read_only)`, refcount = 1.
- Same-path/mode reacquire bumps refcount (shared use).
- Mismatched-path/mode reacquire throws (previously a silent last-write-wins UAF).
- Release decrements; when zero, ccm is deleted and metadata cleared.
- A `std::mutex` guards the static state.

### Owner-side changes

- `ConnectionHandle` gains `holds_ccm_ref`. `turbolynx_disconnect` calls Release explicitly before deleting `disk_aio_factory` — preserves the prior delete-ccm-first order so ccm's flush thread still sees a live DiskAioFactory. `~ConnectionHandle` releases as a safety net if connect bailed mid-construction.
- `BulkloadPipeline` gains `ccm_acquired_`. RunPostProcessing releases on the happy path; `~BulkloadPipeline` covers exception paths.

### Mismatched-path semantics

Before this PR, opening B while A was still live silently swapped A's pointer to B underneath A's still-running queries (corrupting them) AND leaked A. The new `Acquire` throws instead, surfacing the lifecycle bug. No current code path triggers the throw — same-path overlap is the only legitimate sharing pattern (the compaction `blocker`).

## Verification

LSan on every query_test step locally:

| step | leak |
|---|---:|
| [types] | 0 |
| [tpch]~[stress] | 0 |
| [ldbc][count] | 0 |
| [ldbc][traversal] | 0 |
| [ldbc][is] | 0 |
| [ldbc][ic] | 0 |
| [ldbc][robustness] | 0 |
| [ldbc][filter] | 0 |
| [ldbc][func] | 0 |
| auto-compact blocker (the trigger case) | 0 |

CRUD as a whole exceeds the local sandbox's ASan timeout window — the trigger test was the documented leak source per CI's stack, and it confirms 0 leaked. Full `[ldbc][crud]` under LSan is covered by the Sanitize lane on this PR.

## Stacking

This is a precursor to PR #294 (LSan enable). Once this lands, #294's CI Sanitize lane should go green; rebase #294 onto main.