### PR TITLE
refactor(common): introduce OwnsObjects mixin (make_owned<T>)

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -248,7 +248,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::Convert(const BoundRegularQuery &q
     }
 
     // Return plan with the first query's schema (column names).
-    return ownPlan(union_expr, *first_schema);
+    return make_owned<turbolynx::LogicalPlan>(union_expr, *first_schema);
 }
 
 // ============================================================
@@ -539,7 +539,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanQueryPart(
                 mp_, GPOS_NEW(mp_) CLogicalConstTableGet(
                     mp_, pdrgpcoldesc, pdrgpdrgpdatum));
             turbolynx::LogicalSchema empty_schema;
-            cur_plan = ownPlan(pexprCTG, empty_schema);
+            cur_plan = make_owned<turbolynx::LogicalPlan>(pexprCTG, empty_schema);
         }
         // WHERE before projection if it references a var the projection drops.
         bool where_before = false;
@@ -797,7 +797,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanUnwindClause(
                 mp_, pdrgpcoldesc, pdrgpdrgpdatum));
 
         turbolynx::LogicalSchema empty_schema;
-        prev_plan = ownPlan(pexprCTG, empty_schema);
+        prev_plan = make_owned<turbolynx::LogicalPlan>(pexprCTG, empty_schema);
     }
 
     // Convert the UNWIND expression to an ORCA scalar
@@ -1523,7 +1523,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
 
             turbolynx::LogicalSchema schema;
             GenerateNodeSchema(node, used_col_idx, colrefs, schema);
-            return ownPlan(plan_expr, schema);
+            return make_owned<turbolynx::LogicalPlan>(plan_expr, schema);
         };
 
     D_ASSERT(qgc.GetNumQueryGraphs() > 0);
@@ -1799,7 +1799,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                         GPOS_NEW(mp_) CLogicalUnionAll(
                             mp_, output_colrefs, input_colrefs),
                         children);
-                    return ownPlan(
+                    return make_owned<turbolynx::LogicalPlan>(
                         union_expr, *edge_first->getSchema());
                 };
 
@@ -2054,7 +2054,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                         MaybeWrapVarlenPath(lhs_plan, qg, *qedge);
                     } else {
                         // Unbound LHS: the per-partition A→R result replaces lhs_plan.
-                        lhs_plan = ownPlan(ar_result, first_combined_schema);
+                        lhs_plan = make_owned<turbolynx::LogicalPlan>(ar_result, first_combined_schema);
                     }
                     // edge_plan is consumed; don't use it below
 
@@ -3622,7 +3622,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanNodeScan(const BoundNodeExpres
     turbolynx::LogicalSchema schema;
     GenerateNodeSchema(node, used_col_idx, colrefs, schema);
 
-    turbolynx::LogicalPlan *plan = ownPlan(plan_expr, schema);
+    turbolynx::LogicalPlan *plan = make_owned<turbolynx::LogicalPlan>(plan_expr, schema);
     D_ASSERT(!plan->getSchema()->isEmpty());
     return plan;
 }
@@ -3697,7 +3697,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanEdgeScan(const BoundRelExpress
     turbolynx::LogicalSchema schema;
     GenerateEdgeSchema(rel, used_col_idx, colrefs, schema);
 
-    turbolynx::LogicalPlan *plan = ownPlan(plan_expr, schema);
+    turbolynx::LogicalPlan *plan = make_owned<turbolynx::LogicalPlan>(plan_expr, schema);
     D_ASSERT(!plan->getSchema()->isEmpty());
     return plan;
 }
@@ -3742,7 +3742,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanEdgeScanSinglePartition(
     turbolynx::LogicalSchema schema;
     GenerateEdgeSchema(rel, used_col_idx, colrefs, schema);
 
-    turbolynx::LogicalPlan *plan = ownPlan(plan_expr, schema);
+    turbolynx::LogicalPlan *plan = make_owned<turbolynx::LogicalPlan>(plan_expr, schema);
     D_ASSERT(!plan->getSchema()->isEmpty());
     return plan;
 }
@@ -3927,7 +3927,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanPathGet(const BoundRelExpressi
     CExpression *path_expr = GPOS_NEW(mp_) CExpression(mp_, pop);
     path_output_cols->AddRef();
 
-    turbolynx::LogicalPlan *plan = ownPlan(path_expr, schema);
+    turbolynx::LogicalPlan *plan = make_owned<turbolynx::LogicalPlan>(path_expr, schema);
     D_ASSERT(!plan->getSchema()->isEmpty());
     return plan;
 }

