### PR TITLE
fix(converter): don't resolve a property expression through its own alias (wrong results on alias re-definition)

### DIFF
--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -276,9 +276,17 @@ CExpression *Cypher2OrcaConverter::TryGenScalarIdent(const BoundExpression &expr
 {
     if (plan == nullptr) return nullptr;
 
+    // A PROPERTY expression names its source (var.key) directly, so do NOT
+    // resolve it through its own output alias: a DEFINING occurrence that
+    // reuses an earlier stage's alias (e.g. `WITH li2.L_SUPPKEY AS suppkey`
+    // when a previous WITH already exported `suppkey`) would short-circuit to
+    // the stale, shadowed column, silently regrouping/joining on the wrong
+    // column (TPC-H q15: 0 rows). ConvertProperty resolves it by (var, key).
+    const bool allow_alias_lookup =
+        expr.GetExprType() != BoundExpressionType::PROPERTY;
     CColRef *cr = plan->getSchema()->getColRefOfKey(
         expr.GetUniqueName(), std::numeric_limits<uint64_t>::max());
-    if (cr == nullptr) {
+    if (cr == nullptr && allow_alias_lookup) {
         cr = plan->getSchema()->getColRefOfKey(
             expr.GetAlias(), std::numeric_limits<uint64_t>::max());
     }
@@ -286,7 +294,7 @@ CExpression *Cypher2OrcaConverter::TryGenScalarIdent(const BoundExpression &expr
         D_ASSERT(outer_plan_ != nullptr);
         cr = outer_plan_->getSchema()->getColRefOfKey(
             expr.GetUniqueName(), std::numeric_limits<uint64_t>::max());
-        if (cr == nullptr) {
+        if (cr == nullptr && allow_alias_lookup) {
             cr = outer_plan_->getSchema()->getColRefOfKey(
                 expr.GetAlias(), std::numeric_limits<uint64_t>::max());
         }


### PR DESCRIPTION
## Summary
Fixes a Cypher→ORCA converter bug where a `WITH` projection item that **re-defines an alias already exported by an earlier stage** silently binds to the stale, shadowed column — the query then aggregates/joins on the wrong column and returns wrong results (TPC-H q15: **0 rows** instead of the top-revenue supplier).

## Repro (committed sf0.01 mini fixture, CPU only)
```
bash scripts/load-tpch-mini.sh <build-dir> /tmp/ws
<build-dir>/tools/turbolynx shell -w /tmp/ws -f benchmark/tpch/sf10/q15.cql
```
- **Before**: `[ScalarIdentMissing] target_name=L_SUPPKEY ...` logged, result **0 rows**.
- **After**: the correct single row — `Supplier#000000027`, total_revenue `1335555.0986` (matches a decomposed ground-truth query: `max(total_revenue)` over the same window).

The query's shape is the trigger (data-independent): the first `WITH` exports `suppkey`; a later stage re-defines it:
```cypher
WITH li.L_SUPPKEY as suppkey, sum(...) as total_revenue     // stage 1
WITH max(total_revenue) as max_total_revenue
MATCH (li2:LINEITEM) ...
WITH max_total_revenue, li2.L_SUPPKEY as suppkey, sum(...)  // stage 2 re-defines `suppkey`
```

## Root cause
`Cypher2OrcaConverter::TryGenScalarIdent` short-circuits `ConvertExpression` when the expression appears to already exist in the plan schema, **falling back to a lookup by the expression's own output alias**. For stage 2's `li2.L_SUPPKEY AS suppkey` (a *defining* occurrence), that fallback finds stage 1's `suppkey` colref and returns a `CScalarIdent` for it — `ConvertProperty` is never reached. The stage-2 aggregate then groups by the shadowed stage-1 column; ORCA plans with a dangling colref no child produces (the group key positionally degenerates to the broadcast scalar, and the correlated join predicate hits `ScalarIdentMissing` → an unresolvable reference), and everything is filtered out.

## Fix
A PROPERTY expression names its source `(variable, property key)` directly, so skip the alias fallback for PROPERTY expressions and let `ConvertProperty` resolve them. The fallback remains for variable/alias references — its intended purpose (re-reading an earlier stage's projection by name, e.g. `ORDER BY` on a `WITH` alias).

One file, +10/−2.

## Verification
- q15 (sf10 text) on the sf0.01 mini fixture: 0 rows → the correct supplier row (ground-truth-exact).
- All 22 `benchmark/tpch/sf0.01` queries: **byte-identical CPU results** before vs after the change.
- (`ninja` full-build of the test suite currently fails on main at `test_ldbc_ic_correctness.cpp` (`IC10_*`), with or without this change — pre-existing, unrelated.)