### PR TITLE
fix(planner): WITH aliases must survive a schema merge (q17 'Variable not defined')

### DIFF
--- a/src/include/planner/logical_schema.hpp
+++ b/src/include/planner/logical_schema.hpp
@@ -105,6 +105,16 @@ class LogicalSchema {
         for (auto &it : sch.bound_edges) {
             this->bound_edges.insert(it);
         }
+        // WITH aliases: a projected scalar alias (e.g. `WITH x.p AS v`) must
+        // survive a later plan-extension merge (e.g. a MATCH anchored on a
+        // node the WITH carried), or every later reference to it fails with
+        // "Variable 'v' is not defined" (TPC-H q17's LQUAN/LEXT group keys
+        // were silently dropped this way).
+        for (auto &kv : sch.alias_map_) {
+            if (alias_map_.find(kv.first) == alias_map_.end()) {
+                alias_map_[kv.first] = kv.second;
+            }
+        }
     }
 
     void appendNodeProperty(string k1, uint64_t k2, CColRef *colref)


### PR DESCRIPTION
## Summary
Fixes a WITH-alias lifetime bug, sibling of #298: `LogicalSchema::appendSchema` copied schema columns and node/edge bindings but **not `alias_map_`**, so a WITH-projected scalar alias was **silently dropped** whenever a later plan extension merged schemas.

## Repro (committed sf0.01 mini fixture, CPU-only)
```
bash scripts/load-tpch-mini.sh <build-dir> /tmp/ws
<build-dir>/tools/turbolynx shell -w /tmp/ws -f benchmark/tpch/sf10/q17.cql
```
- **Before**: `Variable 'LQUAN' is not defined` → `Invalid property` (both backends).
- **After**: `avg_yearly = 5576.257143` — matching an independently computed ground truth (DuckDB, same generated data and predicate: `5576.257142857144`).

Trigger shape (data-independent):
```cypher
WITH lineitem.L_QUANTITY AS LQUAN, ..., part          // scalar aliases + a carried node
MATCH (item2:LINEITEM)-[:COMPOSED_BY]->(part)         // MATCH anchored on the carried node
WITH LID, LQUAN, LEXT, avg(item2.L_QUANTITY) ...      // ← group keys silently dropped
WHERE ... LQUAN                                       // ← "Variable 'LQUAN' is not defined"
```

## Root cause
The anchored-MATCH plan extension merges schemas via `appendSchema`, which dropped the alias map. `PlanGroupBy` then resolved the vanished aliases to `nullptr` and **skipped them without any diagnostic** (the group keys disappeared), and the first later reference errored.

Note: comparison-based harnesses scored q17 as a *false pass* for a long time — both backends errored identically, so empty-vs-empty compared equal. Worth keeping in mind for regression tooling.

## Fix
Merge `alias_map_` in `appendSchema` (non-overwriting — the same policy as `inheritAliases`). +10 lines, one header.

## Verification
- q17 on the mini fixture: error → ground-truth-exact result.
- All 22 `benchmark/tpch/sf0.01` fixture queries: **byte-identical CPU results** before vs after.