### PR TITLE
fix(common): Value::ToString must not truncate VARCHAR values (corrupts all result output)

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -1347,11 +1347,7 @@ string Value::ToString() const {
 		return Interval::ToString(value_.interval);
 	case LogicalTypeId::JSON:
 	case LogicalTypeId::VARCHAR:
-		if (str_value.size() < 25) {
-			return str_value;
-		} else {
-			return str_value.substr(0, 25) + " ...";
-		}
+		return str_value;
 	case LogicalTypeId::BLOB:
 		return Blob::ToString(string_t(str_value));
 	case LogicalTypeId::POINTER:


### PR DESCRIPTION
## Summary
`Value::ToString` truncated any VARCHAR of ≥ 25 characters to a 25-char prefix + `" ..."` — and it feeds **every result-serialization path** (table, csv, json), so query outputs were silently corrupted.

## Impact
- TPC-H q2/q10/q16/q20 render supplier/customer addresses and comments as `"prefix ..."` in ALL output modes.
- Any cross-engine result comparison (e.g. LDBC-BI validation against Neo4j on identical data) fails on string columns.
- Storage itself was always intact (equality predicates and `size()` return full-string results) — only the output was lossy.

The check dates back to a 2025-01 refactor (`7ba6ed543`) and looks like debug-print behaviour that leaked into the result path. No test hardcodes the truncated form.

## Fix
Return the string verbatim; preview shortening, if desired, belongs to the caller. (+5/−5, one file.)

## Verification
- Long strings now round-trip through table/csv/json output.
- An LDBC-BI cross-check against Neo4j 5.26 on identical imported data goes from string-mismatch to exact row equality (e.g. BI-2, 100 rows incl. unicode names).
- TPC-H sf0.01 fixture: the only output changes are previously-truncated strings now printed in full (all other queries byte-identical).