--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -1511,7 +1511,7 @@ CExpression *Cypher2OrcaConverter::ConvertExistsSubquery(
         inner_expr->AddRef();
         CExpression *select_expr = CUtils::PexprLogicalSelect(mp_, inner_expr, corr_pred);
 
-        inner_plan = ownPlan(
+        inner_plan = make_owned<turbolynx::LogicalPlan>(
             select_expr, *inner_plan->getSchema());
     } else {
         corr_preds->Release();
@@ -1594,7 +1594,7 @@ CExpression *Cypher2OrcaConverter::ConvertPatternComprehension(
         auto *inner_expr = inner_plan->getPlanExpr();
         inner_expr->AddRef();
         CExpression *select_expr = CUtils::PexprLogicalSelect(mp_, inner_expr, corr_pred);
-        inner_plan = ownPlan(
+        inner_plan = make_owned<turbolynx::LogicalPlan>(
             select_expr, *inner_plan->getSchema());
     } else {
         corr_preds->Release();
@@ -1646,7 +1646,7 @@ CExpression *Cypher2OrcaConverter::ConvertPatternComprehension(
                     inner_expr_p, proj_list);
                 turbolynx::LogicalSchema new_schema = *inner_plan->getSchema();
                 new_schema.appendColumn(col_alias, pcr);
-                inner_plan = ownPlan(
+                inner_plan = make_owned<turbolynx::LogicalPlan>(
                     proj_expr, new_schema);
             };
         auto make_var = [](const string &n) -> shared_ptr<BoundExpression> {

--- a/src/include/common/owns_objects.hpp
+++ b/src/include/common/owns_objects.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <memory>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace turbolynx {
+
+// Mixin: lifetime-management for objects produced by a class that holds
+// onto them via raw observer pointers. Same idea as ORCA's GPOS_NEW(mp)
+// but scoped to a normal C++ object.
+//
+//   class Planner : public OwnsObjects<CypherPhysicalOperator, ...> { ... };
+//   auto *op = make_owned<PhysicalNodeScan>(args...);   // creates + owns
+//
+// make_owned<T> picks the owner vector whose element_type is a base
+// of (or equal to) T. clear_owned() drops every owner vector in
+// declaration order.
+template <typename... OwnedTypes>
+class OwnsObjects {
+public:
+    template <typename T, typename... Args>
+    T *make_owned(Args &&...args) {
+        auto p = std::make_unique<T>(std::forward<Args>(args)...);
+        T *raw = p.get();
+        push_into_owner<T>(std::move(p));
+        return raw;
+    }
+
+    void clear_owned() {
+        std::apply([](auto &...v) { (..., v.clear()); }, owned_);
+    }
+
+protected:
+    ~OwnsObjects() = default;
+
+private:
+    template <typename T>
+    void push_into_owner(std::unique_ptr<T> p) {
+        bool placed = false;
+        auto try_place = [&](auto &vec) {
+            using OwnedT = typename std::decay_t<decltype(vec)>::value_type::element_type;
+            if constexpr (std::is_base_of_v<OwnedT, T> || std::is_same_v<OwnedT, T>) {
+                if (!placed) {
+                    vec.emplace_back(std::move(p));
+                    placed = true;
+                }
+            }
+        };
+        std::apply([&](auto &...vs) { (try_place(vs), ...); }, owned_);
+        static_assert(sizeof...(OwnedTypes) > 0, "OwnsObjects needs at least one type");
+    }
+
+    std::tuple<std::vector<std::unique_ptr<OwnedTypes>>...> owned_;
+};
+
+} // namespace turbolynx

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -10,6 +10,7 @@
 // ORCA CExpression tree that the rest of the Planner consumes.
 // ============================================================
 
+#include "common/owns_objects.hpp"
 #include "main/client_context.hpp"
 #include "catalog/catalog_entry/graph_catalog_entry.hpp"
 #include "catalog/catalog_entry/partition_catalog_entry.hpp"
@@ -130,7 +131,7 @@ struct ListComprehensionExprInfo {
 // Created by Planner for each query; holds all ORCA state
 // passed in from the owning Planner.
 // --------------------------------------------------------
-class Cypher2OrcaConverter {
+class Cypher2OrcaConverter : public turbolynx::OwnsObjects<turbolynx::LogicalPlan> {
 public:
     // mp, context, provider — owned by caller (Planner)
     // col_name_map — reference to Planner's mapping
@@ -382,17 +383,7 @@ private:
 
     bool IsCastingFunction(const string &func_name);
 
-    // Heap-construct and take ownership. Planner reads but never deletes.
-    template <typename... Args>
-    turbolynx::LogicalPlan *ownPlan(Args &&...args) {
-        auto p = new turbolynx::LogicalPlan(std::forward<Args>(args)...);
-        owned_logical_plans_.emplace_back(p);
-        return p;
-    }
-
 private:
-    std::vector<std::unique_ptr<turbolynx::LogicalPlan>> owned_logical_plans_;
-
     CMemoryPool *mp_;
     duckdb::ClientContext *context_;
     MDProviderTBGPP *provider_;

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "common/owns_objects.hpp"
 #include "main/client_context.hpp"
 #include "common/enums/index_type.hpp"
 #include "common/constants.hpp"
@@ -216,7 +217,10 @@ class PlannerUtils {
 public:
 };
 
-class Planner {
+class Planner : public turbolynx::OwnsObjects<
+    duckdb::CypherPhysicalOperator,
+    duckdb::CypherPhysicalOperatorGroup,
+    duckdb::CypherPhysicalOperatorGroups> {
 
 public:
 	Planner(PlannerConfig config, MDProviderType mdp_type, duckdb::ClientContext *context, string memory_mdp_path = "");	// TODO change client signature to reference
@@ -520,33 +524,6 @@ private:
 	// used and initialized in each execution
 	duckdb::BoundRegularQuery *bound_regular_query;								// input bound query
 	vector<duckdb::CypherPipeline *> pipelines;									// output plan pipelines
-	// Plan-tree owners. Group / Pipeline / PipelineExecutor hold raw
-	// observer pointers into these.
-	vector<unique_ptr<duckdb::CypherPhysicalOperator>> owned_operators;
-	template <typename T, typename... Args>
-	T *ownOp(Args &&...args) {
-		auto p = new T(std::forward<Args>(args)...);
-		owned_operators.emplace_back(p);
-		return p;
-	}
-
-	// Standalone Groups (e.g. UnionAll's union_group); Groups created
-	// via Groups::push_back(op) are self-owned.
-	vector<unique_ptr<duckdb::CypherPhysicalOperatorGroup>> owned_groups;
-	template <typename... Args>
-	duckdb::CypherPhysicalOperatorGroup *ownGroup(Args &&...args) {
-		auto g = new duckdb::CypherPhysicalOperatorGroup(std::forward<Args>(args)...);
-		owned_groups.emplace_back(g);
-		return g;
-	}
-
-	// Outer Groups shells returned by pTransform*.
-	vector<unique_ptr<duckdb::CypherPhysicalOperatorGroups>> owned_group_collections;
-	duckdb::CypherPhysicalOperatorGroups *ownGroups() {
-		owned_group_collections.emplace_back(
-		    std::make_unique<duckdb::CypherPhysicalOperatorGroups>());
-		return owned_group_collections.back().get();
-	}
 	std::map<CColRef *, std::string> property_col_to_output_col_names_mapping; 	// actual output col names for property columns
 	// Complex type registry: stores full LogicalType for types that can't be
 	// represented by ORCA's (OID, INT modifier) pair (e.g. STRUCT with named fields).

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -63,9 +63,7 @@ Planner::~Planner()
     }
     for (auto *p : pipelines) delete p;
     pipelines.clear();
-    owned_operators.clear();
-    owned_groups.clear();
-    owned_group_collections.clear();
+    clear_owned();
     CMDCache::Shutdown();
     CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(this->memory_pool);
 }
@@ -92,9 +90,7 @@ void Planner::reset()
     // Pipelines first: they observe operators/groups.
     for (auto *p : pipelines) delete p;
     pipelines.clear();
-    owned_operators.clear();
-    owned_groups.clear();
-    owned_group_collections.clear();
+    clear_owned();
     pruned_key_ids.clear();
     logical_plan_output_col_names.clear();
     logical_plan_output_colrefs.clear();

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -487,7 +487,7 @@ void Planner::pGenPhysicalPlan(CExpression *orca_plan_root)
     if (wrap_final_with_optional) {
         duckdb::Schema opt_schema =
             final_pipeline_ops[final_pipeline_ops.size() - 1]->schema;
-        auto *opt_op = ownOp<duckdb::PhysicalOptional>(opt_schema);
+        auto *opt_op = make_owned<duckdb::PhysicalOptional>(opt_schema);
         final_pipeline_ops.push_back(opt_op);
     }
 
@@ -501,7 +501,7 @@ void Planner::pGenPhysicalPlan(CExpression *orca_plan_root)
     vector<uint64_t> projection_mapping;
     vector<vector<uint64_t>> projection_mappings;
     if (logical_plan_output_colrefs.empty()) {
-        op = ownOp<duckdb::PhysicalProduceResults>(final_output_schema);
+        op = make_owned<duckdb::PhysicalProduceResults>(final_output_schema);
         final_pipeline_ops.push_back(op);
         D_ASSERT(final_pipeline_ops.size() > 0);
 
@@ -518,7 +518,7 @@ void Planner::pGenPhysicalPlan(CExpression *orca_plan_root)
             }
         }
     }
-    op = ownOp<duckdb::PhysicalProduceResults>(final_output_schema,
+    op = make_owned<duckdb::PhysicalProduceResults>(final_output_schema,
                                             projection_mappings);
 
     final_pipeline_ops.push_back(op);
@@ -757,8 +757,8 @@ Planner::pTraverseTransformPhysicalPlan(CExpression *plan_expr)
 			}
 			// TODO: extract actual datum values for non-empty ConstTableGet
 
-			auto *op = ownOp<duckdb::PhysicalConstScan>(ctg_schema, std::move(const_rows));
-			result = ownGroups();
+			auto *op = make_owned<duckdb::PhysicalConstScan>(ctg_schema, std::move(const_rows));
+			result = make_owned<duckdb::CypherPhysicalOperatorGroups>();
 			result->push_back(op);
 			break;
 		}
@@ -837,7 +837,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
     auto *mp = this->memory_pool;
 
     // leaf node
-    auto result = ownGroups();
+    auto result = make_owned<duckdb::CypherPhysicalOperatorGroups>();
 
     CExpression *scan_expr = NULL;
     CExpression *filter_expr = NULL;
@@ -1230,13 +1230,13 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
 
         // Create schemaless PhysicalNodeScan
         if (!do_filter_pushdown) {
-            op = ownOp<duckdb::PhysicalNodeScan>(local_schemas, tmp_schema, oids,
+            op = make_owned<duckdb::PhysicalNodeScan>(local_schemas, tmp_schema, oids,
                                               output_projection_mapping,
                                               scan_projection_mapping);
         } else if (is_simple_filter) {
             if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                 IMDType::ECmpType::EcmptEq) {
-                op = ownOp<duckdb::PhysicalNodeScan>(local_schemas, tmp_schema, oids,
+                op = make_owned<duckdb::PhysicalNodeScan>(local_schemas, tmp_schema, oids,
                                                   output_projection_mapping,
                                                   scan_projection_mapping,
                                                   filter_key_idxs, filter_values);
@@ -1264,7 +1264,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
                     }
                     range_values.push_back({l_val, r_val, l_inc, r_inc});
                 }
-                op = ownOp<duckdb::PhysicalNodeScan>(local_schemas, tmp_schema, oids,
+                op = make_owned<duckdb::PhysicalNodeScan>(local_schemas, tmp_schema, oids,
                                                   output_projection_mapping,
                                                   scan_projection_mapping,
                                                   filter_key_idxs, range_values);
@@ -1274,14 +1274,14 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
             vector<unique_ptr<duckdb::Expression>> filter_exprs;
             filter_exprs.push_back(
                 std::move(pTransformScalarExpr(filter_pred_expr, scan_cols->Pdrgpcr(mp), nullptr)));
-            op = ownOp<duckdb::PhysicalNodeScan>(local_schemas, tmp_schema, oids,
+            op = make_owned<duckdb::PhysicalNodeScan>(local_schemas, tmp_schema, oids,
                                               output_projection_mapping,
                                               scan_projection_mapping, move(filter_exprs));
         }
     } else {
         // Single-partition: original code path
         if (!do_filter_pushdown) {
-            op = ownOp<duckdb::PhysicalNodeScan>(tmp_schema, oids,
+            op = make_owned<duckdb::PhysicalNodeScan>(tmp_schema, oids,
                                               output_projection_mapping,
                                               scan_types,
                                               scan_projection_mapping);
@@ -1290,13 +1290,13 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
             if (is_simple_filter) {
                 if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                     IMDType::ECmpType::EcmptEq) {
-                    op = ownOp<duckdb::PhysicalNodeScan>(
+                    op = make_owned<duckdb::PhysicalNodeScan>(
                         tmp_schema, oids, output_projection_mapping, scan_types,
                         scan_projection_mapping, pred_attr_pos, literal_val);
                 }
                 else if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                         IMDType::ECmpType::EcmptL) {
-                    op = ownOp<duckdb::PhysicalNodeScan>(
+                    op = make_owned<duckdb::PhysicalNodeScan>(
                         tmp_schema, oids, output_projection_mapping, scan_types,
                         scan_projection_mapping, pred_attr_pos,
                         duckdb::Value::MinimumValue(literal_val.type()), literal_val,
@@ -1304,7 +1304,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
                 }
                 else if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                         IMDType::ECmpType::EcmptLEq) {
-                    op = ownOp<duckdb::PhysicalNodeScan>(
+                    op = make_owned<duckdb::PhysicalNodeScan>(
                         tmp_schema, oids, output_projection_mapping, scan_types,
                         scan_projection_mapping, pred_attr_pos,
                         duckdb::Value::MinimumValue(literal_val.type()), literal_val,
@@ -1312,14 +1312,14 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
                 }
                 else if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                         IMDType::ECmpType::EcmptG) {
-                    op = ownOp<duckdb::PhysicalNodeScan>(
+                    op = make_owned<duckdb::PhysicalNodeScan>(
                         tmp_schema, oids, output_projection_mapping, scan_types,
                         scan_projection_mapping, pred_attr_pos, literal_val,
                         duckdb::Value::MaximumValue(literal_val.type()), false, true);
                 }
                 else if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                         IMDType::ECmpType::EcmptGEq) {
-                    op = ownOp<duckdb::PhysicalNodeScan>(
+                    op = make_owned<duckdb::PhysicalNodeScan>(
                         tmp_schema, oids, output_projection_mapping, scan_types,
                         scan_projection_mapping, pred_attr_pos, literal_val,
                         duckdb::Value::MaximumValue(literal_val.type()), true, true);
@@ -1332,7 +1332,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
                 vector<unique_ptr<duckdb::Expression>> filter_exprs;
                 filter_exprs.push_back(
                     std::move(pTransformScalarExpr(filter_pred_expr, scan_cols->Pdrgpcr(mp), nullptr)));
-                op = ownOp<duckdb::PhysicalNodeScan>(
+                op = make_owned<duckdb::PhysicalNodeScan>(
                     tmp_schema, oids, output_projection_mapping, scan_types,
                     scan_projection_mapping, move(filter_exprs));
             }
@@ -1355,7 +1355,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
 
     auto *mp = this->memory_pool;
     duckdb::Catalog &cat_instance = context->db->GetCatalog();
-    auto result = ownGroups();
+    auto result = make_owned<duckdb::CypherPhysicalOperatorGroups>();
 
     // variables for scan op
     vector<uint64_t> oids;
@@ -1472,7 +1472,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
         if (is_simple_filter) {
             if (((CScalarCmp *)(filter_pred_expr->Pop()))->ParseCmpType() ==
                 IMDType::ECmpType::EcmptEq) {
-                op = ownOp<duckdb::PhysicalNodeScan>(
+                op = make_owned<duckdb::PhysicalNodeScan>(
                     local_schemas, global_schema, oids, projection_mappings,
                     scan_projection_mappings, pred_attr_pos_vec,
                     literal_val_vec);
@@ -1484,7 +1484,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
                         {duckdb::Value::MinimumValue(literal_val_vec[i].type()),
                          literal_val_vec[i], true, false});
                 }
-                op = ownOp<duckdb::PhysicalNodeScan>(
+                op = make_owned<duckdb::PhysicalNodeScan>(
                     local_schemas, global_schema, oids, projection_mappings,
                     scan_projection_mappings, pred_attr_pos_vec,
                     range_filter_values);
@@ -1496,7 +1496,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
                         {duckdb::Value::MinimumValue(literal_val_vec[i].type()),
                          literal_val_vec[i], true, true});
                 }
-                op = ownOp<duckdb::PhysicalNodeScan>(
+                op = make_owned<duckdb::PhysicalNodeScan>(
                     local_schemas, global_schema, oids, projection_mappings,
                     scan_projection_mappings, pred_attr_pos_vec,
                     range_filter_values);
@@ -1509,7 +1509,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
                          duckdb::Value::MaximumValue(literal_val_vec[i].type()),
                          false, true});
                 }
-                op = ownOp<duckdb::PhysicalNodeScan>(
+                op = make_owned<duckdb::PhysicalNodeScan>(
                     local_schemas, global_schema, oids, projection_mappings,
                     scan_projection_mappings, pred_attr_pos_vec,
                     range_filter_values);
@@ -1522,7 +1522,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
                          duckdb::Value::MaximumValue(literal_val_vec[i].type()),
                          true, true});
                 }
-                op = ownOp<duckdb::PhysicalNodeScan>(
+                op = make_owned<duckdb::PhysicalNodeScan>(
                     local_schemas, global_schema, oids, projection_mappings,
                     scan_projection_mappings, pred_attr_pos_vec,
                     range_filter_values);
@@ -1535,12 +1535,12 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
             vector<unique_ptr<duckdb::Expression>> filter_exprs;
             filter_exprs.push_back(
                 std::move(pTransformScalarExpr(filter_pred_expr, scan_cols, nullptr)));
-            op = ownOp<duckdb::PhysicalNodeScan>(
+            op = make_owned<duckdb::PhysicalNodeScan>(
                 local_schemas, global_schema, oids, projection_mappings,
                 scan_projection_mappings, move(filter_exprs));
         }
     } else {
-        op = ownOp<duckdb::PhysicalNodeScan>(
+        op = make_owned<duckdb::PhysicalNodeScan>(
             local_schemas, global_schema, oids, projection_mappings,
             scan_projection_mappings);
     }
@@ -1564,7 +1564,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopDSITableScan(CExpres
         pGetProjectionExprs(proj_types, bound_ref_idxs, proj_exprs);
         if (!proj_exprs.empty()) {
             result->push_back(
-                ownOp<duckdb::PhysicalProjection>(proj_schema, move(proj_exprs)));
+                make_owned<duckdb::PhysicalProjection>(proj_schema, move(proj_exprs)));
         }
     }
 
@@ -1583,7 +1583,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
              COperator::EOperatorId::EopPhysicalSerialUnionAll);
 
     // Result containers for processing projections and schemas
-    auto result = ownGroups();
+    auto result = make_owned<duckdb::CypherPhysicalOperatorGroups>();
     vector<uint64_t> oids;
     vector<vector<uint64_t>> projection_mapping;
     vector<vector<uint64_t>> scan_projection_mapping;
@@ -1745,7 +1745,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
             auto num_vals = literal_vals.size();
             switch (cmp_type) {
                 case IMDType::ECmpType::EcmptEq:
-                    op = ownOp<duckdb::PhysicalNodeScan>(
+                    op = make_owned<duckdb::PhysicalNodeScan>(
                         local_schemas, global_schema, oids, projection_mapping,
                         scan_projection_mapping, pred_attr_poss, literal_vals);
                     break;
@@ -1755,7 +1755,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
                             {duckdb::Value::MinimumValue(
                                  literal_vals[i].type()),
                              literal_vals[i], true, false});
-                    op = ownOp<duckdb::PhysicalNodeScan>(
+                    op = make_owned<duckdb::PhysicalNodeScan>(
                         local_schemas, global_schema, oids, projection_mapping,
                         scan_projection_mapping, pred_attr_poss,
                         range_filter_values);
@@ -1766,7 +1766,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
                             {duckdb::Value::MinimumValue(
                                  literal_vals[i].type()),
                              literal_vals[i], true, true});
-                    op = ownOp<duckdb::PhysicalNodeScan>(
+                    op = make_owned<duckdb::PhysicalNodeScan>(
                         local_schemas, global_schema, oids, projection_mapping,
                         scan_projection_mapping, pred_attr_poss,
                         range_filter_values);
@@ -1778,7 +1778,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
                              duckdb::Value::MaximumValue(
                                  literal_vals[i].type()),
                              false, true});
-                    op = ownOp<duckdb::PhysicalNodeScan>(
+                    op = make_owned<duckdb::PhysicalNodeScan>(
                         local_schemas, global_schema, oids, projection_mapping,
                         scan_projection_mapping, pred_attr_poss,
                         range_filter_values);
@@ -1790,7 +1790,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
                              duckdb::Value::MaximumValue(
                                  literal_vals[i].type()),
                              true, true});
-                    op = ownOp<duckdb::PhysicalNodeScan>(
+                    op = make_owned<duckdb::PhysicalNodeScan>(
                         local_schemas, global_schema, oids, projection_mapping,
                         scan_projection_mapping, pred_attr_poss,
                         range_filter_values);
@@ -1818,7 +1818,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
             filter_exprs.push_back(std::move(repr_filter_expr));
 
             duckdb::CypherPhysicalOperator *scan_cypher_op =
-                ownOp<duckdb::PhysicalNodeScan>(
+                make_owned<duckdb::PhysicalNodeScan>(
                     local_schemas, global_schema, oids, projection_mapping,
                     scan_projection_mapping, move(filter_exprs));
             if (!oids.empty()) scan_cypher_op->display_name = pResolvePartitionName(oids[0]);
@@ -1869,7 +1869,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
             if (!proj_exprs.empty()) {
                 D_ASSERT(proj_exprs.size() == proj_op_output_types.size());
                 duckdb::CypherPhysicalOperator *proj_op =
-                    ownOp<duckdb::PhysicalProjection>(proj_op_output_union_schema,
+                    make_owned<duckdb::PhysicalProjection>(proj_op_output_union_schema,
                                                    std::move(proj_exprs));
                 result->push_back(proj_op);
             }
@@ -1879,7 +1879,7 @@ Planner::pTransformEopUnionAllForNodeOrEdgeScan(CExpression *plan_expr)
         }
     }
     else {
-        duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalNodeScan>(
+        duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalNodeScan>(
             local_schemas, global_schema, oids, projection_mapping,
             scan_projection_mapping);
         if (!oids.empty()) op->display_name = pResolvePartitionName(oids[0]);
@@ -1895,8 +1895,8 @@ Planner::pTransformEopUnionAll(CExpression *plan_expr)
 {
     auto *mp = this->memory_pool;
 
-    duckdb::CypherPhysicalOperatorGroups *result = ownGroups();
-    duckdb::CypherPhysicalOperatorGroup *union_group = ownGroup();
+    duckdb::CypherPhysicalOperatorGroups *result = make_owned<duckdb::CypherPhysicalOperatorGroups>();
+    duckdb::CypherPhysicalOperatorGroup *union_group = make_owned<duckdb::CypherPhysicalOperatorGroup>();
 
     CExpressionArray *childs = plan_expr->PdrgPexpr();
     const ULONG num_childs = childs->Size();
@@ -2378,7 +2378,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
         D_ASSERT(edge_id_col_idx != std::numeric_limits<uint32_t>::max());
     }
     auto *duckdb_adjidx_op =
-        ownOp<duckdb::PhysicalAdjIdxJoin>(
+        make_owned<duckdb::PhysicalAdjIdxJoin>(
             schema_adj, adjidx_obj_id,
             is_left_outer ? duckdb::JoinType::LEFT : duckdb::JoinType::INNER,
             is_adjidxjoin_into, outer_join_key_col_idx, tgt_key_col_idx,
@@ -2680,7 +2680,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
         pGetFilterDuckDBExprs(filter_expr, adj_output_cols, nullptr,
                               adj_output_cols->Size(), filter_duckdb_exprs);
         duckdb::CypherPhysicalOperator *duckdb_filter_op =
-            ownOp<duckdb::PhysicalFilter>(schema_adj, move(filter_duckdb_exprs));
+            make_owned<duckdb::PhysicalFilter>(schema_adj, move(filter_duckdb_exprs));
         result->push_back(duckdb_filter_op);
 
         // Construct projection
@@ -2694,7 +2694,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
                                     output_types_proj, proj_exprs);
                 if (proj_exprs.size() != 0) {
                     duckdb::CypherPhysicalOperator *duckdb_proj_op =
-                        ownOp<duckdb::PhysicalProjection>(schema_proj,
+                        make_owned<duckdb::PhysicalProjection>(schema_proj,
                                                        move(proj_exprs));
                     result->push_back(duckdb_proj_op);
                 }
@@ -2844,7 +2844,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
         // Construct IdSeek Operator
         duckdb::CypherPhysicalOperator *duckdb_idseek_op;
         if (!filter_in_seek) {
-            duckdb_idseek_op = ownOp<duckdb::PhysicalIdSeek>(
+            duckdb_idseek_op = make_owned<duckdb::PhysicalIdSeek>(
                 schema_seek, edge_id_col_idx, seek_obj_ids,
                 output_projection_mappings_seek /* not used */,
                 outer_col_maps_seek, inner_col_maps_seek,
@@ -2878,7 +2878,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
                 }
             }
             // Construct IdSeek Operator for filter
-            duckdb_idseek_op = ownOp<duckdb::PhysicalIdSeek>(
+            duckdb_idseek_op = make_owned<duckdb::PhysicalIdSeek>(
                 schema_seek, edge_id_col_idx, seek_obj_ids,
                 output_projection_mappings_seek /* not used */,
                 outer_col_maps_seek, inner_col_maps_seek,
@@ -3070,7 +3070,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToVarlenAdjIdxJoin(
     uint64_t upper_bound = pathscan_op->UpperBound();
     uint64_t lower_bound = pathscan_op->LowerBound();
     if (upper_bound == -1) upper_bound = std::numeric_limits<uint64_t>::max();
-    duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalVarlenAdjIdxJoin>(
+    duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalVarlenAdjIdxJoin>(
         tmp_schema, path_index_oids, duckdb::JoinType::INNER, sid_col_idx, false,
         lower_bound, upper_bound, outer_col_map,
         inner_col_map, std::move(dst_partition_ids),
@@ -3576,7 +3576,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekNormal(CExpression *plan_e
             if (proj_exprs.size() != 0) {
                 D_ASSERT(proj_exprs.size() == output_cols->Size());
                 duckdb::CypherPhysicalOperator *op =
-                    ownOp<duckdb::PhysicalProjection>(tmp_schema,
+                    make_owned<duckdb::PhysicalProjection>(tmp_schema,
                                                    std::move(proj_exprs));
                 result->push_back(op);
 
@@ -3860,7 +3860,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekNormal(CExpression *plan_e
         if (has_filter) {
             D_ASSERT(per_schema_filter_exprs.size() == inner_col_maps.size());
             D_ASSERT(filter_col_idxs.size() == inner_col_maps.size());
-            duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalIdSeek>(
+            duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalIdSeek>(
                 tmp_schema, sid_col_idx, oids, output_projection_mapping,
                 outer_col_map, inner_col_maps, union_inner_col_map,
                 scan_projection_mapping, scan_types, per_schema_filter_exprs, filter_col_idxs,
@@ -3869,7 +3869,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekNormal(CExpression *plan_e
             result->push_back(op);
         }
         else {
-            duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalIdSeek>(
+            duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalIdSeek>(
                 tmp_schema, sid_col_idx, oids, output_projection_mapping,
                 outer_col_map, inner_col_maps, union_inner_col_map,
                 scan_projection_mapping, scan_types, force_output_union, join_type,
@@ -3880,7 +3880,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekNormal(CExpression *plan_e
     }
     else {
         D_ASSERT(false);
-        duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalIdSeek>(
+        duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalIdSeek>(
             tmp_schema, sid_col_idx, oids, output_projection_mapping,
             outer_col_map, inner_col_maps, union_inner_col_map,
             scan_projection_mapping, scan_types, false, join_type,
@@ -4185,7 +4185,7 @@ void Planner::
             size_t n_outer = GetActiveTailOperator(result)
                                  ? GetActiveTailOperator(result)->GetNumOutputSchemas()
                                  : 1;
-            duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalIdSeek>(
+            duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalIdSeek>(
                 tmp_schema, sid_col_idx, oids, output_projection_mapping,
                 outer_col_map, inner_col_maps, union_inner_col_map,
                 scan_projection_mapping, scan_types, true, join_type,
@@ -4303,7 +4303,7 @@ void Planner::
                                 output_types_proj, proj_exprs);
             if (proj_exprs.size() != 0) {
                 duckdb::CypherPhysicalOperator *duckdb_proj_op =
-                    ownOp<duckdb::PhysicalProjection>(schema_proj,
+                    make_owned<duckdb::PhysicalProjection>(schema_proj,
                                                     move(proj_exprs));
                 result->push_back(duckdb_proj_op);
             }
@@ -4494,7 +4494,7 @@ void Planner::
         duckdb::Schema schema_condition_filter;
         schema_condition_filter.setStoredTypes(output_types_condition_filter);
         duckdb::CypherPhysicalOperator *duckdb_filter_op =
-            ownOp<duckdb::PhysicalFilter>(schema_condition_filter, move(condition_filter_duckdb_exprs));
+            make_owned<duckdb::PhysicalFilter>(schema_condition_filter, move(condition_filter_duckdb_exprs));
         result->push_back(duckdb_filter_op);
     }
 
@@ -4506,7 +4506,7 @@ void Planner::
                                    ? GetActiveTailOperator(result)->GetNumOutputSchemas()
                                    : 1;
     if (!do_filter_pushdown) {
-        duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalIdSeek>(
+        duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalIdSeek>(
             seek_schema, sid_col_idx, oids, projection_mapping,
             outer_col_map, inner_col_maps, union_inner_col_map,
             scan_projection_mapping, scan_types, false, join_type,
@@ -4520,7 +4520,7 @@ void Planner::
             pGetDuckDBTypesFromColRefs(pushed_filter_output_cols, output_types_filter);
             schema_filter.setStoredTypes(output_types_filter);
             duckdb::CypherPhysicalOperator *duckdb_filter_op =
-                ownOp<duckdb::PhysicalFilter>(schema_filter, move(pushed_filter_duckdb_exprs));
+                make_owned<duckdb::PhysicalFilter>(schema_filter, move(pushed_filter_duckdb_exprs));
             result->push_back(duckdb_filter_op);
 
             // Construct projection
@@ -4534,7 +4534,7 @@ void Planner::
                                     output_types_proj, proj_exprs);
                 if (proj_exprs.size() != 0) {
                     duckdb::CypherPhysicalOperator *duckdb_proj_op =
-                        ownOp<duckdb::PhysicalProjection>(schema_proj,
+                        make_owned<duckdb::PhysicalProjection>(schema_proj,
                                                        move(proj_exprs));
                     result->push_back(duckdb_proj_op);
                 }
@@ -4918,7 +4918,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekDSI(CExpression *plan_expr
                                         proj_exprs);
         if (proj_exprs.size() != 0) {
             duckdb::CypherPhysicalOperator *duckdb_proj_op =
-                ownOp<duckdb::PhysicalProjection>(schema_proj,
+                make_owned<duckdb::PhysicalProjection>(schema_proj,
                                                 move(proj_exprs));
             result->push_back(duckdb_proj_op);
         }
@@ -4944,7 +4944,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekDSI(CExpression *plan_expr
         duckdb::Schema schema_cycle_filter;
         schema_cycle_filter.setStoredTypes(output_types_cycle_filter);
         duckdb::CypherPhysicalOperator *duckdb_filter_op =
-            ownOp<duckdb::PhysicalFilter>(schema_cycle_filter, move(cycle_filter_duckdb_exprs));
+            make_owned<duckdb::PhysicalFilter>(schema_cycle_filter, move(cycle_filter_duckdb_exprs));
         result->push_back(duckdb_filter_op);
     }
 
@@ -4960,7 +4960,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekDSI(CExpression *plan_expr
                                    ? GetActiveTailOperator(result)->GetNumOutputSchemas()
                                    : 1;
     if (!do_filter_pushdown) {
-        duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalIdSeek>(
+        duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalIdSeek>(
             tmp_schema, sid_col_idx, oids, output_projection_mapping,
             outer_col_map, inner_col_maps, union_inner_col_map,
             scan_projection_mapping, scan_types, false, join_type,
@@ -4974,7 +4974,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekDSI(CExpression *plan_expr
             duckdb::Schema schema_filter;
             schema_filter.setStoredTypes(output_types_filter);
             duckdb::CypherPhysicalOperator *duckdb_filter_op =
-                ownOp<duckdb::PhysicalFilter>(schema_filter, move(filter_duckdb_exprs));
+                make_owned<duckdb::PhysicalFilter>(schema_filter, move(filter_duckdb_exprs));
             result->push_back(duckdb_filter_op);
 
             // Construct projection
@@ -4988,7 +4988,7 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToIdSeekDSI(CExpression *plan_expr
                                     output_types_proj, proj_exprs);
                 if (proj_exprs.size() != 0) {
                     duckdb::CypherPhysicalOperator *duckdb_proj_op =
-                        ownOp<duckdb::PhysicalProjection>(schema_proj,
+                        make_owned<duckdb::PhysicalProjection>(schema_proj,
                                                        move(proj_exprs));
                     result->push_back(duckdb_proj_op);
                 }
@@ -5047,7 +5047,7 @@ void Planner::pTransformEopPhysicalInnerIndexNLJoinToProjectionForUnionAllInner(
 
     // define op
     duckdb::CypherPhysicalOperator *op =
-        ownOp<duckdb::PhysicalProjection>(proj_schema, move(proj_exprs));
+        make_owned<duckdb::PhysicalProjection>(proj_schema, move(proj_exprs));
     result->push_back(op);
 
     // generate schema flow graph
@@ -5196,7 +5196,7 @@ Planner::pTransformEopPhysicalHashJoinToHashJoin(CExpression *plan_expr)
     duckdb::Schema schema;
     schema.setStoredTypes(hash_output_types);
 
-    duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalHashJoin>(
+    duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalHashJoin>(
         schema, move(join_conds), join_type, left_col_map, right_col_map,
         right_build_types, right_build_map);
     pSetExplicitPhysicalOutputLayout(hash_output_cols);
@@ -5301,7 +5301,7 @@ Planner::pTransformEopPhysicalMergeJoinToMergeJoin(CExpression *plan_expr)
         rhs_types.push_back(pConvertTypeOidToLogicalType(type_oid, type_mod));
     }
 
-    duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalPiecewiseMergeJoin>(
+    duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalPiecewiseMergeJoin>(
         schema, move(join_conds), join_type, lhs_types, rhs_types, left_col_map,
         right_col_map);
 
@@ -5372,7 +5372,7 @@ Planner::pTransformEopPhysicalInnerNLJoinToCartesianProduct(
     schema.setStoredTypes(types);
 
     duckdb::CypherPhysicalOperator *op =
-        ownOp<duckdb::PhysicalCrossProduct>(schema, left_col_map, right_col_map);
+        make_owned<duckdb::PhysicalCrossProduct>(schema, left_col_map, right_col_map);
     pSetExplicitPhysicalOutputLayout(physical_output_cols);
     return pBuildSchemaflowGraphForBinaryJoin(plan_expr, op, schema,
                                               lhs_result, rhs_result);
@@ -5450,7 +5450,7 @@ Planner::pTransformEopPhysicalNLJoinToBlockwiseNLJoin(CExpression *plan_expr,
     pShiftFilterPredInnerColumnIndices(join_condition_expr,
                                        actual_outer_cols->Size());
 
-    duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalBlockwiseNLJoin>(
+    duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalBlockwiseNLJoin>(
         schema, move(join_condition_expr), join_type, outer_col_map,
         inner_col_map);
 
@@ -5501,7 +5501,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopLimit(
 
 
     duckdb::CypherPhysicalOperator *op =
-        ownOp<duckdb::PhysicalTop>(tmp_schema, limit, offset);
+        make_owned<duckdb::PhysicalTop>(tmp_schema, limit, offset);
     result->push_back(op);
 
     return result;
@@ -5732,7 +5732,7 @@ Planner::pTransformEopProjectionColumnar(CExpression *plan_expr)
 
 
     duckdb::CypherPhysicalOperator *op =
-        ownOp<duckdb::PhysicalProjection>(tmp_schema, std::move(proj_exprs));
+        make_owned<duckdb::PhysicalProjection>(tmp_schema, std::move(proj_exprs));
     result->push_back(op);
 
     return result;
@@ -5887,7 +5887,7 @@ Planner::pTransformEopProjectionColumnar(CExpression *plan_expr)
 //         proj_schema.setStoredColumnNames(output_column_names_proj);
 //         pBuildSchemaFlowGraphForUnaryOperator(proj_schema);
 //         duckdb::CypherPhysicalOperator *proj_op =
-//             ownOp<duckdb::PhysicalProjection>(proj_schema, move(proj_exprs));
+//             make_owned<duckdb::PhysicalProjection>(proj_schema, move(proj_exprs));
 //         result->push_back(proj_op);
 //     }
 
@@ -5895,11 +5895,11 @@ Planner::pTransformEopProjectionColumnar(CExpression *plan_expr)
 
 //     duckdb::CypherPhysicalOperator *op;
 //     if (agg_groups.empty()) {
-//         op = ownOp<duckdb::PhysicalHashAggregate>(
+//         op = make_owned<duckdb::PhysicalHashAggregate>(
 //             agg_schema, output_projection_mapping, move(agg_exprs));
 //     }
 //     else {
-//         op = ownOp<duckdb::PhysicalHashAggregate>(
+//         op = make_owned<duckdb::PhysicalHashAggregate>(
 //             agg_schema, output_projection_mapping, move(agg_exprs),
 //             move(agg_groups));
 //     }
@@ -5931,7 +5931,7 @@ Planner::pTransformEopProjectionColumnar(CExpression *plan_expr)
 //         // post_proj_schema.setStoredTypes(post_proj_type);
 //         // pBuildSchemaFlowGraphForUnaryOperator(post_proj_schema);
 //         // duckdb::CypherPhysicalOperator *post_proj_op =
-//         //     ownOp<duckdb::PhysicalProjection>(post_proj_schema, move(post_proj_exprs));
+//         //     make_owned<duckdb::PhysicalProjection>(post_proj_schema, move(post_proj_exprs));
 //         // new_result->push_back(post_proj_op);
 //     }
 //     return new_result;
@@ -6190,7 +6190,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopAgg(
         duckdb::Schema passthru_schema;
         passthru_schema.setStoredTypes(passthru_types);
         passthru_schema.setStoredColumnNames(passthru_names);
-        auto *proj_op = ownOp<duckdb::PhysicalProjection>(passthru_schema,
+        auto *proj_op = make_owned<duckdb::PhysicalProjection>(passthru_schema,
                                                         move(passthru_exprs));
         result->push_back(proj_op);
         return result;
@@ -6203,17 +6203,17 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopAgg(
         proj_schema.setStoredTypes(proj_types);
         proj_schema.setStoredColumnNames(output_column_names_proj);
         duckdb::CypherPhysicalOperator *proj_op =
-            ownOp<duckdb::PhysicalProjection>(proj_schema, move(proj_exprs));
+            make_owned<duckdb::PhysicalProjection>(proj_schema, move(proj_exprs));
         result->push_back(proj_op);
     }
     duckdb::CypherPhysicalOperator *op;
     if (agg_groups.empty()) {
-        op = ownOp<duckdb::PhysicalHashAggregate>(
+        op = make_owned<duckdb::PhysicalHashAggregate>(
             tmp_schema, output_projection_mapping, move(agg_exprs),
             node_pid_idxs);
     }
     else {
-        op = ownOp<duckdb::PhysicalHashAggregate>(
+        op = make_owned<duckdb::PhysicalHashAggregate>(
             tmp_schema, output_projection_mapping, move(agg_exprs),
             move(agg_groups), node_pid_idxs);
     }
@@ -6222,7 +6222,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopAgg(
     auto pipeline = new duckdb::CypherPipeline(std::move(*result), pipelines.size());
     pipelines.push_back(pipeline);
     // new pipeline
-    auto new_result = ownGroups();
+    auto new_result = make_owned<duckdb::CypherPhysicalOperatorGroups>();
     new_result->push_back(op);
 
     return new_result;
@@ -6368,7 +6368,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopPhysicalFilter(
     duckdb::CypherPhysicalOperator *last_op = GetActiveTailOperator(result);
     tmp_schema.setStoredTypes(last_op->GetTypes());
     duckdb::CypherPhysicalOperator *op =
-        ownOp<duckdb::PhysicalFilter>(tmp_schema, move(filter_exprs));
+        make_owned<duckdb::PhysicalFilter>(tmp_schema, move(filter_exprs));
     result->push_back(op);
 
     // generate schema flow graph for the filter
@@ -6388,7 +6388,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopPhysicalFilter(
         }
         if (proj_exprs.size() != 0) {
             D_ASSERT(proj_exprs.size() == output_cols->Size());
-            duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalProjection>(
+            duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalProjection>(
                 output_schema, std::move(proj_exprs));
             result->push_back(op);
 
@@ -6456,14 +6456,14 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopSort(
 
 
     duckdb::CypherPhysicalOperator *op =
-        ownOp<duckdb::PhysicalSort>(tmp_schema, move(orders));
+        make_owned<duckdb::PhysicalSort>(tmp_schema, move(orders));
     result->push_back(op);
 
     // break pipeline
     auto pipeline = new duckdb::CypherPipeline(std::move(*result), pipelines.size());
     pipelines.push_back(pipeline);
 
-    auto new_result = ownGroups();
+    auto new_result = make_owned<duckdb::CypherPhysicalOperatorGroups>();
     new_result->push_back(op);
 
 
@@ -6558,11 +6558,11 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopTopNSort(
 
     duckdb::CypherPhysicalOperator *op;
     if (has_limit) {
-        op = ownOp<duckdb::PhysicalTopNSort>(tmp_schema, move(orders), limit,
+        op = make_owned<duckdb::PhysicalTopNSort>(tmp_schema, move(orders), limit,
                                           offset);
     }
     else {
-        op = ownOp<duckdb::PhysicalSort>(tmp_schema, move(orders));
+        op = make_owned<duckdb::PhysicalSort>(tmp_schema, move(orders));
     }
 
     result->push_back(op);
@@ -6571,7 +6571,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopTopNSort(
     auto pipeline = new duckdb::CypherPipeline(std::move(*result), pipelines.size());
     pipelines.push_back(pipeline);
 
-    auto new_result = ownGroups();
+    auto new_result = make_owned<duckdb::CypherPhysicalOperatorGroups>();
     new_result->push_back(op);
 
 
@@ -6660,7 +6660,7 @@ duckdb::CypherPhysicalOperatorGroups* Planner::pTransformEopShortestPath(CExpres
     D_ASSERT(pmdindex != nullptr);
     OID path_index_oid_bwd = CMDIdGPDB::CastMdid(pmdindex->MDId())->Oid();
 
-    duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalShortestPathJoin>(schema, path_index_oid_fwd, path_index_oid_bwd,
+    duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalShortestPathJoin>(schema, path_index_oid_fwd, path_index_oid_bwd,
                                                     input_col_map, output_idx, src_id_idx, dest_id_idx, lower_bound, upper_bound);
     result->push_back(op);
 
@@ -6795,7 +6795,7 @@ duckdb::CypherPhysicalOperatorGroups* Planner::pTransformEopAllShortestPath(CExp
     D_ASSERT(pmdindex != nullptr);
     OID path_index_oid_bwd = CMDIdGPDB::CastMdid(pmdindex->MDId())->Oid();
 
-    duckdb::CypherPhysicalOperator *op = ownOp<duckdb::PhysicalAllShortestPathJoin>(schema, path_index_oid_fwd, path_index_oid_bwd,
+    duckdb::CypherPhysicalOperator *op = make_owned<duckdb::PhysicalAllShortestPathJoin>(schema, path_index_oid_fwd, path_index_oid_bwd,
                                                     input_col_map, output_idx, src_id_idx, dest_id_idx, lower_bound, upper_bound);
     result->push_back(op);
 
@@ -9017,8 +9017,8 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopUnnest(
             }
         }
 
-        auto *op = ownOp<duckdb::PhysicalConstScan>(scan_schema, std::move(scan_rows));
-        auto *result = ownGroups();
+        auto *op = make_owned<duckdb::PhysicalConstScan>(scan_schema, std::move(scan_rows));
+        auto *result = make_owned<duckdb::CypherPhysicalOperatorGroups>();
         result->push_back(op);
         return result;
     }
@@ -9066,7 +9066,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopUnnest(
     tmp_schema.setStoredTypes(out_types);
 
     duckdb::CypherPhysicalOperator *op =
-        ownOp<duckdb::PhysicalUnwind>(tmp_schema, list_col_idx);
+        make_owned<duckdb::PhysicalUnwind>(tmp_schema, list_col_idx);
     result->push_back(op);
 
 


### PR DESCRIPTION
## What

Consolidate four ad-hoc owner-aware allocation helpers into a single mixin.

Before:
- \`Cypher2OrcaConverter::ownPlan(args...)\` → \`unique_ptr<LogicalPlan>\`
- \`Planner::ownOp<T>(args...)\` → \`unique_ptr<CypherPhysicalOperator>\`
- \`Planner::ownGroup(args...)\` → \`unique_ptr<CypherPhysicalOperatorGroup>\`
- \`Planner::ownGroups()\` → \`unique_ptr<CypherPhysicalOperatorGroups>\`

After: a single mixin \`turbolynx::OwnsObjects<Ts...>\` in \`src/include/common/owns_objects.hpp\` exposing \`make_owned<T>(args...)\` and \`clear_owned()\`. \`make_owned\` dispatches to the owner vector whose \`element_type\` is a base of (or equal to) \`T\` via \`if constexpr + std::is_base_of_v\` — no virtual dispatch, all resolved at compile time.

## Why

- Same pattern, four implementations. The naming surfaced owner-vector identity (\`ownPlan\`, \`ownOp\`) rather than intent (\"allocate + own\").
- \`Planner\` had a 3-line \`.clear()\` block in two reset paths — easy to forget when adding a fourth owner type. \`clear_owned()\` covers all of them.

## Changes

| File | Change |
|---|---|
| \`src/include/common/owns_objects.hpp\` (new) | Mixin template (~60 LOC including doc comment) |
| \`src/include/converter/cypher2orca_converter.hpp\` | inherit \`OwnsObjects<LogicalPlan>\`; drop \`ownPlan\` + \`owned_logical_plans_\` |
| \`src/include/planner/planner.hpp\` | inherit \`OwnsObjects<CypherPhysicalOperator, ...Group, ...Groups>\`; drop \`ownOp/ownGroup/ownGroups\` + owner vectors |
| \`src/converter/cypher2orca_converter.cpp\`, \`cypher2orca_scalar.cpp\` | 13 sites: \`ownPlan(...)\` → \`make_owned<turbolynx::LogicalPlan>(...)\` |
| \`src/planner/planner_physical.cpp\` | 86 sites: \`ownOp<T>\`, \`ownGroup\`, \`ownGroups()\` → \`make_owned<T>(...)\` |
| \`src/planner/planner.cpp\` | 3-line \`.clear()\` block × 2 → \`clear_owned()\` × 2 |

Net diff: +1 file, +167 / -144 LOC. No behavior change.

## Verification

Local LSan on representative steps + the trigger case from PR #295:

| step | leak |
|---|---:|
| [types] | 0 |
| [ldbc][count] | 0 |
| [ldbc][traversal] | 0 |
| [ldbc][filter] | 0 |
| auto-compact blocker (ccm refcount path) | 0 |

The full LSan matrix (9 steps + [ldbc][crud]) is covered by CI Sanitize on this PR.

## Notes

The owner vector dispatch is exact: \`make_owned<PhysicalNodeScan>(args...)\` is resolved at compile time to the \`CypherPhysicalOperator\` vector by walking the variadic owner-type tuple. \`unique_ptr<Base>\` handles polymorphic delete the same way the previous \`owned_operators\` did — the mixin destructor is \`protected\` and intentionally non-virtual since the deriving classes have their own lifetime control.