### PR TITLE
fix: three optimizer crashes exposed by LDBC BI-17

### DIFF
--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CLogicalGet.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CLogicalGet.h
@@ -104,11 +104,13 @@ public:
 		return m_pruned_pdrgpcrOutput;
 	}
 
-	// setter
+	// setter; consumes a reference on the given array and drops the
+	// reference held on the previously stored one
 	void
 	SetPrunedOutputCols(CColRefArray *pruned_pdrgpcrOutput)
 	{
 		GPOS_ASSERT(NULL != pruned_pdrgpcrOutput);
+		CRefCount::SafeRelease(m_pruned_pdrgpcrOutput);
 		m_pruned_pdrgpcrOutput = pruned_pdrgpcrOutput;
 	}
 

--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CLogicalIndexGet.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CLogicalIndexGet.h
@@ -111,11 +111,13 @@ public:
 		return m_pruned_pdrgpcrOutput;
 	}
 
-	// setter
+	// setter; consumes a reference on the given array and drops the
+	// reference held on the previously stored one
 	void
 	SetPrunedOutputCols(CColRefArray *pruned_pdrgpcrOutput)
 	{
 		GPOS_ASSERT(NULL != pruned_pdrgpcrOutput);
+		CRefCount::SafeRelease(m_pruned_pdrgpcrOutput);
 		m_pruned_pdrgpcrOutput = pruned_pdrgpcrOutput;
 	}
 

--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CPhysicalScan.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/operators/CPhysicalScan.h
@@ -104,11 +104,13 @@ public:
 		return m_pruned_pdrgpcrOutput;
 	}
 
-	// setter
+	// setter; consumes a reference on the given array and drops the
+	// reference held on the previously stored one
 	void
 	SetPrunedOutputCols(CColRefArray *pruned_pdrgpcrOutput)
 	{
 		GPOS_ASSERT(NULL != pruned_pdrgpcrOutput);
+		CRefCount::SafeRelease(m_pruned_pdrgpcrOutput);
 		m_pruned_pdrgpcrOutput = pruned_pdrgpcrOutput;
 		ComputeTableStats(m_mp);
 	}

--- a/src/optimizer/orca/gporca/libgpopt/operators/CLogical.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/operators/CLogical.cpp
@@ -181,6 +181,15 @@ CLogical::PosFromIndex(CMemoryPool *mp, const IMDIndex *pmdindex,
 
 		// get the position of the index key column relative to the table descriptor
 		const ULONG ulPosTabDesc = ptabdesc->GetAttributePosition(attno);
+		if (ulPosTabDesc == gpos::ulong_max ||
+			ulPosTabDesc >= colref_array->Size())
+		{
+			// The index key column is not part of this scan's output; with
+			// column pruning the table descriptor / output array may no
+			// longer cover every index key. An order spec is only valid as
+			// a prefix of the index key order, so stop here.
+			break;
+		}
 		CColRef *colref = (*colref_array)[ulPosTabDesc];
 
 		IMDId *mdid =

--- a/src/optimizer/orca/gporca/libgpopt/operators/CLogicalGet.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/operators/CLogicalGet.cpp
@@ -80,6 +80,9 @@ CLogicalGet::CLogicalGet(CMemoryPool *mp, const CName *pnameAlias,
 		m_pdrgpdrgpcrPart = PdrgpdrgpcrCreatePartCols(
 			mp, m_pdrgpcrOutput, m_ptabdesc->PdrgpulPart());
 	}
+	// m_pruned_pdrgpcrOutput aliases m_pdrgpcrOutput until pruning replaces
+	// it; take a reference of its own since the dtor releases both members.
+	m_pdrgpcrOutput->AddRef();
 	m_pruned_pdrgpcrOutput = m_pdrgpcrOutput;
 	m_pcrsDist = CLogical::PcrsDist(mp, m_ptabdesc, m_pdrgpcrOutput); // S62 disable
 }
