### PR TITLE
fix: LDBC BI correctness — VLE direction, IdSeek rescan, edge-family coverage, OPTIONAL chaining, N-ary join predicates (all BI DIFFs resolved)

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -1334,7 +1334,12 @@ shared_ptr<BoundRelExpression> Binder::BindRelPattern(const RelPattern& rel,
         auto src_pids = expand_vpids(raw_src_pids);
         auto dst_pids = expand_vpids(raw_dst_pids);
 
-        bool has_src_constraint = !src_pids.empty();
+        // Variable-length paths must not prune edge partitions by endpoint
+        // labels at all: intermediate hops may traverse any partition of the
+        // edge type (e.g. (p:Post)<-[:REPLY_OF*0..]-(m) needs Comment→Comment
+        // for depth >= 2 even though neither endpoint touches it). The
+        // anchor-side seek is handled by the adjacency index itself.
+        bool has_src_constraint = !src_pids.empty() && !is_varlen;
         bool has_dst_constraint = !dst_pids.empty() && !is_varlen;
         std::unordered_map<idx_t, std::unordered_set<idx_t>> connected_edge_cache;
 

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -1661,6 +1661,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                 bool lhs_is_src = (qedge->GetDirection() != RelDirection::LEFT);
                 bool is_both = (qedge->GetDirection() == RelDirection::BOTH);
                 bool is_both_self_ref = false;
+                bool edge_unsatisfiable = false;
                 auto &catalog = context_->db->GetCatalog();
                 auto expanded_lhs_pids = ExpandRealVertexPartitions(
                     catalog, *context_, lhs_node->GetPartitionIDs());
@@ -1719,14 +1720,23 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                         }
                     } else {
                         // Directed pattern
+                        bool arrow_lhs_is_src =
+                            (qedge->GetDirection() != RelDirection::LEFT);
                         if (any_self_ref || (any_src_only && any_dst_only)) {
-                            lhs_is_src = (qedge->GetDirection() != RelDirection::LEFT);
+                            lhs_is_src = arrow_lhs_is_src;
                         } else if (any_src_only) {
                             lhs_is_src = true;
+                            // Arrow demands lhs on the dst side but every
+                            // partition stores it as src: the pattern can
+                            // never match, e.g. (m:Message)<-[:HAS_CREATOR]-(p).
+                            // Plan with the storage orientation (so lowering
+                            // stays well-formed) and force the empty result.
+                            edge_unsatisfiable = !arrow_lhs_is_src;
                         } else if (any_dst_only) {
                             lhs_is_src = false;
+                            edge_unsatisfiable = arrow_lhs_is_src;
                         } else {
-                            lhs_is_src = (qedge->GetDirection() != RelDirection::LEFT);
+                            lhs_is_src = arrow_lhs_is_src;
                         }
                     }
                 }
@@ -2263,6 +2273,20 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                     }
                 }
                 D_ASSERT(hop_plan != nullptr);
+
+                if (edge_unsatisfiable) {
+                    // `edge._id IS NULL` is always false at runtime but is
+                    // not constant-folded, so the plan keeps its regular
+                    // scan/join shape (a folded const-false Select collapses
+                    // to a ConstTableGet the physical lowering can't align).
+                    CColRef *edge_id = hop_plan->getSchema()->getColRefOfKey(
+                        edge_name, ID_KEY_ID);
+                    CExpression *false_pred = CUtils::PexprIsNull(
+                        mp_, CUtils::PexprScalarIdent(mp_, edge_id));
+                    CExpression *sel_expr = CUtils::PexprLogicalSelect(
+                        mp_, hop_plan->getPlanExpr(), false_pred);
+                    hop_plan->addUnaryParentOp(sel_expr);
+                }
 
                 // Merge with existing plan via CartProd if both sides were unbound
                 if (qg_plan != nullptr && !is_lhs_bound && !is_rhs_bound) {

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -1191,7 +1191,15 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
                 auto primary_graphlet = (idx_t)qedge->GetGraphletIDs()[0];
                 auto &siblings = multi_edge_partitions_[primary_graphlet];
                 for (size_t pi = 1; pi < qedge->GetPartitionIDs().size(); pi++) {
-                    siblings.push_back((idx_t)qedge->GetPartitionIDs()[pi]);
+                    // The map is keyed per edge type, so a second pattern on
+                    // the same type must not register the siblings again —
+                    // duplicated entries make the lowering seek the sibling
+                    // CSR twice, doubling every match from that partition.
+                    auto sib = (idx_t)qedge->GetPartitionIDs()[pi];
+                    if (std::find(siblings.begin(), siblings.end(), sib) ==
+                        siblings.end()) {
+                        siblings.push_back(sib);
+                    }
                 }
             }
 

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -145,7 +145,8 @@ Cypher2OrcaConverter::Cypher2OrcaConverter(
     std::unordered_set<idx_t> &both_edge_partitions,
     std::unordered_map<idx_t, std::vector<idx_t>> &multi_edge_partitions,
     std::unordered_map<idx_t, std::vector<idx_t>> &multi_vertex_partitions,
-    std::unordered_map<idx_t, std::vector<uint16_t>> &path_dst_vertex_partitions,
+    std::unordered_map<idx_t, std::pair<std::vector<uint16_t>, std::vector<uint16_t>>> &path_dst_vertex_partitions,
+    std::unordered_map<idx_t, std::vector<idx_t>> &path_edge_partitions,
     std::unordered_map<ULONG, MpvNullPropInfo> &mpv_null_colref_props,
     std::unordered_map<INT, LogicalType> &complex_type_registry,
     INT &next_complex_type_id,
@@ -157,6 +158,7 @@ Cypher2OrcaConverter::Cypher2OrcaConverter(
       multi_edge_partitions_(multi_edge_partitions),
       multi_vertex_partitions_(multi_vertex_partitions),
       path_dst_vertex_partitions_(path_dst_vertex_partitions),
+      path_edge_partitions_(path_edge_partitions),
       mpv_null_colref_props_(mpv_null_colref_props),
       complex_type_registry_(complex_type_registry),
       next_complex_type_id_(next_complex_type_id),
@@ -2036,11 +2038,15 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                                 ? PlanEdgeScanSinglePartition(*qedge, 0)
                                 : PlanEdgeScan(*qedge));
                         auto ar_join_type = gpopt::COperator::EOperatorId::EopLogicalInnerJoin;
+                        // The var-length join must bind LHS to its actual
+                        // endpoint key like the single-edge join does:
+                        // (a)<-[:E*..]-(b) anchors a on the edge's _tid, not
+                        // _sid, otherwise the traversal expands the wrong way.
                         CExpression *a_r_join_expr = is_pathjoin
                             ? ExprLogicalPathJoin(
                                   lhs_plan->getPlanExpr(), edge_plan->getPlanExpr(),
                                   lhs_plan->getSchema()->getColRefOfKey(lhs_name, ID_KEY_ID),
-                                  edge_plan->getSchema()->getColRefOfKey(edge_name, SID_KEY_ID),
+                                  edge_plan->getSchema()->getColRefOfKey(edge_name, lhs_edge_key),
                                   (int32_t)qedge->GetLowerBound(),
                                   (int32_t)qedge->GetUpperBound(),
                                   ar_join_type)
@@ -2103,11 +2109,13 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                                 ? PlanEdgeScanSinglePartition(*qedge, 0)
                                 : PlanEdgeScan(*qedge)));
                     auto ar_join_type = gpopt::COperator::EOperatorId::EopLogicalInnerJoin;
+                    // See the bound-LHS branch above: var-length joins must
+                    // bind LHS to its actual endpoint key (direction-aware).
                     CExpression *a_r_join_expr = is_pathjoin
                         ? ExprLogicalPathJoin(
                               lhs_plan->getPlanExpr(), edge_plan->getPlanExpr(),
                               lhs_plan->getSchema()->getColRefOfKey(lhs_name, ID_KEY_ID),
-                              edge_plan->getSchema()->getColRefOfKey(edge_name, SID_KEY_ID),
+                              edge_plan->getSchema()->getColRefOfKey(edge_name, lhs_edge_key),
                               (int32_t)qedge->GetLowerBound(),
                               (int32_t)qedge->GetUpperBound(),
                               ar_join_type)
@@ -3824,42 +3832,74 @@ void Cypher2OrcaConverter::RegisterPathDstPartitions(
     if (edge_partitions.empty()) return;
 
     auto &catalog = context_->db->GetCatalog();
-    std::vector<uint16_t> dst_partitions;
-    auto append_partitions = [&](const BoundNodeExpression &n) {
-        // BoundNodeExpression::partition_ids holds catalog OIDs; resolve
-        // each to the 16-bit VID prefix that operator-side dst_ok uses.
-        for (auto part_oid : n.GetPartitionIDs()) {
+    auto collect_partitions =
+        [&](const BoundNodeExpression &n) -> std::vector<uint16_t> {
+        // BoundNodeExpression::partition_ids holds catalog OIDs; expand
+        // virtual/superlabel partitions (e.g. Message → Comment, Post) to
+        // real ones, then resolve each to the 16-bit VID prefix that the
+        // operator-side dst_ok check uses.
+        std::vector<uint16_t> out;
+        if (n.GetLabels().empty()) {
+            // Unlabeled far end matches anything — no filter. The binder
+            // still infers a partition set for unlabeled nodes, but it can
+            // be narrower than what the traversal legitimately reaches
+            // (e.g. it misses the anchor's partition for zero-hop results).
+            return out;
+        }
+        auto expanded = ExpandRealVertexPartitions(
+            catalog, *context_, n.GetPartitionIDs());
+        for (auto part_oid : expanded) {
             auto *vpart = static_cast<duckdb::PartitionCatalogEntry *>(
                 catalog.GetEntry(*context_, DEFAULT_SCHEMA, (idx_t)part_oid, true));
             if (vpart) {
-                dst_partitions.push_back((uint16_t)vpart->GetPartitionID());
+                out.push_back((uint16_t)vpart->GetPartitionID());
             }
         }
+        std::sort(out.begin(), out.end());
+        out.erase(std::unique(out.begin(), out.end()), out.end());
+        return out;
     };
+    // Record the node-pattern partitions per STORAGE side of the edge; the
+    // physical lowering picks the side the traversal terminates on from the
+    // primary index direction (fwd CSR → storage-dst side, bwd CSR →
+    // storage-src side). This keeps the filter exact whichever endpoint the
+    // optimizer anchors on. RIGHT: lhs is the storage src; LEFT: lhs is the
+    // storage dst; BOTH: either side can terminate, use the union.
+    std::vector<uint16_t> src_side, dst_side;
     switch (rel.GetDirection()) {
         case RelDirection::RIGHT:
-            append_partitions(rhs_node);
+            src_side = collect_partitions(lhs_node);
+            dst_side = collect_partitions(rhs_node);
             break;
         case RelDirection::LEFT:
-            append_partitions(lhs_node);
+            src_side = collect_partitions(rhs_node);
+            dst_side = collect_partitions(lhs_node);
             break;
-        case RelDirection::BOTH:
-            append_partitions(lhs_node);
-            append_partitions(rhs_node);
+        case RelDirection::BOTH: {
+            auto l = collect_partitions(lhs_node);
+            auto r = collect_partitions(rhs_node);
+            std::vector<uint16_t> u;
+            std::set_union(l.begin(), l.end(), r.begin(), r.end(),
+                           std::back_inserter(u));
+            src_side = u;
+            dst_side = std::move(u);
             break;
+        }
     }
-
-    std::sort(dst_partitions.begin(), dst_partitions.end());
-    dst_partitions.erase(
-        std::unique(dst_partitions.begin(), dst_partitions.end()),
-        dst_partitions.end());
 
     // Key by edge partition OID so planner_physical can look it up via
     // IndexCatalogEntry::GetPartitionID(). Multi-partition edges share
-    // the same dst-vertex-pattern, so every partition entry stores the
-    // same vector.
+    // the same node patterns, so every partition entry stores the same pair.
+    std::vector<idx_t> all_edge_parts;
     for (auto pid : edge_partitions) {
-        path_dst_vertex_partitions_[(idx_t)pid] = dst_partitions;
+        all_edge_parts.push_back((idx_t)pid);
+    }
+    for (auto pid : edge_partitions) {
+        path_dst_vertex_partitions_[(idx_t)pid] = {src_side, dst_side};
+        // Record the full partition family so the physical lowering can add
+        // every partition's same-direction CSR to the traversal (levels >= 2
+        // may cross edge partitions, e.g. REPLY_OF Comment->Post/Comment).
+        path_edge_partitions_[(idx_t)pid] = all_edge_parts;
     }
 }
 

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -2037,11 +2037,21 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                         // Bound LHS with multi-edge: use single-partition edge scan
                         // so ORCA generates IndexNLJoin → AdjIdxJoin. Remaining
                         // partitions are expanded via multi_edge_partitions_ siblings.
-                        if (qedge->GetPartitionIDs().size() > 1) {
+                        // Variable-length joins expand their family via
+                        // path_edge_partitions_ in the VLE lowering;
+                        // registering here would leak the UNPRUNED family
+                        // into single-hop AdjIdxJoins on the same edge type
+                        // (self/foreign extras double- and phantom-matched).
+                        if (qedge->GetPartitionIDs().size() > 1 &&
+                            !qedge->IsVariableLength()) {
                             auto primary_graphlet = (idx_t)qedge->GetGraphletIDs()[0];
                             auto &siblings = multi_edge_partitions_[primary_graphlet];
                             for (size_t pi = 1; pi < qedge->GetPartitionIDs().size(); pi++) {
-                                siblings.push_back((idx_t)qedge->GetPartitionIDs()[pi]);
+                                auto sib = (idx_t)qedge->GetPartitionIDs()[pi];
+                                if (std::find(siblings.begin(), siblings.end(),
+                                              sib) == siblings.end()) {
+                                    siblings.push_back(sib);
+                                }
                             }
                         }
                         if (is_pathjoin) {
@@ -2082,11 +2092,16 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                 } else if (lhs_is_subquery_outer) {
                     // EXISTS subquery: lhs node is outer-bound, skip scanning it.
                     // Only scan edge (+ rhs below). Correlation will use edge._sid/_tid.
-                    if (qedge->GetPartitionIDs().size() > 1) {
+                    if (qedge->GetPartitionIDs().size() > 1 &&
+                        !qedge->IsVariableLength()) {
                         auto primary_graphlet = (idx_t)qedge->GetGraphletIDs()[0];
                         auto &siblings = multi_edge_partitions_[primary_graphlet];
                         for (size_t pi = 1; pi < qedge->GetPartitionIDs().size(); pi++) {
-                            siblings.push_back((idx_t)qedge->GetPartitionIDs()[pi]);
+                            auto sib = (idx_t)qedge->GetPartitionIDs()[pi];
+                            if (std::find(siblings.begin(), siblings.end(),
+                                          sib) == siblings.end()) {
+                                siblings.push_back(sib);
+                            }
                         }
                     }
                     edge_plan = wrap_edge_for_both_self_ref(
@@ -2107,11 +2122,16 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                     // M27: Record multi-partition edge info for the planner.
                     // Use single-partition edge scan when bound so ORCA generates
                     // IndexNLJoin → AdjIdxJoin. Siblings handle remaining partitions.
-                    if (qedge->GetPartitionIDs().size() > 1) {
+                    if (qedge->GetPartitionIDs().size() > 1 &&
+                        !qedge->IsVariableLength()) {
                         auto primary_graphlet = (idx_t)qedge->GetGraphletIDs()[0];
                         auto &siblings = multi_edge_partitions_[primary_graphlet];
                         for (size_t pi = 1; pi < qedge->GetPartitionIDs().size(); pi++) {
-                            siblings.push_back((idx_t)qedge->GetPartitionIDs()[pi]);
+                            auto sib = (idx_t)qedge->GetPartitionIDs()[pi];
+                            if (std::find(siblings.begin(), siblings.end(),
+                                          sib) == siblings.end()) {
+                                siblings.push_back(sib);
+                            }
                         }
                     }
                     if (is_pathjoin) {

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -3456,6 +3456,24 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanDistinct(
             for (auto *colref : prop_colrefs) {
                 key_columns->Append(colref);
             }
+        } else {
+            // Computed projection (e.g. `score + CASE ... AS x`): the
+            // preceding projection materialized it into a column. It is a
+            // DISTINCT key like every other projected item — leaving it out
+            // also drops the column from the GbAgg output, so later
+            // references dangle.
+            string key_name = expr.HasAlias() ? expr.GetAlias()
+                                              : expr.GetUniqueName();
+            CColRef *colref = prev_plan->getSchema()->getColRefOfKey(
+                key_name, std::numeric_limits<uint64_t>::max());
+            if (!colref) {
+                auto cands =
+                    prev_plan->getSchema()->getAllColRefsOfKey(key_name);
+                if (!cands.empty()) colref = cands.front();
+            }
+            if (colref) {
+                key_columns->Append(colref);
+            }
         }
     }
 

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -2923,9 +2923,12 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanSelection(
 {
     D_ASSERT(!preds.empty());
     CExpressionArray *cnf_exprs = GPOS_NEW(mp_) CExpressionArray(mp_);
+    bool saved_filter_ctx = in_filter_context_;
+    in_filter_context_ = true;
     for (auto &pred : preds) {
         cnf_exprs->Append(ConvertExpression(*pred, prev_plan));
     }
+    in_filter_context_ = saved_filter_ctx;
 
     CExpression *pred_expr;
     if (cnf_exprs->Size() > 1) {

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -2941,6 +2941,12 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanProjection(
                         colref->RetrieveType(),
                         colref->TypeModifier(),
                         colref->Name());
+                    // Keep the lineage: physical lowering resolves columns
+                    // across stages via the PrevId chain, and a fresh colref
+                    // with no lineage degrades to name matching — ambiguous
+                    // when two variables share a property name (BI-4 grouped
+                    // topForum by country's 'id' column).
+                    new_colref->SetPrevId(colref->Id());
                     new_colref->MarkAsUsed();
                     gen_colrefs.push_back(new_colref);
                     uint64_t prop_key =
@@ -2966,6 +2972,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanProjection(
                         colref->RetrieveType(),
                         colref->TypeModifier(),
                         colref->Name());
+                    new_colref->SetPrevId(colref->Id());
                     new_colref->MarkAsUsed();
                     gen_colrefs.push_back(new_colref);
                     uint64_t prop_key =

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -1217,15 +1217,22 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
                 edge_plan = PlanEdgeScan(*qedge);
             }
 
-            // If subsequent edge has endpoint bound only in prev_plan
-            // (not in subquery), close the current subquery first to avoid
+            // If subsequent edge connects ONLY to prev_plan (neither endpoint
+            // in the subquery), close the current subquery first to avoid
             // building a huge unfiltered join.  The closed subquery gets
             // LOJ'd with prev_plan, and this edge starts a fresh subquery
             // where both endpoints are now in prev_plan.
+            // An edge that still touches the subquery must stay INSIDE it:
+            // splitting the pattern into two LOJs breaks OPTIONAL MATCH
+            // semantics — a failed second join can no longer nullify the
+            // first join's bindings (BI-16 counted friends whose messages
+            // never joined back to the bound tag). The subsequent-edge path
+            // below handles the prev-only endpoint via the LOJ predicate.
             if (subquery) {
                 bool lhs_prev_only = is_lhs_bound_prev && !is_lhs_bound_sub;
                 bool rhs_prev_only = is_rhs_bound_prev && !is_rhs_bound_sub;
-                if (lhs_prev_only || rhs_prev_only) {
+                bool edge_touches_sub = is_lhs_bound_sub || is_rhs_bound_sub;
+                if ((lhs_prev_only || rhs_prev_only) && !edge_touches_sub) {
                     // Close current atomic subquery with LOJ
                     absorb_optional_predicates(subquery, loj_additional_pred);
                     CExpression *loj = ExprLogicalJoin(

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -4816,6 +4816,14 @@ void Cypher2OrcaConverter::CollectDownstreamPropertyRefs(
         CollectPropertyRefsFromExpr(*cur_part->GetProjectionBodyPredicate(),
                                     var_name, out_key_ids);
     }
+    // 1b. Current part's own ORDER BY — sorting runs on the aggregation
+    // output, so its property refs must survive the group-by projection.
+    if (cur_part->HasProjectionBody() &&
+        cur_part->GetProjectionBody()->HasOrderBy()) {
+        for (auto &item : cur_part->GetProjectionBody()->GetOrderBy()) {
+            CollectPropertyRefsFromExpr(*item.expr, var_name, out_key_ids);
+        }
+    }
 
     // 2. All subsequent query parts
     for (idx_t i = current_part_idx_ + 1; i < current_sq_->GetNumQueryParts(); ++i) {

--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -282,8 +282,15 @@ CExpression *Cypher2OrcaConverter::TryGenScalarIdent(const BoundExpression &expr
     // when a previous WITH already exported `suppkey`) would short-circuit to
     // the stale, shadowed column, silently regrouping/joining on the wrong
     // column (TPC-H q15: 0 rows). ConvertProperty resolves it by (var, key).
+    // The same shadowing hazard applies to computed expressions: in
+    // `WITH score + (CASE ...) AS score` the whole computation would be
+    // replaced by the stale `score` column (LDBC BI-14 accumulated 0
+    // forever). A genuine re-reference of a computed alias arrives as a
+    // VARIABLE expression, so alias lookup stays available there.
     const bool allow_alias_lookup =
-        expr.GetExprType() != BoundExpressionType::PROPERTY;
+        expr.GetExprType() != BoundExpressionType::PROPERTY &&
+        expr.GetExprType() != BoundExpressionType::FUNCTION &&
+        expr.GetExprType() != BoundExpressionType::CASE;
     CColRef *cr = plan->getSchema()->getColRefOfKey(
         expr.GetUniqueName(), std::numeric_limits<uint64_t>::max());
     if (cr == nullptr && allow_alias_lookup) {

--- a/src/converter/cypher2orca_scalar.cpp
+++ b/src/converter/cypher2orca_scalar.cpp
@@ -509,8 +509,12 @@ CExpression *Cypher2OrcaConverter::ConvertBoolOp(const BoundBoolExpression &expr
     }
 
     // NOT EXISTS → CScalarSubqueryNotExists (enables ORCA to decorrelate
-    // into LeftAntiSemiHashJoin instead of falling back to NLJ)
-    if (op == CScalarBoolOp::EboolopNot && expr.GetNumChildren() == 1 &&
+    // into LeftAntiSemiHashJoin instead of falling back to NLJ).
+    // Filter context only: NotExists unnesting in value context is
+    // unsound (bad plans/crashes), so projections keep NOT(SubqueryExists)
+    // and rely on the count(*)+coalesce rewrite instead.
+    if (in_filter_context_ &&
+        op == CScalarBoolOp::EboolopNot && expr.GetNumChildren() == 1 &&
         expr.GetChild(0)->GetExprType() == BoundExpressionType::EXISTENTIAL) {
         auto &exists_expr = static_cast<const BoundExistsSubqueryExpression &>(*expr.GetChild(0));
         CExpression *exists_orca = ConvertExistsSubquery(exists_expr, plan);

--- a/src/execution/execution/physical_operator/physical_id_seek.cpp
+++ b/src/execution/execution/physical_operator/physical_id_seek.cpp
@@ -582,9 +582,6 @@ OperatorResultType PhysicalIdSeek::ExecuteInner(ExecutionContext &context,
         state.has_materialized_filtered_output = false;
         doSeekColumnar(context, seek_input, chunk, state, state.target_eids,
                        target_seqnos_per_extent, mapping_idxs, output_size);
-        spdlog::debug("[IDSEEK-PATH] id_col_idx={} do_filter={} num_inner_schemas={} has_mat={}",
-                     id_col_idx, (int)do_filter_pushdown, num_inner_schemas,
-                     (int)state.has_materialized_filtered_output);
         if (state.has_materialized_filtered_output) {
             chunk.Reset();
             if (output_size == 0) {
@@ -931,12 +928,19 @@ void PhysicalIdSeek::doSeekColumnar(
 
             for (u_int64_t extentIdx = 0; extentIdx < target_eids.size();
                  extentIdx++) {
+                // The rescan must use the scan-aligned map (one entry per
+                // scan column, ulong_max for pred-only columns). The
+                // compacted inner_output_col_idxs would shift every column
+                // after a pred-only slot, making GetNextExtent write scan
+                // column i into the wrong output vector.
                 const vector<uint32_t> &output_col_idx =
-                    inner_output_col_idxs[mapping_idxs[extentIdx]];
+                    inner_col_maps[mapping_idxs[extentIdx]];
                 vector<idx_t> cols_to_include;
                 cols_to_include.reserve(output_col_idx.size());
                 for (auto col_idx : output_col_idx) {
-                    cols_to_include.push_back(col_idx);
+                    if (col_idx != std::numeric_limits<uint32_t>::max()) {
+                        cols_to_include.push_back(col_idx);
+                    }
                 }
                 context.client->graph_storage_wrapper->doVertexIndexSeek(
                     state.ext_it, filtered_output, input, nodeColIdx,

--- a/src/execution/execution/physical_operator/physical_ordered_distinct.cpp
+++ b/src/execution/execution/physical_operator/physical_ordered_distinct.cpp
@@ -1,0 +1,69 @@
+#include "execution/physical_operator/physical_ordered_distinct.hpp"
+
+#include <string>
+#include <unordered_set>
+
+#include "common/types/selection_vector.hpp"
+#include "common/types/value.hpp"
+
+namespace duckdb {
+
+class OrderedDistinctState : public OperatorState {
+public:
+	OrderedDistinctState() : sel(STANDARD_VECTOR_SIZE) {}
+
+	SelectionVector sel;
+	std::unordered_set<std::string> seen;
+};
+
+unique_ptr<OperatorState> PhysicalOrderedDistinct::GetOperatorState(
+    ExecutionContext &context) const {
+	return make_unique<OrderedDistinctState>();
+}
+
+OperatorResultType PhysicalOrderedDistinct::Execute(ExecutionContext &context,
+                                                    DataChunk &input,
+                                                    DataChunk &chunk,
+                                                    OperatorState &lstate) const {
+	auto &state = (OrderedDistinctState &)lstate;
+
+	idx_t result_count = 0;
+	std::string key;
+	for (idx_t row = 0; row < input.size(); row++) {
+		key.clear();
+		for (auto col : key_input_idxs) {
+			Value v = input.GetValue(col, row);
+			if (v.IsNull()) {
+				key += "\x01N";
+			} else {
+				key += v.ToString();
+			}
+			key += '\x1f';
+		}
+		if (state.seen.insert(key).second) {
+			state.sel.set_index(result_count++, row);
+		}
+	}
+
+	for (idx_t out = 0; out < output_input_idxs.size(); out++) {
+		chunk.data[out].Slice(input.data[output_input_idxs[out]], state.sel,
+		                      result_count);
+	}
+	chunk.SetCardinality(result_count);
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+std::string PhysicalOrderedDistinct::ParamsToString() const {
+	std::string keys;
+	for (auto k : key_input_idxs) {
+		if (!keys.empty()) keys += ",";
+		keys += std::to_string(k);
+	}
+	return "ordered-distinct keys: [" + keys + "]";
+}
+
+std::string PhysicalOrderedDistinct::ToString() const {
+	return "OrderedDistinct";
+}
+
+}  // namespace duckdb

--- a/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
+++ b/src/execution/execution/physical_operator/physical_varlen_adjidxjoin.cpp
@@ -132,6 +132,10 @@ public:
 	vector<int> adj_col_idxs;					// indices
 	vector<LogicalType> adj_col_types;			// forward_adj or backward_adj
 	unordered_set<uint16_t> src_partition_ids;	// partitions where adj lists are stored; others are terminal
+	// per adj col: the partitions whose extents carry that CSR; the DFS
+	// must not seek a col on a partition that stores another edge type's
+	// CSR in the same slot index
+	vector<unordered_set<uint16_t>> adj_col_src_pids;
 
 	// join data - initialized per new input
 	vector<bool> src_nullity;
@@ -186,8 +190,16 @@ void PhysicalVarlenAdjIdxJoin::GetJoinMatches(ExecutionContext& context, DataChu
 		for (uint64_t oid : adjidx_obj_ids) {
 			context.client->graph_storage_wrapper->getAdjColIdxs(
 				(idx_t)oid, state.adj_col_idxs, state.adj_col_types);
-			uint16_t src_pid = context.client->graph_storage_wrapper->getAdjListSrcPartitionId((idx_t)oid);
-			state.src_partition_ids.insert(src_pid);
+			// Expand virtual seek-side partitions (superlabels) to all real
+			// partitions, or mid-path nodes on a sibling partition are
+			// treated as terminals and the DFS never descends past level 1.
+			// Track them per adj col too: the DFS must only seek a col on
+			// the partitions that actually carry that CSR.
+			unordered_set<uint16_t> col_pids;
+			context.client->graph_storage_wrapper->getAdjListSrcPartitionIds(
+				(idx_t)oid, col_pids);
+			for (auto p : col_pids) state.src_partition_ids.insert(p);
+			state.adj_col_src_pids.push_back(std::move(col_pids));
 		}
 	}
 	
@@ -318,7 +330,6 @@ void PhysicalVarlenAdjIdxJoin::ProcessVarlenEquiJoin(ExecutionContext& context, 
 		state.lhs_idx++;
 		state.first_time_in_this_loop = true;
 	}
-
 	// chunk determined. now fill in lhs using slice operation
 	D_ASSERT(input.ColumnCount() == state.outer_col_map.size());
 	for (idx_t colId = 0; colId < input.ColumnCount(); colId++) {
@@ -362,7 +373,7 @@ uint64_t PhysicalVarlenAdjIdxJoin::VarlengthExpand_internal(ExecutionContext& co
 		for (auto &t : state.adj_col_types) {
 			adj_col_is_fwds.push_back(t == LogicalType::FORWARD_ADJLIST);
 		}
-		state.dfs_it->initialize(*context.client, src_vid, state.adj_col_idxs, adj_col_is_fwds, state.src_partition_ids);
+		state.dfs_it->initialize(*context.client, src_vid, state.adj_col_idxs, adj_col_is_fwds, state.src_partition_ids, &state.adj_col_src_pids);
 		if (state.cur_lv >= state.start_lv) {
 			// Zero-hop emits the src vid into the dst column; only
 			// safe if src's partition is in the dst pattern's set.
@@ -458,9 +469,13 @@ uint64_t PhysicalVarlenAdjIdxJoin::VarlengthExpand_internal(ExecutionContext& co
             bool dst_ok = dst_partition_ids.empty() ||
                           dst_partition_ids.count(resolved_tgt_partition) > 0;
             if (dst_ok) {
+                // Emit the RESOLVED physical id, not the raw adj-list entry:
+                // delta-resident entries carry a synthetic logical id that
+                // downstream CSR seeks (e.g. an AdjIdxJoin on the reached
+                // node) cannot resolve, silently dropping those rows.
                 addNewPathToOutput(tgt_adj_column, eid_adj_column,
                                    state.output_idx + num_found_paths,
-                                   state.current_path, new_tgt_id,
+                                   state.current_path, resolved_tgt_id,
                                    new_edge_id);
                 if (path_col_idx >= 0) {
                     writePathColumnForRow(chunk,
@@ -468,7 +483,9 @@ uint64_t PhysicalVarlenAdjIdxJoin::VarlengthExpand_internal(ExecutionContext& co
                                           src_vid, state.current_path,
                                           state.current_path_vid);
                 }
-                if (++num_found_paths == remaining_output) break;
+                if (++num_found_paths == remaining_output) {
+                    break;
+                }
             }
         }
 

--- a/src/include/common/enums/physical_operator_type.hpp
+++ b/src/include/common/enums/physical_operator_type.hpp
@@ -38,6 +38,7 @@ enum class PhysicalOperatorType : uint8_t {
 	SORT,
 	TOP_N_SORT,
 	HASH_AGGREGATE,
+	ORDERED_DISTINCT,
 //DATA SOURCE
 	NODE_SCAN,
 //ETC

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -420,6 +420,13 @@ private:
     bool outer_plan_registered_ = false;
     turbolynx::LogicalPlan *outer_plan_ = nullptr;
 
+    // True while converting WHERE/filter predicates (PlanSelection).
+    // NOT EXISTS is only specialized to CScalarSubqueryNotExists (anti-join
+    // decorrelation) in filter context; in value context (projections,
+    // ORDER BY) it stays NOT(SubqueryExists) so the count(*)+coalesce
+    // rewrite applies — the NotExists value-unnesting path is unsound.
+    bool in_filter_context_ = false;
+
     // Multi-part query context (set by PlanSingleQuery for PlanGroupBy lookahead)
     const NormalizedSingleQuery *current_sq_ = nullptr;
     idx_t current_part_idx_ = 0;

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -149,7 +149,8 @@ public:
                          std::unordered_set<duckdb::idx_t> &both_edge_partitions,
                          std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> &multi_edge_partitions,
                          std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> &multi_vertex_partitions,
-                         std::unordered_map<duckdb::idx_t, std::vector<uint16_t>> &path_dst_vertex_partitions,
+                         std::unordered_map<duckdb::idx_t, std::pair<std::vector<uint16_t>, std::vector<uint16_t>>> &path_dst_vertex_partitions,
+                         std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> &path_edge_partitions,
                          std::unordered_map<ULONG, MpvNullPropInfo> &mpv_null_colref_props,
                          std::unordered_map<INT, LogicalType> &complex_type_registry,
                          INT &next_complex_type_id,
@@ -391,8 +392,11 @@ private:
     std::unordered_set<duckdb::idx_t> &both_edge_partitions_;
     std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> &multi_edge_partitions_;
     std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> &multi_vertex_partitions_;
-    // #36: dst-vertex partition IDs per primary path-edge graphlet.
-    std::unordered_map<duckdb::idx_t, std::vector<uint16_t>> &path_dst_vertex_partitions_;
+    // #36: (storage-src-side, storage-dst-side) node partition IDs per
+    // path-edge partition; the lowering picks the traversal's far end.
+    std::unordered_map<duckdb::idx_t, std::pair<std::vector<uint16_t>, std::vector<uint16_t>>> &path_dst_vertex_partitions_;
+    // All edge partition OIDs of a VLE edge type, keyed by each partition.
+    std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> &path_edge_partitions_;
     std::unordered_map<ULONG, MpvNullPropInfo> &mpv_null_colref_props_;
 
     // Complex type registry — shared with Planner for STRUCT/ANY type resolution

--- a/src/include/execution/physical_operator/physical_ordered_distinct.hpp
+++ b/src/include/execution/physical_operator/physical_ordered_distinct.hpp
@@ -1,0 +1,37 @@
+#pragma once
+#include "common/typedef.hpp"
+
+#include "execution/physical_operator/cypher_physical_operator.hpp"
+#include "execution/execution_context.hpp"
+
+namespace duckdb {
+
+//! Streaming duplicate elimination that preserves the input row order.
+//! Used to lower a pure-distinct GbAgg sitting above a Sort: a hash
+//! aggregate would discard the sort order, changing which rows a
+//! subsequent LIMIT keeps.
+class PhysicalOrderedDistinct : public CypherPhysicalOperator {
+public:
+	PhysicalOrderedDistinct(Schema &sch, vector<uint32_t> key_input_idxs,
+	                        vector<uint32_t> output_input_idxs)
+	    : CypherPhysicalOperator(PhysicalOperatorType::ORDERED_DISTINCT, sch),
+	      key_input_idxs(std::move(key_input_idxs)),
+	      output_input_idxs(std::move(output_input_idxs)) {}
+	~PhysicalOrderedDistinct() {}
+
+	unique_ptr<OperatorState> GetOperatorState(
+	    ExecutionContext &context) const override;
+	OperatorResultType Execute(ExecutionContext &context, DataChunk &input,
+	                           DataChunk &chunk,
+	                           OperatorState &state) const override;
+
+	std::string ParamsToString() const override;
+	std::string ToString() const override;
+
+	//! Input column positions forming the distinct key.
+	vector<uint32_t> key_input_idxs;
+	//! Input column position feeding each output column.
+	vector<uint32_t> output_input_idxs;
+};
+
+}  // namespace duckdb

--- a/src/include/optimizer/orca/gporca/libgpopt/gpopt/xforms/CXformSimplifySubquery.h
+++ b/src/include/optimizer/orca/gporca/libgpopt/gpopt/xforms/CXformSimplifySubquery.h
@@ -70,7 +70,8 @@ private:
 	// main driver, transform existential/quantified subqueries to count(*) subqueries
 	static BOOL FSimplify(CMemoryPool *mp, CExpression *pexprScalar,
 						  CExpression **ppexprNewScalar,
-						  FnSimplify *pfnsimplify, FnMatch *pfnmatch);
+						  FnSimplify *pfnsimplify, FnMatch *pfnmatch,
+						  BOOL fSimplifyNotExists);
 
 	// private copy ctor
 	CXformSimplifySubquery(const CXformSimplifySubquery &);

--- a/src/include/parser/cypher_transformer.hpp
+++ b/src/include/parser/cypher_transformer.hpp
@@ -114,6 +114,13 @@ private:
     string transformStringLiteral(antlr4::tree::TerminalNode& literal);
 
     CypherParser::OC_CypherContext& root_;
+
+    // Depth of per-element lambda contexts (list/pattern comprehension
+    // filters and mappings, reduce). Pattern expressions inside these
+    // cannot lower to existential subqueries — the comprehension is
+    // evaluated element-wise by a scalar function, so they fall back to
+    // the __pattern_exists* scalar probes.
+    int lambda_depth_ = 0;
 };
 
 } // namespace turbolynx

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -196,6 +196,12 @@ public:
 	bool ORCA_COMPILE_ONLY;
 	PlannerConfig::JoinOrderType JOIN_ORDER_TYPE;
 	uint8_t JOIN_ORDER_DP_THRESHOLD_CONFIG;
+	//! N-ary joins wider than this keep the query's join order (ORCA's
+	//! commutativity/associativity xforms are disabled for them). The
+	//! exhaustive search on very wide joins explodes the memo (LDBC BI-17:
+	//! 165K memo groups, 112s compile) and its cost model picks worse
+	//! plans than the written order anyway.
+	uint8_t JOIN_ARITY_REORDER_THRESHOLD;
 	
 	PlannerConfig() :
 		DEBUG_PRINT(false),
@@ -208,7 +214,8 @@ public:
 		DISABLE_INDEX_JOIN(false),
 		ORCA_COMPILE_ONLY(false),
 		JOIN_ORDER_TYPE(JoinOrderType::JOIN_ORDER_EXHAUSTIVE_SEARCH),
-		JOIN_ORDER_DP_THRESHOLD_CONFIG(10)
+		JOIN_ORDER_DP_THRESHOLD_CONFIG(10),
+		JOIN_ARITY_REORDER_THRESHOLD(8)
 	{ }
 };
 

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -347,6 +347,7 @@ private:
 	unique_ptr<duckdb::Expression> pTransformScalarSwitch(CExpression *scalar_expr, CColRefArray *child_cols, CColRefArray *rhs_child_cols = nullptr);
 	unique_ptr<duckdb::Expression> pTransformScalarIf(CExpression *scalar_expr, CColRefArray *child_cols, CColRefArray *rhs_child_cols = nullptr);
 	unique_ptr<duckdb::Expression> pTransformScalarNullTest(CExpression *scalar_expr, CColRefArray *child_cols, CColRefArray *rhs_child_cols = nullptr);
+	unique_ptr<duckdb::Expression> pTransformScalarCoalesce(CExpression *scalar_expr, CColRefArray *child_cols, CColRefArray *rhs_child_cols = nullptr);
 	unique_ptr<duckdb::Expression> pTransformScalarCast(CExpression *scalar_expr, CColRefArray *child_cols, CColRefArray *rhs_child_cols = nullptr);
 	unique_ptr<duckdb::Expression> pGenScalarCast(unique_ptr<duckdb::Expression> orig_expr, duckdb::LogicalType target_type);
 	void pGetAllScalarIdents(CExpression * scalar_expr, vector<uint32_t> &sccmp_colids);

--- a/src/include/planner/planner.hpp
+++ b/src/include/planner/planner.hpp
@@ -551,9 +551,18 @@ private:
 	std::unordered_set<duckdb::idx_t> both_edge_partitions;							// edge partition OIDs needing BOTH-direction scan
 	std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> multi_edge_partitions;	// primary OID → sibling OIDs
 	std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> multi_vertex_partitions;	// primary graphlet OID → sibling graphlet OIDs
-	// edge partition OID → dst-vertex-pattern partition IDs (16-bit).
-	// Converter fills it; planner_physical reads it as VLE output filter (#36).
-	std::unordered_map<duckdb::idx_t, std::vector<uint16_t>> path_dst_vertex_partitions;
+	// edge partition OID → (storage-src-side, storage-dst-side) node-pattern
+	// partition IDs (16-bit). Converter fills it; planner_physical picks the
+	// side the traversal terminates on by the primary index direction and
+	// uses it as the VLE output filter (#36): a forward CSR traversal ends on
+	// the storage-dst side, a backward one on the storage-src side.
+	std::unordered_map<duckdb::idx_t,
+	                   std::pair<std::vector<uint16_t>, std::vector<uint16_t>>>
+	    path_dst_vertex_partitions;
+	// edge partition OID → ALL edge partition OIDs of the same VLE edge type.
+	// Converter fills it; planner_physical uses it to add every partition's
+	// same-direction CSR to the traversal (levels >= 2 cross partitions).
+	std::unordered_map<duckdb::idx_t, std::vector<duckdb::idx_t>> path_edge_partitions;
 
 	// MPV sibling-only property info: CColRef ID → property key ID
 	// Populated by converter for NULL properties on MPV nodes.

--- a/src/include/storage/extent/adjlist_iterator.hpp
+++ b/src/include/storage/extent/adjlist_iterator.hpp
@@ -65,9 +65,14 @@ public:
         for (auto *p : adjlist_iters) delete p;
     }
 
+    //! `adj_col_src_pids`, when given, holds for each adj col the partition
+    //! IDs whose extents actually carry that CSR; cols not owned by the
+    //! current node's partition are skipped (the same slot index can hold a
+    //! different edge type's CSR on another partition).
     void initialize(ClientContext &context, uint64_t src_id,
                     vector<int> adj_col_idxs, vector<bool> adj_col_is_fwds,
-                    const std::unordered_set<uint16_t> &src_partition_ids = {});
+                    const std::unordered_set<uint16_t> &src_partition_ids = {},
+                    const vector<std::unordered_set<uint16_t>> *adj_col_src_pids = nullptr);
     bool getNextEdge(ClientContext &context, int lv, uint64_t &tgt, uint64_t &edge);
     void reduceLevel();
 
@@ -79,6 +84,7 @@ private:
     int current_lv = 0;
     int max_lv = 0;
     std::unordered_set<uint16_t> src_partition_ids_;
+    const vector<std::unordered_set<uint16_t>> *adj_col_src_pids_ = nullptr;
 
     // Per adj_col
     vector<int> adjColIdxs;

--- a/src/include/storage/graph_storage_wrapper.hpp
+++ b/src/include/storage/graph_storage_wrapper.hpp
@@ -168,6 +168,11 @@ public:
  void getAdjColIdxs(idx_t index_cat_oid, vector<int> &adjColIdxs,
                     vector<LogicalType> &adjColTypes);
  uint16_t getAdjListSrcPartitionId(idx_t index_cat_oid);
+ //! Like getAdjListSrcPartitionId, but expands a virtual seek-side vertex
+ //! partition (e.g. a superlabel like Message) into all of its real
+ //! partitions' 16-bit IDs. Inserts into `out`.
+ void getAdjListSrcPartitionIds(idx_t index_cat_oid,
+                                std::unordered_set<uint16_t> &out);
  uint16_t getNodePartitionId(uint64_t vid);
  //! `scratch_buf` is caller-owned. When base CSR + AdjListDelta need to be
  //! merged, the returned (start_ptr, end_ptr) point into this buffer, so the

--- a/src/optimizer/orca/gporca/libgpopt/search/CMemo.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/search/CMemo.cpp
@@ -35,7 +35,7 @@
 
 using namespace gpopt;
 
-#define GPOPT_MEMO_HT_BUCKETS 50000
+#define GPOPT_MEMO_HT_BUCKETS 524288
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/optimizer/orca/gporca/libgpopt/xforms/CXformJoin2IndexApplyGeneric.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/xforms/CXformJoin2IndexApplyGeneric.cpp
@@ -15,11 +15,14 @@
 #include "gpopt/operators/CLogicalGet.h"
 #include "gpopt/operators/CScalarIdent.h"
 
+#include "naucrates/md/CMDIdGPDB.h"
+
 #include "gpopt/operators/CLogicalPathJoin.h"
 #include "gpopt/operators/CLogicalPathGet.h"
 #include "gpopt/operators/CLogicalIndexPathGet.h"
 #include "gpopt/operators/CLogicalIndexPathApply.h"
 
+#include <set>
 #include <vector>
 
 using namespace gpmd;
@@ -490,8 +493,32 @@ CXformJoin2IndexApplyGeneric::TransformApplyOnPathGet(CXformContext *pxfctxt, CX
 
 		CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
 
-		// Collect forward adj list indexes from all table descriptors (one per edge type)
+		// Determine the traversal direction from the join predicate. The
+		// path output layout is [_id, _sid, _tid] and the predicate seeks
+		// on the endpoint column that joins to the outer side. A pattern
+		// like (a)<-[:E*0..]-(b) anchors a on _tid and must expand through
+		// the backward adjacency index; expanding it through the forward
+		// index finds nothing beyond length 0.
+		IMDIndex::EmdindexType required_idx_type = IMDIndex::EmdindFwdAdjlist;
+		if (pdrgpcrOutput->Size() >= 3)
+		{
+			CColRef *pcrSid = (*pdrgpcrOutput)[1];
+			CColRef *pcrTid = (*pdrgpcrOutput)[2];
+			BOOL fSeeksSid = pcrsScalarExpr->FMember(pcrSid);
+			BOOL fSeeksTid = pcrsScalarExpr->FMember(pcrTid);
+			if (fSeeksTid && !fSeeksSid)
+			{
+				required_idx_type = IMDIndex::EmdindBwdAdjlist;
+			}
+		}
+
+		// Collect the adj list indexes of the required direction from all
+		// table descriptors. A multi-partition edge type exposes the same
+		// index through several graphlets' relations, so dedup by mdid: the
+		// traversal needs the distinct set of same-direction CSRs, not one
+		// entry per table descriptor.
 		std::vector<const IMDIndex *> pmdindexarray;
+		std::set<OID> seen_index_oids;
 		const IMDRelation *first_pmdrel = nullptr;
 		for (ULONG td_idx = 0; td_idx < path_op->PtabdescArray()->Size(); td_idx++)
 		{
@@ -504,7 +531,11 @@ CXformJoin2IndexApplyGeneric::TransformApplyOnPathGet(CXformContext *pxfctxt, CX
 			{
 				IMDId *pmdidIndex = pmdrel->IndexMDidAt(ul);
 				const IMDIndex *pmdindex = md_accessor->RetrieveIndex(pmdidIndex);
-				if (pmdindex->IndexType() == IMDIndex::EmdindFwdAdjlist) {
+				if (pmdindex->IndexType() != required_idx_type) {
+					continue;
+				}
+				OID oid = CMDIdGPDB::CastMdid(pmdindex->MDId())->Oid();
+				if (seen_index_oids.insert(oid).second) {
 					pmdindexarray.push_back(pmdindex);
 				}
 			}
@@ -513,15 +544,12 @@ CXformJoin2IndexApplyGeneric::TransformApplyOnPathGet(CXformContext *pxfctxt, CX
 		{
 			return;
 		}
-		if (pmdindexarray.size() != path_op->PtabdescArray()->Size())
-		{
-			return;
-		}
 		// Check that the join predicate references the index key of the first index
 		CColRefSet *pcrsIndexCols =
 			CXformUtils::PcrsIndexKeys(mp, pdrgpcrOutput, pmdindexarray[0], first_pmdrel);
 		if (pcrsScalarExpr->IsDisjoint(pcrsIndexCols))
 		{
+			fprintf(stderr, "[VLE-XFORM] predicate disjoint from index keys\n");
 			return;
 		}
 

--- a/src/optimizer/orca/gporca/libgpopt/xforms/CXformSimplifySubquery.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/xforms/CXformSimplifySubquery.cpp
@@ -167,15 +167,20 @@ CXformSimplifySubquery::FSimplifyExistential(CMemoryPool *mp,
 BOOL
 CXformSimplifySubquery::FSimplify(CMemoryPool *mp, CExpression *pexprScalar,
 								  CExpression **ppexprNewScalar,
-								  FnSimplify *pfnsimplify, FnMatch *pfnmatch)
+								  FnSimplify *pfnsimplify, FnMatch *pfnmatch,
+								  BOOL fSimplifyNotExists)
 {
 	// protect against stack overflow during recursion
 	GPOS_CHECK_STACK_SIZE;
 	GPOS_ASSERT(NULL != mp);
 	GPOS_ASSERT(NULL != pexprScalar);
 
-	// TODO currently, s62 do not allow to simplify subquerynotexists. it generates wrong plan
-	if ((COperator::EopScalarSubqueryNotExists != pexprScalar->Pop()->Eopid()) &&
+	// NotExists is only simplified in value (project) context: there the
+	// count(*)+coalesce rewrite is the sound lowering, while in filters the
+	// anti-join decorrelation of the un-simplified NotExists is both correct
+	// and much faster.
+	if ((fSimplifyNotExists ||
+		 COperator::EopScalarSubqueryNotExists != pexprScalar->Pop()->Eopid()) &&
 		pfnmatch(pexprScalar->Pop()))
 	{
 		return pfnsimplify(mp, pexprScalar, ppexprNewScalar);
@@ -200,7 +205,7 @@ CXformSimplifySubquery::FSimplify(CMemoryPool *mp, CExpression *pexprScalar,
 	{
 		CExpression *pexprChild = NULL;
 		fSuccess = FSimplify(mp, (*pexprScalar)[ul], &pexprChild, pfnsimplify,
-							 pfnmatch);
+							 pfnmatch, fSimplifyNotExists);
 		if (fSuccess)
 		{
 			pdrgpexprChildren->Append(pexprChild);
@@ -252,8 +257,11 @@ CXformSimplifySubquery::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 		CExpression *pexprScalar = (*pexprInput)[1];
 		CExpression *pexprNewScalar = NULL;
 
+		BOOL fValueContext =
+			COperator::EopLogicalSelect != pexprInput->Pop()->Eopid();
 		if (!FSimplify(mp, pexprScalar, &pexprNewScalar,
-					   m_rgssm[ul].m_pfnsimplify, m_rgssm[ul].m_pfnmatch))
+					   m_rgssm[ul].m_pfnsimplify, m_rgssm[ul].m_pfnmatch,
+					   fValueContext))
 		{
 			CRefCount::SafeRelease(pexprNewScalar);
 			continue;

--- a/src/optimizer/orca/gporca/libgpopt/xforms/CXformSimplifySubquery.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/xforms/CXformSimplifySubquery.cpp
@@ -17,6 +17,8 @@
 #include "gpopt/operators/CExpressionHandle.h"
 #include "gpopt/operators/CNormalizer.h"
 #include "gpopt/operators/COperator.h"
+#include "gpopt/operators/CScalarCoalesce.h"
+#include "gpopt/operators/CScalarIdent.h"
 #include "gpopt/xforms/CXformUtils.h"
 #include "naucrates/md/IMDScalarOp.h"
 
@@ -128,10 +130,21 @@ CXformSimplifySubquery::FSimplifyExistential(CMemoryPool *mp,
 	CXformUtils::ExistentialToAgg(mp, pexprScalar, &pexprNewSubquery,
 								  &pexprCmp);
 
-	// create a comparison predicate involving subquery expression
+	// create a comparison predicate involving subquery expression;
+	// the count value comes back NULL (not 0) when the subquery is
+	// decorrelated below an outer join and no rows match, so compare on
+	// coalesce(count, 0) to keep EXISTS false rather than NULL
+	IMDId *mdid_count_type =
+		CScalarIdent::PopConvert((*pexprCmp)[0]->Pop())->MdidType();
+	mdid_count_type->AddRef();
+	(*pexprCmp)[1]->AddRef();
+	CExpression *pexprCoalesce = GPOS_NEW(mp) CExpression(
+		mp, GPOS_NEW(mp) CScalarCoalesce(mp, mdid_count_type),
+		pexprNewSubquery, (*pexprCmp)[1]);
+
 	CExpressionArray *pdrgpexpr = GPOS_NEW(mp) CExpressionArray(mp);
 	(*pexprCmp)[1]->AddRef();
-	pdrgpexpr->Append(pexprNewSubquery);
+	pdrgpexpr->Append(pexprCoalesce);
 	pdrgpexpr->Append((*pexprCmp)[1]);
 	pexprCmp->Pop()->AddRef();
 

--- a/src/parser/cypher_transformer.cpp
+++ b/src/parser/cypher_transformer.cpp
@@ -1107,7 +1107,8 @@ unique_ptr<ParsedExpression> CypherTransformer::transformAtom(CypherParser::OC_A
             // So: expressions[0] = WHERE (if exists), last expression = mapping
         }
 
-        // Mapping expression (after |)
+        // Mapping expression (after |) — evaluated per element: lambda context
+        lambda_depth_++;
         auto map_expr = transformExpression(*pc->oC_Expression().back());
         args.push_back(std::move(map_expr));
 
@@ -1116,13 +1117,12 @@ unique_ptr<ParsedExpression> CypherTransformer::transformAtom(CypherParser::OC_A
             auto where_expr = transformExpression(*pc->oC_Expression(0));
             args.push_back(std::move(where_expr));
         }
+        lambda_depth_--;
 
         return make_unique<FunctionExpression>("__pattern_comprehension", std::move(args));
     }
     if (ctx.oC_RelationshipsPattern()) {
-        // Pattern expression in expression context.
-        // 1-hop: (a)-[:R]->(b) → __pattern_exists(a, 'R', 'OUT', b)
-        // 2-hop: (a)-[:R1]->()<-[:R2]-(b) → __pattern_exists_2hop(a, 'R1', 'OUT', 'R2', 'OUT', b)
+        // Pattern expression in expression context, e.g. WHERE (a)-[:R]->(b).
         auto *rp = ctx.oC_RelationshipsPattern();
         auto *start_node = rp->oC_NodePattern();
         auto chains = rp->oC_PatternElementChain();
@@ -1130,6 +1130,30 @@ unique_ptr<ParsedExpression> CypherTransformer::transformAtom(CypherParser::OC_A
             throw NotImplementedException("Pattern expression start node is missing");
         }
 
+        if (lambda_depth_ == 0) {
+            // Lower to an existential subquery so the optimizer plans it as
+            // a (anti-)semi-join rather than a per-row storage probe.
+            auto elem = make_unique<PatternElement>(transformNodePattern(*start_node));
+            bool has_bound_endpoint = start_node->oC_Variable() != nullptr;
+            for (auto &chain : chains) {
+                has_bound_endpoint |= chain->oC_NodePattern()->oC_Variable() != nullptr;
+                elem->AddChain(transformRelationshipPattern(*chain->oC_RelationshipPattern()),
+                               transformNodePattern(*chain->oC_NodePattern()));
+            }
+            if (!has_bound_endpoint) {
+                throw NotImplementedException(
+                    "Pattern expression with only anonymous endpoints is degenerate");
+            }
+            auto exists = make_unique<ExistsSubqueryExpression>(false);
+            exists->patterns.push_back(std::move(elem));
+            return exists;
+        }
+
+        // Inside a comprehension/reduce lambda the pattern is evaluated
+        // per element by a scalar function — subqueries can't run there.
+        // Fall back to the __pattern_exists* scalar probes:
+        // 1-hop: (a)-[:R]->(b) → __pattern_exists(a, 'R', 'OUT', b)
+        // 2-hop: (a)-[:R1]->()<-[:R2]-(b) → __pattern_exists_2hop(a, 'R1', 'OUT', 'R2', 'OUT', b)
         if (chains.size() == 2) {
             string start_var = RequirePatternExprEndpointVar(*start_node, "start");
             ValidateAnonymousPatternExprMiddle(*chains[0]->oC_NodePattern());
@@ -1154,12 +1178,6 @@ unique_ptr<ParsedExpression> CypherTransformer::transformAtom(CypherParser::OC_A
             auto rel = transformRelationshipPattern(*chains[0]->oC_RelationshipPattern());
             ValidatePatternExprRel(*rel, "single");
             string rel_type = PatternExprRelType(*rel);
-            // Pattern existence with an anonymous endpoint is an
-            // existence-only semi-join: `(a)-[:T]->()` is "does `a`
-            // have any outgoing :T edge". Lower to `__check_any_adj`
-            // with the surviving bound variable in the source slot
-            // (flipping the direction when the anonymous side is the
-            // source). Reject the both-anonymous degenerate.
             if (start_var.empty() && end_var.empty()) {
                 throw NotImplementedException(
                     "Pattern expression with two anonymous endpoints is degenerate");
@@ -1183,7 +1201,8 @@ unique_ptr<ParsedExpression> CypherTransformer::transformAtom(CypherParser::OC_A
             return make_unique<FunctionExpression>("__pattern_exists", std::move(args));
         }
         throw NotImplementedException(
-            "Pattern expressions only support 1-hop checks or 2-hop checks with an anonymous middle node");
+            "Pattern expressions in comprehensions only support 1-hop checks or "
+            "2-hop checks with an anonymous middle node");
     }
     if (ctx.oC_ReduceExpression()) {
         // reduce(acc = init, var IN list | expr)
@@ -1193,7 +1212,9 @@ unique_ptr<ParsedExpression> CypherTransformer::transformAtom(CypherParser::OC_A
         string loop_var = re->oC_Variable(1)->getText();
         auto init_expr = transformExpression(*re->oC_Expression(0));
         auto list_expr = transformExpression(*re->oC_Expression(1));
+        lambda_depth_++;
         auto body_expr = transformExpression(*re->oC_Expression(2));
+        lambda_depth_--;
 
         vector<unique_ptr<ParsedExpression>> args;
         args.push_back(std::move(init_expr));
@@ -1218,6 +1239,7 @@ unique_ptr<ParsedExpression> CypherTransformer::transformAtom(CypherParser::OC_A
 
         unique_ptr<ParsedExpression> filter_expr;
         unique_ptr<ParsedExpression> mapping_expr;
+        lambda_depth_++;
 
         // Optional WHERE filter. The generated grammar can greedily parse
         // `WHERE pred | map` as a bitwise-OR inside the WHERE expression,
@@ -1247,6 +1269,7 @@ unique_ptr<ParsedExpression> CypherTransformer::transformAtom(CypherParser::OC_A
         if (mapping_expr) {
             args.push_back(std::move(mapping_expr));
         }
+        lambda_depth_--;
 
         return make_unique<FunctionExpression>("__list_comprehension", std::move(args));
     }

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -424,7 +424,7 @@ void Planner::_orcaSetOptCtxt(CMemoryPool *mp, CMDAccessor *mda,
 {
 
     auto hint = GPOS_NEW(mp) CHint(
-        gpos::int_max, /* join_arity_for_associativity_commutativity */
+        config.JOIN_ARITY_REORDER_THRESHOLD, /* join_arity_for_associativity_commutativity */
         gpos::int_max, /* array_expansion_threshold */
         config.JOIN_ORDER_DP_THRESHOLD_CONFIG, /*ulJoinOrderDPLimit*/
         BROADCAST_THRESHOLD,                   /*broadcast_threshold*/

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -102,6 +102,8 @@ void Planner::reset()
     both_edge_partitions.clear();
     multi_edge_partitions.clear();
     multi_vertex_partitions.clear();
+    path_dst_vertex_partitions.clear();
+    path_edge_partitions.clear();
     mpv_null_colref_props.clear();
     mpv_colref_to_scan_idx_.clear();
     complex_type_registry.clear();
@@ -489,6 +491,7 @@ void *Planner::_orcaExec(void *planner_ptr)
             planner->multi_edge_partitions,
             planner->multi_vertex_partitions,
             planner->path_dst_vertex_partitions,
+            planner->path_edge_partitions,
             planner->mpv_null_colref_props,
             planner->complex_type_registry,
             planner->next_complex_type_id,

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -2596,6 +2596,16 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
                         sib_idx = find_bwd_index(sib_epart, sib_fwd);
                     }
                     if (sib_idx == 0) continue;
+                    // Defense: never attach the primary index as its own
+                    // extra, and never attach the same extra twice — either
+                    // double-counts every match.
+                    if (sib_idx == adjidx_obj_id) continue;
+                    if (std::find(duckdb_adjidx_op->extra_fwd_obj_ids.begin(),
+                                  duckdb_adjidx_op->extra_fwd_obj_ids.end(),
+                                  sib_idx) !=
+                        duckdb_adjidx_op->extra_fwd_obj_ids.end()) {
+                        continue;
+                    }
 
                     duckdb_adjidx_op->extra_fwd_obj_ids.push_back(sib_idx);
 

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -7291,12 +7291,14 @@ void Planner::pTranslatePredicateToJoinCondition(
     if (op->Eopid() == COperator::EOperatorId::EopScalarBoolOp) {
         CScalarBoolOp *boolop = (CScalarBoolOp *)op;
         if (boolop->Eboolop() == CScalarBoolOp::EBoolOperator::EboolopAnd) {
-            D_ASSERT(pred->Arity() == 2);
-            // Split predicates
-            pTranslatePredicateToJoinCondition(pred->operator[](0), out_conds,
-                                               lhs_cols, rhs_cols);
-            pTranslatePredicateToJoinCondition(pred->operator[](1), out_conds,
-                                               lhs_cols, rhs_cols);
+            // ORCA builds N-ARY conjunctions; translating only the first two
+            // children silently drops the rest of the join condition and the
+            // join degenerates toward a cross product.
+            for (ULONG child_idx = 0; child_idx < pred->Arity(); child_idx++) {
+                pTranslatePredicateToJoinCondition(pred->operator[](child_idx),
+                                                   out_conds, lhs_cols,
+                                                   rhs_cols);
+            }
         }
         else if (boolop->Eboolop() == CScalarBoolOp::EBoolOperator::EboolopOr) {
             D_ASSERT(false);
@@ -7401,8 +7403,14 @@ bool Planner::pCanTranslatePredicateToJoinCondition(CExpression *pred)
     if (op->Eopid() == COperator::EOperatorId::EopScalarBoolOp) {
         auto *boolop = (CScalarBoolOp *)op;
         if (boolop->Eboolop() == CScalarBoolOp::EBoolOperator::EboolopAnd) {
-            return pCanTranslatePredicateToJoinCondition(pred->operator[](0)) &&
-                   pCanTranslatePredicateToJoinCondition(pred->operator[](1));
+            // N-ary conjunction: every child must be translatable.
+            for (ULONG child_idx = 0; child_idx < pred->Arity(); child_idx++) {
+                if (!pCanTranslatePredicateToJoinCondition(
+                        pred->operator[](child_idx))) {
+                    return false;
+                }
+            }
+            return true;
         }
         if (boolop->Eboolop() == CScalarBoolOp::EBoolOperator::EboolopNot) {
             if (pred->Arity() != 1) {

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -789,15 +789,27 @@ Planner::pTraverseTransformPhysicalPlan(CExpression *plan_expr)
         !preserve_custom_output_cols && derived_output_cols &&
         derived_output_cols->Size() == actual_output_col_count &&
         actual_output_col_count > output_cols->Size();
+    // Rebuilding assumes the operator emits exactly these columns at
+    // identity positions. A pass-through operator (Sort/Limit) keeps its
+    // child's full physical layout even when the parent requires fewer
+    // columns; rebuilding from the shrunken required set would re-anchor
+    // those columns at positions 0..N-1 and every later ident binding
+    // shifts (BI-4: topForum bound to country's columns). Only rebuild
+    // when the chosen set is at least count-consistent with the actual
+    // physical output; otherwise keep the child's (still valid) layout.
     if (!preserve_custom_output_cols && !preserve_explicit_output_cols &&
         output_cols->Size() > 0) {
-        physical_plan_output_colrefs.clear();  // TODO strange.. multiple times?
-        physical_plan_output_positions.clear();
         auto *chosen_cols = prefer_derived_output_cols ? derived_output_cols
                                                        : output_cols;
-        for (ULONG idx = 0; idx < chosen_cols->Size(); idx++) {
-            physical_plan_output_colrefs.push_back(chosen_cols->operator[](idx));
-            physical_plan_output_positions.push_back(idx);
+        if (actual_output_col_count == 0 ||
+            chosen_cols->Size() == actual_output_col_count) {
+            physical_plan_output_colrefs.clear();
+            physical_plan_output_positions.clear();
+            for (ULONG idx = 0; idx < chosen_cols->Size(); idx++) {
+                physical_plan_output_colrefs.push_back(
+                    chosen_cols->operator[](idx));
+                physical_plan_output_positions.push_back(idx);
+            }
         }
     }
     preserve_explicit_physical_output_layout = false;

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -794,15 +794,20 @@ Planner::pTraverseTransformPhysicalPlan(CExpression *plan_expr)
     // child's full physical layout even when the parent requires fewer
     // columns; rebuilding from the shrunken required set would re-anchor
     // those columns at positions 0..N-1 and every later ident binding
-    // shifts (BI-4: topForum bound to country's columns). Only rebuild
-    // when the chosen set is at least count-consistent with the actual
-    // physical output; otherwise keep the child's (still valid) layout.
+    // shifts (BI-4: topForum bound to country's columns). For those
+    // operators keep the child's (still valid) layout unless the counts
+    // line up; every other operator keeps the previous rebuild behavior.
+    bool is_layout_passthrough =
+        plan_expr->Pop()->Eopid() ==
+            COperator::EOperatorId::EopPhysicalLimit ||
+        plan_expr->Pop()->Eopid() == COperator::EOperatorId::EopPhysicalSort;
     if (!preserve_custom_output_cols && !preserve_explicit_output_cols &&
         output_cols->Size() > 0) {
         auto *chosen_cols = prefer_derived_output_cols ? derived_output_cols
                                                        : output_cols;
-        if (actual_output_col_count == 0 ||
-            chosen_cols->Size() == actual_output_col_count) {
+        bool count_consistent = actual_output_col_count == 0 ||
+                                chosen_cols->Size() == actual_output_col_count;
+        if (count_consistent || !is_layout_passthrough) {
             physical_plan_output_colrefs.clear();
             physical_plan_output_positions.clear();
             for (ULONG idx = 0; idx < chosen_cols->Size(); idx++) {

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -3033,8 +3033,81 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToVarlenAdjIdxJoin(
         }
     }
 
-    // Output filter from the dst vertex pattern (via converter map),
-    // not edge-schema terminal partitions. Empty set → no filter (#36).
+    // Multi-partition edge types (M27): CSRs live per edge partition, so
+    // levels >= 2 of the traversal need every sibling partition's
+    // same-direction CSR as well. Backward CSRs in particular split by
+    // destination partition (e.g. REPLY_OF → Comment@Post_bwd and
+    // Comment@Comment_bwd) while the plan's PathGet carries only the
+    // primary graphlet's index. Mirror of the single-hop M27-C logic.
+    {
+        auto &cat = context->db->GetCatalog();
+        bool primary_is_fwd = true;
+        std::unordered_set<uint64_t> have_oids(path_index_oids.begin(),
+                                               path_index_oids.end());
+        std::unordered_set<duckdb::idx_t> have_parts;
+        for (auto oid : path_index_oids) {
+            auto *ie = static_cast<duckdb::IndexCatalogEntry *>(
+                cat.GetEntry(*context, DEFAULT_SCHEMA, oid, true));
+            if (!ie) continue;
+            have_parts.insert(ie->GetPartitionID());
+            if (oid == path_index_oids[0]) {
+                primary_is_fwd =
+                    ie->GetIndexType() == duckdb::IndexType::FORWARD_CSR;
+            }
+        }
+        vector<uint64_t> extra_oids;
+        std::vector<duckdb::idx_t> family;
+        for (auto part : have_parts) {
+            auto it = path_edge_partitions.find(part);
+            if (it == path_edge_partitions.end()) continue;
+            family = it->second;
+            break;
+        }
+        // M30 virtual unified edge partitions: the partition's CSRs are
+        // split into per-sub-partition fragments (a backward CSR fragment
+        // per destination vertex partition). The traversal needs every
+        // same-direction fragment; seeking a vid in a fragment that does
+        // not own it is a plain miss, so adding all of them is safe.
+        for (auto part : std::vector<duckdb::idx_t>(have_parts.begin(),
+                                                    have_parts.end())) {
+            auto *epart = static_cast<duckdb::PartitionCatalogEntry *>(
+                cat.GetEntry(*context, DEFAULT_SCHEMA, part, true));
+            if (!epart) continue;
+            for (auto sub_oid : epart->sub_partition_oids) {
+                family.push_back((duckdb::idx_t)sub_oid);
+            }
+        }
+        for (auto sib_part_oid : family) {
+            if (have_parts.count(sib_part_oid)) continue;
+            auto *epart = static_cast<duckdb::PartitionCatalogEntry *>(
+                cat.GetEntry(*context, DEFAULT_SCHEMA, sib_part_oid, true));
+            if (!epart) continue;
+            for (auto idx_oid : *epart->GetAdjIndexOidVec()) {
+                auto *ie = static_cast<duckdb::IndexCatalogEntry *>(
+                    cat.GetEntry(*context, DEFAULT_SCHEMA, idx_oid, true));
+                if (!ie) continue;
+                bool is_fwd =
+                    ie->GetIndexType() == duckdb::IndexType::FORWARD_CSR;
+                bool is_bwd =
+                    ie->GetIndexType() == duckdb::IndexType::BACKWARD_CSR;
+                if (!is_fwd && !is_bwd) continue;
+                if (is_fwd == primary_is_fwd &&
+                    have_oids.insert(idx_oid).second) {
+                    extra_oids.push_back(idx_oid);
+                }
+            }
+            have_parts.insert(sib_part_oid);
+        }
+        for (auto o : extra_oids) {
+            path_index_oids.push_back(o);
+        }
+    }
+
+    // Output filter from the node pattern the traversal terminates on (via
+    // converter map), not edge-schema terminal partitions. The converter
+    // records both storage sides; a forward-CSR traversal ends on the
+    // storage-dst side, a backward one on the storage-src side. Empty set →
+    // no filter (#36).
     std::unordered_set<uint16_t> dst_partition_ids;
     {
         auto &cat = context->db->GetCatalog();
@@ -3045,8 +3118,11 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToVarlenAdjIdxJoin(
             duckdb::idx_t edge_part_oid = idx_entry->GetPartitionID();
             auto it = path_dst_vertex_partitions.find(edge_part_oid);
             if (it == path_dst_vertex_partitions.end()) continue;
-            for (auto pid : it->second) dst_partition_ids.insert(pid);
-            break;  // every path_index of a given VLE maps to the same dst pattern
+            bool is_fwd = idx_entry->GetIndexType() ==
+                          duckdb::IndexType::FORWARD_CSR;
+            auto &side = is_fwd ? it->second.second : it->second.first;
+            for (auto pid : side) dst_partition_ids.insert(pid);
+            break;  // every path_index of a given VLE maps to the same pattern
         }
     }
 

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -921,7 +921,37 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
 
     // Check for multi-partition vertex (MPV) expansion
     auto vp_it = multi_vertex_partitions.find(table_obj_id);
-    bool is_mpv = (vp_it != multi_vertex_partitions.end() && !vp_it->second.empty());
+    vector<uint64_t> mpv_siblings;
+    if (vp_it != multi_vertex_partitions.end()) {
+        mpv_siblings = vp_it->second;
+    }
+    // Edge-family siblings registered by the converter's single-edge
+    // optimization expand AdjIdxJoins at lowering, but a plan that scans
+    // the edge table directly (e.g. hash join under OPTIONAL) would
+    // silently read only the primary partition. Expand the scan over the
+    // sibling partitions' PropertySchemas the same way as MPV.
+    {
+        auto ep_it = multi_edge_partitions.find(table_obj_id);
+        if (ep_it != multi_edge_partitions.end()) {
+            duckdb::Catalog &cat_inst = context->db->GetCatalog();
+            for (auto sib_part_oid : ep_it->second) {
+                auto *sib_epart = static_cast<duckdb::PartitionCatalogEntry *>(
+                    cat_inst.GetEntry(*context, DEFAULT_SCHEMA,
+                                      (duckdb::idx_t)sib_part_oid));
+                if (!sib_epart) continue;
+                auto *ps_ids = sib_epart->GetPropertySchemaIDs();
+                if (!ps_ids) continue;
+                for (auto ps_id : *ps_ids) {
+                    if ((uint64_t)ps_id == (uint64_t)table_obj_id) continue;
+                    if (std::find(mpv_siblings.begin(), mpv_siblings.end(),
+                                  (uint64_t)ps_id) == mpv_siblings.end()) {
+                        mpv_siblings.push_back((uint64_t)ps_id);
+                    }
+                }
+            }
+        }
+    }
+    bool is_mpv = !mpv_siblings.empty();
 
     duckdb::Schema tmp_schema;
     tmp_schema.setStoredTypes(types);
@@ -973,14 +1003,14 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
             auto *primary_part = static_cast<duckdb::PartitionCatalogEntry *>(
                 cat_instance.GetEntry(*context, DEFAULT_SCHEMA, primary_ps->partition_oid));
             if (primary_part && !primary_part->sub_partition_oids.empty()
-                && !vp_it->second.empty()) {
+                && !mpv_siblings.empty()) {
                 // Virtual partition: replace with first real sub-partition
-                oids[0] = vp_it->second[0];
+                oids[0] = mpv_siblings[0];
                 sibling_start_idx = 1;
 
                 auto *first_ps = static_cast<duckdb::PropertySchemaCatalogEntry *>(
                     cat_instance.GetEntry(*context, DEFAULT_SCHEMA,
-                                          (duckdb::idx_t)vp_it->second[0]));
+                                          (duckdb::idx_t)mpv_siblings[0]));
                 auto first_key_names = first_ps ? first_ps->GetKeysWithCopy()
                                                 : vector<string>{};
                 std::unordered_map<string, duckdb::idx_t> first_name_pos;
@@ -1053,8 +1083,8 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
         }
 
         // Sibling partitions
-        for (size_t si = sibling_start_idx; si < vp_it->second.size(); si++) {
-            auto sib_oid = vp_it->second[si];
+        for (size_t si = sibling_start_idx; si < mpv_siblings.size(); si++) {
+            auto sib_oid = mpv_siblings[si];
             oids.push_back(sib_oid);
 
             auto *sib_ps2 = static_cast<duckdb::PropertySchemaCatalogEntry *>(
@@ -1131,8 +1161,8 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
         if (!mpv_null_colref_props.empty()) {
             // Collect all sibling name → position maps
             std::vector<std::unordered_map<string, duckdb::idx_t>> all_sib_name_pos;
-            for (size_t si = 0; si < vp_it->second.size(); si++) {
-                auto sib_oid = vp_it->second[si];
+            for (size_t si = 0; si < mpv_siblings.size(); si++) {
+                auto sib_oid = mpv_siblings[si];
                 auto *sib_ps3 = static_cast<duckdb::PropertySchemaCatalogEntry *>(
                     cat_instance.GetEntry(*context, DEFAULT_SCHEMA, sib_oid));
                 auto sib_names3 = sib_ps3 ? sib_ps3->GetKeysWithCopy() : vector<string>{};
@@ -1165,11 +1195,11 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
 
                 // Layout of scan_projection_mapping / local_schemas:
                 //   * virtual-partition mode (sibling_start_idx == 1):
-                //     index i ∈ [0, N) maps to vp_it->second[i] — the
+                //     index i ∈ [0, N) maps to mpv_siblings[i] — the
                 //     "primary" slot is actually the first real sub.
                 //   * old-style MPV mode (sibling_start_idx == 0):
                 //     slot 0 is a separately-stored real primary and
-                //     slots 1..N map to vp_it->second[0..N-1].
+                //     slots 1..N map to mpv_siblings[0..N-1].
                 //
                 // Earlier revisions of this block always wrote NULL to
                 // slot 0 and then iterated siblings at [si+1], which
@@ -1188,7 +1218,7 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopNormalTableScan(CExp
                         duckdb::LogicalType::SQLNULL);
                 }
                 const size_t sib_base = is_virtual_mode ? 0 : 1;
-                for (size_t si = 0; si < vp_it->second.size(); si++) {
+                for (size_t si = 0; si < mpv_siblings.size(); si++) {
                     size_t smp_idx = sib_base + si;
                     auto &spmap = all_sib_name_pos[si];
                     auto kit = spmap.find(prop_name);

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -2462,12 +2462,23 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
 
         bool is_both = both_edge_partitions.count(edge_part_oid) > 0;
 
-        // Primary partition: BOTH backward
+        // Primary partition: complementary-direction CSR for BOTH patterns.
+        // The optimizer may pick either CSR as the primary index, so the
+        // complement must be chosen by the primary's actual direction —
+        // unconditionally asking for a backward CSR leaves the second phase
+        // without an index whenever the primary already is the backward one.
         if (is_both) {
             auto *epart = static_cast<duckdb::PartitionCatalogEntry *>(
                 cat.GetEntry(*context, DEFAULT_SCHEMA, edge_part_oid));
             if (epart) {
-                duckdb_adjidx_op->bwd_adjidx_obj_id = find_bwd_index(epart, adjidx_obj_id);
+                auto *primary_idx_entry = static_cast<duckdb::IndexCatalogEntry *>(
+                    cat.GetEntry(*context, DEFAULT_SCHEMA, adjidx_obj_id, true));
+                bool primary_is_fwd = primary_idx_entry &&
+                    primary_idx_entry->GetIndexType() ==
+                        duckdb::IndexType::FORWARD_CSR;
+                duckdb_adjidx_op->bwd_adjidx_obj_id =
+                    primary_is_fwd ? find_bwd_index(epart, adjidx_obj_id)
+                                   : find_fwd_index(epart);
                 // No dedup needed: from a single vertex's perspective,
                 // forward CSR and backward CSR contain disjoint edge sets.
                 // Edge A→B appears in A's forward and B's backward only.
@@ -2519,6 +2530,57 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
                         duckdb_adjidx_op->extra_bwd_obj_ids.push_back(sib_complement);
                         duckdb_adjidx_op->extra_dedup_flags.push_back(false);
                     }
+                }
+            }
+        }
+
+        // DSI: an edge Get coalesced across partitions lowers to an index
+        // scan on the representative table, which carries only its own
+        // partition's CSR. Attach the matching-direction CSR of every other
+        // group member's partition so the join covers the whole edge family.
+        if (idxscan_op->Ptabdesc()->IsInstanceDescriptor()) {
+            IMdIdArray *group_tables = idxscan_op->Ptabdesc()->GetTableIdsInGroup();
+            auto *primary_idx_entry = static_cast<duckdb::IndexCatalogEntry *>(
+                cat.GetEntry(*context, DEFAULT_SCHEMA, adjidx_obj_id, true));
+            bool primary_is_fwd = primary_idx_entry &&
+                primary_idx_entry->GetIndexType() == duckdb::IndexType::FORWARD_CSR;
+            std::set<duckdb::idx_t> covered_parts;
+            covered_parts.insert(edge_part_oid);
+            for (ULONG gi = 0; group_tables && gi < group_tables->Size(); gi++) {
+                auto member_oid =
+                    (duckdb::idx_t)CMDIdGPDB::CastMdid((*group_tables)[gi])->Oid();
+                auto *member_ps =
+                    dynamic_cast<duckdb::PropertySchemaCatalogEntry *>(
+                        cat.GetEntry(*context, DEFAULT_SCHEMA, member_oid, true));
+                if (!member_ps) continue;
+                if (!covered_parts.insert(member_ps->partition_oid).second) {
+                    continue;
+                }
+                auto *sib_epart = static_cast<duckdb::PartitionCatalogEntry *>(
+                    cat.GetEntry(*context, DEFAULT_SCHEMA, member_ps->partition_oid));
+                if (!sib_epart) continue;
+                duckdb::idx_t sib_idx;
+                if (primary_is_fwd) {
+                    sib_idx = find_fwd_index(sib_epart);
+                } else {
+                    sib_idx = find_bwd_index(sib_epart, find_fwd_index(sib_epart));
+                }
+                if (sib_idx == 0) continue;
+                auto &extras = duckdb_adjidx_op->extra_fwd_obj_ids;
+                if (std::find(extras.begin(), extras.end(), sib_idx) !=
+                    extras.end()) {
+                    continue;
+                }
+                extras.push_back(sib_idx);
+                if (is_both) {
+                    duckdb::idx_t sib_complement;
+                    if (primary_is_fwd) {
+                        sib_complement = find_bwd_index(sib_epart, sib_idx);
+                    } else {
+                        sib_complement = find_fwd_index(sib_epart);
+                    }
+                    duckdb_adjidx_op->extra_bwd_obj_ids.push_back(sib_complement);
+                    duckdb_adjidx_op->extra_dedup_flags.push_back(false);
                 }
             }
         }

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -2397,9 +2397,72 @@ Planner::pTransformEopPhysicalInnerIndexNLJoinToAdjIdxJoin(
         CMDIdGPDB::CastMdid(idxscan_op->Pindexdesc()->MDId());
     adjidx_obj_id = index_mdid->Oid();
 
+    // The optimizer may implement a seek keyed on the edge's _sid with the
+    // backward CSR (which is keyed by _tid) or vice versa; the probe then
+    // runs against the wrong vertex partition and silently matches nothing.
+    // Detect which endpoint column the join predicate binds and swap to the
+    // matching-direction CSR of the same edge partition.
+    IMDIndex::EmdindexType emdind_type = idxscan_op->Pindexdesc()->IndexType();
+    {
+        CExpression *idx_cond = idxscan_expr->operator[](0);
+        bool pred_on_sid = false, pred_on_tid = false;
+        if (idx_cond->Pop()->Eopid() == COperator::EOperatorId::EopScalarCmp) {
+            for (ULONG ci = 0; ci < idx_cond->Arity(); ci++) {
+                CExpression *c = idx_cond->operator[](ci);
+                if (c->Pop()->Eopid() !=
+                    COperator::EOperatorId::EopScalarIdent) {
+                    continue;
+                }
+                const CColRef *col = ((CScalarIdent *)c->Pop())->Pcr();
+                if (pFindColRefIndex(actual_outer_cols, col) !=
+                    gpos::ulong_max) {
+                    continue;  // outer side of the predicate
+                }
+                std::wstring ws(col->Name().Pstr()->GetBuffer());
+                std::string cname(ws.begin(), ws.end());
+                if (cname == "_sid") pred_on_sid = true;
+                if (cname == "_tid") pred_on_tid = true;
+            }
+        }
+        auto &cat_inst = context->db->GetCatalog();
+        auto *idx_entry = static_cast<duckdb::IndexCatalogEntry *>(
+            cat_inst.GetEntry(*context, DEFAULT_SCHEMA, adjidx_obj_id, true));
+        if (idx_entry && (pred_on_sid != pred_on_tid)) {
+            bool idx_is_fwd = idx_entry->GetIndexType() ==
+                              duckdb::IndexType::FORWARD_CSR;
+            bool need_fwd = pred_on_sid;
+            if (idx_is_fwd != need_fwd) {
+                auto *epart_entry =
+                    static_cast<duckdb::PartitionCatalogEntry *>(
+                        cat_inst.GetEntry(*context, DEFAULT_SCHEMA,
+                                          idx_entry->pid, true));
+                auto *adj_oids =
+                    epart_entry ? epart_entry->GetAdjIndexOidVec() : nullptr;
+                for (duckdb::idx_t cand :
+                     adj_oids ? *adj_oids : duckdb::vector<duckdb::idx_t>{}) {
+                    auto *cand_entry =
+                        static_cast<duckdb::IndexCatalogEntry *>(
+                            cat_inst.GetEntry(*context, DEFAULT_SCHEMA, cand,
+                                              true));
+                    if (!cand_entry) continue;
+                    bool cand_fwd = cand_entry->GetIndexType() ==
+                                    duckdb::IndexType::FORWARD_CSR;
+                    bool cand_bwd = cand_entry->GetIndexType() ==
+                                    duckdb::IndexType::BACKWARD_CSR;
+                    if ((need_fwd && cand_fwd) || (!need_fwd && cand_bwd)) {
+                        adjidx_obj_id = cand;
+                        emdind_type = need_fwd ? IMDIndex::EmdindFwdAdjlist
+                                               : IMDIndex::EmdindBwdAdjlist;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     // Construct adjacency index
     auto adjidx_idx_idxs =
-        pGetAdjIdxIdIdxs(adj_inner_cols, idxscan_op->Pindexdesc()->IndexType());
+        pGetAdjIdxIdIdxs(adj_inner_cols, emdind_type);
     if (generate_seek) {
         auto edge_inner_idx = std::get<0>(adjidx_idx_idxs);
         D_ASSERT(edge_inner_idx != (duckdb::idx_t)-1);

--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -14,6 +14,7 @@
 #include "execution/physical_operator/physical_blockwise_nl_join.hpp"
 #include "execution/physical_operator/physical_cross_product.hpp"
 #include "execution/physical_operator/physical_filter.hpp"
+#include "execution/physical_operator/physical_ordered_distinct.hpp"
 #include "execution/physical_operator/physical_hash_aggregate.hpp"
 #include "execution/physical_operator/physical_hash_join.hpp"
 #include "execution/physical_operator/physical_id_seek.hpp"
@@ -6456,6 +6457,66 @@ duckdb::CypherPhysicalOperatorGroups *Planner::pTransformEopAgg(
     duckdb::Schema tmp_schema;
     tmp_schema.setStoredTypes(types);
     tmp_schema.setStoredColumnNames(output_column_names);
+
+    // Pure DISTINCT (no aggregate functions) directly above an ORDER BY:
+    // a hash aggregate discards the sort order, so a following LIMIT keeps
+    // an arbitrary subset instead of the sorted head (BI-4's top-100
+    // forums). Lower it as a streaming, order-preserving dedup instead.
+    if (pexprProjList->Arity() == 0 && !agg_groups.empty() &&
+        !has_pre_projection) {
+        auto order_defined_below = [&]() -> bool {
+            CExpression *cur = (*plan_expr)[0];
+            while (cur != nullptr) {
+                auto eid = cur->Pop()->Eopid();
+                if (eid == COperator::EOperatorId::EopPhysicalSort) {
+                    return true;
+                }
+                if (eid == COperator::EOperatorId::EopPhysicalLimit ||
+                    eid == COperator::EOperatorId::EopPhysicalComputeScalar ||
+                    eid == COperator::EOperatorId::
+                               EopPhysicalComputeScalarColumnar ||
+                    eid == COperator::EOperatorId::EopPhysicalFilter) {
+                    cur = cur->Arity() > 0 ? (*cur)[0] : nullptr;
+                    continue;
+                }
+                return false;
+            }
+            return false;
+        };
+        if (order_defined_below()) {
+            vector<uint32_t> key_input_idxs;
+            vector<uint32_t> output_input_idxs(types.size(),
+                                               std::numeric_limits<uint32_t>::max());
+            bool mapping_ok = true;
+            for (ULONG gi = 0; gi < agg_groups.size(); gi++) {
+                auto *ref = (duckdb::BoundReferenceExpression *)agg_groups[gi].get();
+                key_input_idxs.push_back((uint32_t)ref->index);
+                auto out_pos = output_projection_mapping[gi];
+                if (out_pos == std::numeric_limits<uint32_t>::max()) {
+                    continue;
+                }
+                if (out_pos >= output_input_idxs.size()) {
+                    mapping_ok = false;
+                    break;
+                }
+                output_input_idxs[out_pos] = (uint32_t)ref->index;
+            }
+            for (auto v : output_input_idxs) {
+                if (v == std::numeric_limits<uint32_t>::max()) {
+                    mapping_ok = false;
+                }
+            }
+            if (mapping_ok) {
+                duckdb::CypherPhysicalOperator *dedup_op =
+                    make_owned<duckdb::PhysicalOrderedDistinct>(
+                        tmp_schema, std::move(key_input_idxs),
+                        std::move(output_input_idxs));
+                result->push_back(dedup_op);
+                return result;
+            }
+        }
+    }
+
     if (has_pre_projection) {
         duckdb::Schema proj_schema;
         proj_schema.setStoredTypes(proj_types);

--- a/src/planner/planner_physical_scalar.cpp
+++ b/src/planner/planner_physical_scalar.cpp
@@ -36,6 +36,7 @@ unique_ptr<duckdb::Expression> Planner::pTransformScalarExpr(CExpression * scala
 		case COperator::EopScalarSwitch: return pTransformScalarSwitch(scalar_expr, lhs_child_cols, rhs_child_cols);
 		case COperator::EopScalarIf: return pTransformScalarIf(scalar_expr, lhs_child_cols, rhs_child_cols);
 		case COperator::EopScalarNullTest: return pTransformScalarNullTest(scalar_expr, lhs_child_cols, rhs_child_cols);
+		case COperator::EopScalarCoalesce: return pTransformScalarCoalesce(scalar_expr, lhs_child_cols, rhs_child_cols);
 		case COperator::EopScalarCast: return pTransformScalarCast(scalar_expr, lhs_child_cols, rhs_child_cols);
 		default:
 			GPOS_ASSERT(false); // NOT implemented yet
@@ -89,6 +90,12 @@ void Planner::pGetAllScalarIdents(CExpression * scalar_expr, vector<uint32_t> &s
 		case COperator::EopScalarFunc: return;
 		case COperator::EopScalarSwitch: return;
 		case COperator::EopScalarIf: {
+			for (ULONG child_idx = 0; child_idx < scalar_expr->Arity(); child_idx++) {
+				pGetAllScalarIdents(scalar_expr->operator[](child_idx), sccmp_colids);
+			}
+			return;
+		}
+		case COperator::EopScalarCoalesce: {
 			for (ULONG child_idx = 0; child_idx < scalar_expr->Arity(); child_idx++) {
 				pGetAllScalarIdents(scalar_expr->operator[](child_idx), sccmp_colids);
 			}
@@ -883,6 +890,24 @@ unique_ptr<duckdb::Expression> Planner::pTransformScalarIf(CExpression *scalar_e
 	}
 
 	return make_unique<duckdb::BoundCaseExpression>(move(e_when), move(e_then), move(e_else));
+}
+
+unique_ptr<duckdb::Expression> Planner::pTransformScalarCoalesce(CExpression *scalar_expr, CColRefArray *lhs_child_cols, CColRefArray* rhs_child_cols) {
+	// CScalarCoalesce(a, b, ...) → first non-NULL child
+	D_ASSERT(scalar_expr->Arity() >= 1);
+	vector<unique_ptr<duckdb::Expression>> children;
+	for (ULONG i = 0; i < scalar_expr->Arity(); i++) {
+		children.push_back(pTransformScalarExpr(scalar_expr->operator[](i), lhs_child_cols, rhs_child_cols));
+	}
+	duckdb::LogicalType ret_type = children[0]->return_type;
+	for (size_t i = 1; i < children.size(); i++) {
+		ret_type = duckdb::LogicalType::MaxLogicalType(ret_type, children[i]->return_type);
+	}
+	auto result = make_unique<duckdb::BoundOperatorExpression>(duckdb::ExpressionType::OPERATOR_COALESCE, ret_type);
+	for (auto &child : children) {
+		result->children.push_back(pGenScalarCast(move(child), ret_type));
+	}
+	return std::move(result);
 }
 
 unique_ptr<duckdb::Expression> Planner::pTransformScalarNullTest(CExpression *scalar_expr, CColRefArray *lhs_child_cols, CColRefArray* rhs_child_cols) {

--- a/src/storage/extent/adjlist_iterator.cpp
+++ b/src/storage/extent/adjlist_iterator.cpp
@@ -104,9 +104,11 @@ int AdjacencyListIterator::requestNewAdjList(duckdb::ClientContext &context, int
 
 void DFSIterator::initialize(duckdb::ClientContext &context, uint64_t src_id,
                               vector<int> adj_col_idxs, vector<bool> adj_col_is_fwds,
-                              const std::unordered_set<uint16_t> &src_partition_ids) {
+                              const std::unordered_set<uint16_t> &src_partition_ids,
+                              const vector<std::unordered_set<uint16_t>> *adj_col_src_pids) {
     current_lv = 0;
     src_partition_ids_ = src_partition_ids;
+    adj_col_src_pids_ = adj_col_src_pids;
     adjColIdxs = adj_col_idxs;
     adjColIsFwds = adj_col_is_fwds;
     int n_ac = (int)adj_col_idxs.size();
@@ -152,7 +154,19 @@ void DFSIterator::setupAdjListsForNode(duckdb::ClientContext &context, int lv, u
     prev_eid_per_lv_per_col[lv].resize(n_ac, std::numeric_limits<ExtentID>::max());
 
     auto &wrapper = *context.graph_storage_wrapper;
+    uint16_t node_pid = wrapper.getNodePartitionId(src_id);
     for (int ac = 0; ac < n_ac; ac++) {
+        // Skip adj cols whose CSR is not stored on this node's partition:
+        // the same slot index can hold a different edge type's CSR on
+        // another partition's extents, so seeking it there reads garbage.
+        if (adj_col_src_pids_ != nullptr &&
+            ac < (int)adj_col_src_pids_->size() &&
+            !(*adj_col_src_pids_)[ac].empty() &&
+            (*adj_col_src_pids_)[ac].count(node_pid) == 0) {
+            offsets_per_lv_per_col[lv][ac] = {nullptr, nullptr};
+            cursor_per_lv_per_col[lv][ac] = 0;
+            continue;
+        }
         ExpandDirection dir = adjColIsFwds[ac] ? ExpandDirection::OUTGOING
                                                : ExpandDirection::INCOMING;
         uint64_t *start = nullptr;
@@ -160,6 +174,18 @@ void DFSIterator::setupAdjListsForNode(duckdb::ClientContext &context, int lv, u
         wrapper.getAdjListFromVid(*adjlist_iters[ac], adjColIdxs[ac],
             prev_eid_per_lv_per_col[lv][ac], src_id, start, end, dir,
             delta_merge_bufs_per_lv_per_col[lv][ac]);
+        // The DFS holds this level's adj list across arbitrarily deep
+        // traversal of the levels below, but (start, end) may point into
+        // the shared per-adj-col iterator's extent buffer, which those
+        // deeper levels re-seek to other extents. Copy into this
+        // (level, col)'s own scratch buffer so the pointers stay valid.
+        auto &own_buf = delta_merge_bufs_per_lv_per_col[lv][ac];
+        if (start != nullptr && end != nullptr && start != own_buf.data()) {
+            size_t n = (size_t)(end - start);
+            own_buf.assign(start, end);
+            start = own_buf.data();
+            end = own_buf.data() + n;
+        }
         offsets_per_lv_per_col[lv][ac] = {start, end};
         cursor_per_lv_per_col[lv][ac] = 0;
     }

--- a/src/storage/graph_storage_wrapper.cpp
+++ b/src/storage/graph_storage_wrapper.cpp
@@ -776,6 +776,46 @@ uint16_t iTbgppGraphStorageWrapper::getAdjListSrcPartitionId(idx_t index_cat_oid
     return (uint16_t)vertex_part->GetPartitionID();
 }
 
+void iTbgppGraphStorageWrapper::getAdjListSrcPartitionIds(
+    idx_t index_cat_oid, std::unordered_set<uint16_t> &out) {
+    Catalog &cat = client.db->GetCatalog();
+    IndexCatalogEntry *index_cat = (IndexCatalogEntry *)cat.GetEntry(
+        client, DEFAULT_SCHEMA, index_cat_oid, true);
+    if (!index_cat)
+        throw InvalidInputException("getAdjListSrcPartitionIds: OID %llu not found",
+                                    (unsigned long long)index_cat_oid);
+    PartitionCatalogEntry *edge_part = (PartitionCatalogEntry *)cat.GetEntry(
+        client, DEFAULT_SCHEMA, index_cat->pid, true);
+    if (!edge_part)
+        throw InvalidInputException("getAdjListSrcPartitionIds: edge partition oid %llu not found",
+                                    (unsigned long long)index_cat->pid);
+
+    bool is_forward = (index_cat->GetIndexType() == IndexType::FORWARD_CSR);
+    idx_t vertex_part_oid =
+        is_forward ? edge_part->GetSrcPartOid() : edge_part->GetDstPartOid();
+
+    PartitionCatalogEntry *vertex_part = (PartitionCatalogEntry *)cat.GetEntry(
+        client, DEFAULT_SCHEMA, vertex_part_oid, true);
+    if (!vertex_part)
+        throw InvalidInputException("getAdjListSrcPartitionIds: vertex partition oid %llu not found",
+                                    (unsigned long long)vertex_part_oid);
+
+    // A virtual seek-side partition (superlabel, e.g. Message covering
+    // Comment and Post) stores the CSR fragments on each real partition:
+    // every one of them is a seekable source for the traversal.
+    if (!vertex_part->sub_partition_oids.empty()) {
+        for (auto sub_oid : vertex_part->sub_partition_oids) {
+            auto *sub = (PartitionCatalogEntry *)cat.GetEntry(
+                client, DEFAULT_SCHEMA, sub_oid, true);
+            if (sub) {
+                out.insert((uint16_t)sub->GetPartitionID());
+            }
+        }
+    } else {
+        out.insert((uint16_t)vertex_part->GetPartitionID());
+    }
+}
+
 uint16_t iTbgppGraphStorageWrapper::getNodePartitionId(uint64_t vid) {
     auto adjacency_pid = client.db->delta_store.ResolveAdjacencyPid(vid);
     return (uint16_t)(adjacency_pid >> 48);

--- a/test/query/test_ldbc_filter.cpp
+++ b/test/query/test_ldbc_filter.cpp
@@ -1011,14 +1011,15 @@ TEST_CASE("pattern expression with anonymous endpoint returns existence", "[ldbc
     CHECK(r[0].bool_at(0) == true);
 }
 
-TEST_CASE("pattern expression still rejects labelled anonymous endpoint", "[ldbc][filter][patternexpr]") {
+TEST_CASE("pattern expression supports labelled anonymous endpoint", "[ldbc][filter][patternexpr]") {
     SKIP_IF_NO_DB();
-    // Anonymous endpoint with a label requires per-partition filtering
-    // on the semi-join side — not yet supported.  Once that lands, this
-    // assertion can be flipped to assert the expected result.
+    // Pattern expressions lower to existential subqueries, which scan the
+    // anonymous endpoint's label partition like any other node pattern.
     auto q = "MATCH (p:Person {id: " + sample_person_id_str() + "}) "
              "RETURN (p)-[:KNOWS]->(:Person) AS x";
-    REQUIRE_THROWS(qr->run(q.c_str(), {qtest::ColType::BOOL}));
+    auto r = qr->run(q.c_str(), {qtest::ColType::BOOL});
+    REQUIRE(r.size() == 1);
+    CHECK(r[0].bool_at(0) == true);
 }
 
 TEST_CASE("CONTAINS in WHERE", "[ldbc][filter][stringpred]") {

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -124,6 +124,7 @@ static void ParseShellOptions(int argc, char** argv, ShellCliOptions& opts) {
         {"disable-merge-join",  no_argument,       0, 1004},
         {"disable-index-join",  no_argument,       0, 1005},
         {"join-order-optimizer",required_argument, 0, 'j'},
+        {"join-arity-threshold", required_argument, 0, 1011},
         {"debug-orca",          no_argument,       0, 1006},
         {"query",               required_argument, 0, 'q'},
         {"q",                   required_argument, 0, 'q'},  // alias for --query
@@ -181,6 +182,8 @@ static void ParseShellOptions(int argc, char** argv, ShellCliOptions& opts) {
         case 1007: opts.warmup = true; break;
         case 1008: opts.enable_profile = true; break;
         case 1009: opts.planner_config.DEBUG_PRINT = true; break;
+        case 1011: opts.planner_config.JOIN_ARITY_REORDER_THRESHOLD =
+                       (uint8_t)std::stoul(optarg); break;
         case 'm': opts.output_mode = optarg; break;
         default: break;
         }


### PR DESCRIPTION
Stacked on #301 (first 3 commits are its base; review the rest).

Thirteen fixes discovered while validating all LDBC BI queries against Neo4j 5.26 on the official SF1 dataset. With this PR **every comparable BI query matches the reference**: bi-1,2,3,4,5,6,8,9,10,11,12,13,14,16,17,18 (bi-7 modulo the already-merged #300; bi-15/19/20 need Neo4j GDS to compare).

### Optimizer / converter
1. **VLE direction** — backward-anchored variable-length patterns traversed nothing beyond length 0.
2. **DFS partition-ownership guard** — unlabeled far ends read another edge type's CSR slot.
3. **IdSeek multi-schema rescan OOB column map** — predicate bytes sprayed over the _id buffer (BI-12).
4. **Edge-family siblings in direct scans** — hash-join build sides read one partition (BI-13 family).
5. **Sibling re-registration per pattern** — duplicate extras doubled sibling matches (BI-8 scores).
6. **DSI edge groups + either-direction BOTH joins** — representative carried one partition's CSR; undirected complement assumed a forward primary (BI-8 friendsScore).
7. **OPTIONAL subquery premature close** — one OPTIONAL MATCH split into two LOJs stopped nullifying earlier bindings (BI-16, incl. a 230s pathological plan).
8. **N-ary AND join predicates** — third+ conjuncts of a hash-join condition silently dropped → cross products (BI-18).
9. **Direction-mismatched CSR choice** — a _sid-keyed seek implemented with the backward CSR matches nothing (BI-14 OPTIONAL chains).
10. **Computed WITH items** — defining `AS <shadowing-alias>` short-circuited to the stale column; `WITH DISTINCT …, expr AS x` dropped x from dedup keys/output; current WITH's ORDER BY property refs now survive aggregation (BI-4 wouldn't prepare, BI-14 score stuck at 0).
11. **Physical layout tracker** — colref lineage across WITH projections (SetPrevId) and no identity re-anchoring on pass-through Sort/Limit (BI-4 read country's columns as topForum).
12. **VLE registrations polluting single-hop sibling extras** — a later single-hop join on the same edge type attached the primary as its own extra (matches ×2) plus the label-pruned family member (:Post phantoms) — exposed by de-vacuating BI-17's 0=0 via stage decomposition (144 vs 50).
13. **Order-preserving DISTINCT** — new streaming `PhysicalOrderedDistinct` lowers pure-distinct GbAggs above a Sort, keeping `ORDER BY .. WITH DISTINCT .. LIMIT` first-occurrence semantics (BI-4's top-100 selection).

### Verification
- LDBC BI SF1 vs Neo4j 5.26 (official datagen + parameters-sf1): 16/16 comparable queries MATCH. bi-10 verified against an equivalence-rewritten Neo4j baseline (original exceeds 30min on Neo4j); bi-17 substantiated by stage-wise nonzero cross-checks (its final 0=0 alone was vacuous).
- Both comparison datasets were repaired during validation (Neo4j lacked Place/Organisation labels; all converted CSVs were CRLF) — earlier vacuous 0=0 passes are now genuinely verified.
- `query_test`: [ldbc] 648/648, [tpch] 58/58, [ldbc][crud] 147/147, remaining tags 71/72 (the one failure, `Bug J unknown property`, pre-exists without this branch); `unittest` 223/223 — re-run after every fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8KAKgKhNeAeckVTEoF9Ho