@@ -104,6 +107,10 @@ CLogicalGet::CLogicalGet(CMemoryPool *mp, const CName *pnameAlias,
 {
 	GPOS_ASSERT(NULL != ptabdesc);
 	GPOS_ASSERT(NULL != pnameAlias);
+
+	// m_pruned_pdrgpcrOutput aliases m_pdrgpcrOutput until pruning replaces
+	// it; take a reference of its own since the dtor releases both members.
+	m_pdrgpcrOutput->AddRef();
 
 	if (m_ptabdesc->IsPartitioned())
 	{

--- a/src/optimizer/orca/gporca/libgpopt/operators/CLogicalIndexGet.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/operators/CLogicalIndexGet.cpp
@@ -78,6 +78,10 @@ CLogicalIndexGet::CLogicalIndexGet(CMemoryPool *mp, const IMDIndex *pmdindex,
 	GPOS_ASSERT(NULL != pnameAlias);
 	GPOS_ASSERT(NULL != pdrgpcrOutput);
 
+	// m_pruned_pdrgpcrOutput aliases m_pdrgpcrOutput until pruning replaces
+	// it; take a reference of its own since the dtor releases both members.
+	m_pdrgpcrOutput->AddRef();
+
 	// create the index descriptor
 	m_pindexdesc = CIndexDescriptor::Pindexdesc(mp, ptabdesc, pmdindex);
 

--- a/src/optimizer/orca/gporca/libgpopt/operators/CPhysicalScan.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/operators/CPhysicalScan.cpp
@@ -47,6 +47,10 @@ CPhysicalScan::CPhysicalScan(CMemoryPool *mp, const CName *pnameAlias,
 	GPOS_ASSERT(NULL != pnameAlias);
 	GPOS_ASSERT(NULL != pdrgpcrOutput);
 
+	// m_pruned_pdrgpcrOutput aliases m_pdrgpcrOutput until pruning replaces
+	// it; take a reference of its own since the dtor releases both members.
+	m_pdrgpcrOutput->AddRef();
+
 	if (ptabdesc->ConvertHashToRandom())
 	{
 		// Treating a hash distributed table as random during planning

--- a/src/optimizer/orca/gporca/libgpopt/xforms/CXformIndexGet2IndexOnlyScan.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/xforms/CXformIndexGet2IndexOnlyScan.cpp
@@ -157,6 +157,8 @@ CXformIndexGet2IndexOnlyScan::Transform(CXformContext *pxfctxt,
 	CPhysicalIndexOnlyScan *popIndexOnlyScan = GPOS_NEW(mp) CPhysicalIndexOnlyScan(
 		mp, pindexdesc, ptabdesc, pop->UlOriginOpId(),
 		GPOS_NEW(mp) CName(mp, pop->NameAlias()), pdrgpcrOutput, pos);
+	// SetPrunedOutputCols consumes a reference
+	pop->PrunedPdrgpcrOutput()->AddRef();
 	popIndexOnlyScan->SetPrunedOutputCols(pop->PrunedPdrgpcrOutput());
 	CExpression *pexprAlt = GPOS_NEW(mp) CExpression(
 		mp, popIndexOnlyScan, pexprIndexCond);

--- a/src/optimizer/orca/gporca/libgpopt/xforms/CXformIndexGet2IndexScan.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/xforms/CXformIndexGet2IndexScan.cpp
@@ -112,6 +112,8 @@ CXformIndexGet2IndexScan::Transform(CXformContext *pxfctxt,
 										pexpr->Pop()->UlOpId(),
 										GPOS_NEW(mp) CName(mp, pop->NameAlias()),
 										pdrgpcrOutput, pos);
+	// SetPrunedOutputCols consumes a reference
+	pop->PrunedPdrgpcrOutput()->AddRef();
 	popPhysicalIndexScan->SetPrunedOutputCols(pop->PrunedPdrgpcrOutput());
 	CExpression *pexprAlt = GPOS_NEW(mp) CExpression(
 		mp, popPhysicalIndexScan, pexprIndexCond);

--- a/src/optimizer/orca/gporca/libgpopt/xforms/CXformJoin2IndexApply.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/xforms/CXformJoin2IndexApply.cpp
@@ -316,6 +316,8 @@ CXformJoin2IndexApply::CreateHomogeneousIndexApplyAlternativesUnionAll(
 					    pexprIdxGetNode->Pop()->Eopid() == COperator::EopLogicalIndexGet &&
 					    prunedCols != NULL) {
 						CLogicalIndexGet *pLogicalIndexGet = CLogicalIndexGet::PopConvert(pexprIdxGetNode->Pop());
+						// SetPrunedOutputCols consumes a reference
+						prunedCols->AddRef();
 						pLogicalIndexGet->SetPrunedOutputCols(prunedCols);
 					}
 					hasResult = true;

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -7162,21 +7162,24 @@ void Planner::pTranslatePredicateToJoinCondition(
         CScalarCmp *cmpop = (CScalarCmp *)op;
         duckdb::JoinCondition cond;
 
-        // Unwrap CScalarCast to find the underlying CScalarIdent for
-        // determining which side (lhs/rhs) each predicate operand belongs to.
-        auto pUnwrapToIdent = [](CExpression *expr) -> CScalarIdent * {
-            while (expr->Pop()->Eopid() == COperator::EOperatorId::EopScalarCast) {
-                D_ASSERT(expr->Arity() == 1);
-                expr = expr->operator[](0);
+        // Determine which side (lhs/rhs) each predicate operand belongs to
+        // from its used column set. An operand is not necessarily a bare
+        // CScalarIdent (or a cast of one): it can be an arbitrary scalar
+        // expression over one side's columns, e.g.
+        //   b.date > a.date + 14400000
+        // so unwrapping to an ident would misinterpret the operator node.
+        auto pSideContains = [](CColRefArray *cols, CColRefSet *used) -> bool {
+            CColRefSetIter crsi(*used);
+            while (crsi.Advance()) {
+                if (cols->IndexOf(crsi.Pcr()) == gpos::ulong_max) {
+                    return false;
+                }
             }
-            D_ASSERT(expr->Pop()->Eopid() == COperator::EOperatorId::EopScalarIdent);
-            return (CScalarIdent *)expr->Pop();
+            return true;
         };
-
-        CScalarIdent *ident0 = pUnwrapToIdent(pred->operator[](0));
-        bool is_left_col_included_in_lhs = lhs_cols->IndexOf(ident0->Pcr()) != gpos::ulong_max;
-        D_ASSERT(is_left_col_included_in_lhs ||
-                 rhs_cols->IndexOf(ident0->Pcr()) != gpos::ulong_max);
+        CColRefSet *used0 = pred->operator[](0)->DeriveUsedColumns();
+        bool is_left_col_included_in_lhs = pSideContains(lhs_cols, used0);
+        D_ASSERT(is_left_col_included_in_lhs || pSideContains(rhs_cols, used0));
         unique_ptr<duckdb::Expression> lhs =
             is_left_col_included_in_lhs
                 ? pTransformScalarExpr(pred->operator[](0), lhs_cols, rhs_cols)


### PR DESCRIPTION
## Summary

Three distinct optimizer crashes, all exposed by LDBC BI-17 (and BI-6/8/13/16 on the official BI SF1 dataset). Each is an independent bug with its own commit:

1. **`fix(planner): derive join-condition operand side from used columns`**
   `pTranslatePredicateToJoinCondition` force-cast each comparison operand to `CScalarIdent` to decide which join side it belongs to. For `b.creationDate > a.creationDate + 14400000` the RHS is an arithmetic expression, so the cast read a garbage `CColRef*` and mis-bound the join condition. Downstream symptoms: `Unimplemented type for normalify`, `INVALID -> VARCHAR` cast errors, `stoll` failures, execution SIGSEGVs. Now decides the side via `DeriveUsedColumns()` containment, which handles arbitrary single-sided scalar expressions.

2. **`fix(orca): balance refcount of pruned output column arrays`**
   The column-pruning extension member `m_pruned_pdrgpcrOutput` (CLogicalGet / CLogicalIndexGet / CPhysicalScan) aliased `m_pdrgpcrOutput` without taking a reference, while the dtors release both members — every operator destruction dropped one foreign reference on the shared array. With enough IndexGet alternatives created and released inside one optimization, the refcount hit zero while the original Get still used the array. Caught by ASan as heap-use-after-free in `CXformUtils::PdrgpcrIndexColumns` during `CXformJoin2IndexApplyGeneric::Transform`. Ctors now AddRef the alias; `SetPrunedOutputCols` consumes a reference and releases the previous one (three call sites that passed borrowed pointers now AddRef).

3. **`fix(orca): guard PosFromIndex against index keys absent from the scan output`**
   With column pruning, a scan's table descriptor / output array may no longer cover every index key column. `PosFromIndex` indexed the output array with a raw `GetAttributePosition` result, so a pruned key column meant `(*colref_array)[ulong_max]`. An order spec is only valid as a prefix of the index key order, so it now stops at the first unresolvable key.

## Verification

- Repro: LDBC BI-17 SIGSEGV'd at prepare (mini fixture) and BI-6/8/13/16 SIGSEGV'd at prepare on BI SF1; all five now run to completion.
- ASan (Debug build): the heap-use-after-free is gone; the BI-17 debug-assert (`EopScalarIdent`) is gone.
- Regression, mini fixture configs (`TURBOLYNX_TPCH_FIXTURE_MINI=ON`, `TURBOLYNX_LDBC_FIXTURE_MINI=ON`):
  - `query_test "[tpch]"`: 58 test cases, 1109 assertions, all passed
  - `query_test "[ldbc]"` (count/filter/functions/traversal/crud/robustness/ic/is): 656 test cases, 2435 assertions, all passed
- Cross-checked BI results against Neo4j 5.26 on identical BI SF1 data (comparison harness; unrelated remaining DIFFs tracked separately).

Note (pre-existing, unrelated): the non-mini test build of `test_ldbc_ic_correctness.cpp` is currently broken on main — commit 78c008996 references `ldbc::IC11_*` constants that are only defined under `#ifdef TURBOLYNX_LDBC_FIXTURE_MINI`.