### PR TITLE
planner: unify multi-label planning under DSI instance descriptors

### DIFF
--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -1497,15 +1497,8 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
 
                     // Inner join edge → new node within subquery
                     // Multi-graphlet (abstract) nodes: scan the primary graphlet
-                    // only (+ MPV siblings) so an edge adjacency index can narrow
-                    // the node, instead of base-scanning every partition as a
-                    // UnionAll. Mirrors PlanRegularMatch; without this an OPTIONAL
-                    // MATCH over an unlabeled multi-graphlet node full-scans every
-                    // partition.
                     turbolynx::LogicalPlan *new_node_plan =
-                        new_node_expr->GetGraphletIDs().size() > 1
-                            ? PlanPrimaryGraphletNodeScan(*new_node_expr)
-                            : PlanNodeScan(*new_node_expr);
+                        PlanNodeScan(*new_node_expr);
                     CExpression *ij = ExprLogicalJoin(
                         subquery->getPlanExpr(), new_node_plan->getPlanExpr(),
                         subquery->getSchema()->getColRefOfKey(edge_name, new_edge_key),
@@ -1592,11 +1585,8 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanOptionalMatch(
                     uint64_t new_edge_key = is_lhs_new ? lhs_edge_key : rhs_edge_key;
 
                     // Inner join: subquery IJ new_node on edge.new_key = node._id.
-                    // Multi-graphlet nodes use the primary-graphlet scan (see above).
                     turbolynx::LogicalPlan *new_node_plan =
-                        new_node_expr->GetGraphletIDs().size() > 1
-                            ? PlanPrimaryGraphletNodeScan(*new_node_expr)
-                            : PlanNodeScan(*new_node_expr);
+                        PlanNodeScan(*new_node_expr);
                     CExpression *ij2 = ExprLogicalJoin(
                         subquery->getPlanExpr(), new_node_plan->getPlanExpr(),
                         subquery->getSchema()->getColRefOfKey(edge_name, new_edge_key),
@@ -1666,13 +1656,6 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
     map<string, SubqueryCorrelation> *subquery_corr_keys)
 {
     turbolynx::LogicalPlan *qg_plan = prev_plan;
-    // Local alias so the call sites below read unchanged. The real logic now
-    // lives in the member PlanPrimaryGraphletNodeScan so PlanOptionalMatch can
-    // reuse it (it previously base-scanned every graphlet via PlanNodeScan).
-    auto plan_primary_graphlet_node_scan =
-        [this](const BoundNodeExpression &node) -> turbolynx::LogicalPlan * {
-            return PlanPrimaryGraphletNodeScan(node);
-        };
 
     D_ASSERT(qgc.GetNumQueryGraphs() > 0);
     // Process QueryGraphs in two phases:
@@ -1872,8 +1855,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                 bool use_per_partition_join = !is_pathjoin
                     && !qedge->IsVariableLength()
                     && (qedge->GetPartitionIDs().size() > 1 ||
-                        expanded_lhs_pids.size() > 1 ||
-                        lhs_node->GetGraphletIDs().size() > 1);
+                        expanded_lhs_pids.size() > 1);
                 if (!qedge->GetPartitionIDs().empty() && !lhs_node->GetPartitionIDs().empty()) {
                     // Classify edge partitions by how LHS matches src/dst
                     bool any_src_only = false, any_dst_only = false, any_self_ref = false;
@@ -2305,18 +2287,8 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                     // Standard single A→R join.
                     // Call PlanNodeScan here (deferred from above) so that
                     // multi_vertex_partitions_ is only set in the standard path.
-                    // For a multi-graphlet node, scan only the primary graphlet
-                    // (single CLogicalGet + MPV siblings) instead of a UnionAll —
-                    // mirrors the R-join-B rhs path below. A multi-graphlet
-                    // UnionAll's output colref does not propagate through the
-                    // subsequent join, collapsing the join predicate to a
-                    // self-comparison and dropping the anchor constraint.
                     if (!is_lhs_bound) {
-                        bool prefer_primary_graphlet_only =
-                            lhs_node->GetGraphletIDs().size() > 1;
-                        lhs_plan = prefer_primary_graphlet_only
-                            ? plan_primary_graphlet_node_scan(*lhs_node)
-                            : PlanNodeScan(*lhs_node);
+                        lhs_plan = PlanNodeScan(*lhs_node);
                     }
                     // M27: Record multi-partition edge info for the planner.
                     // Use single-partition edge scan when bound so ORCA generates
@@ -2388,11 +2360,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanRegularMatch(
                 } else {
                     turbolynx::LogicalPlan *rhs_plan;
                     if (!is_rhs_bound) {
-                        bool prefer_primary_graphlet_only =
-                            rhs_node->GetGraphletIDs().size() > 1;
-                        rhs_plan = prefer_primary_graphlet_only
-                            ? plan_primary_graphlet_node_scan(*rhs_node)
-                            : PlanNodeScan(*rhs_node);
+                        rhs_plan = PlanNodeScan(*rhs_node);
                     } else {
                         rhs_plan = qg_plan;
                     }
@@ -3847,81 +3815,6 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanSkipOrLimit(
 // ============================================================
 // Node scan
 // ============================================================
-turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanPrimaryGraphletNodeScan(
-    const BoundNodeExpression &node)
-{
-    const string &name = node.GetUniqueName();
-    vector<uint64_t> graphlet_oids(node.GetGraphletIDs().begin(),
-                                   node.GetGraphletIDs().end());
-    if (graphlet_oids.empty()) {
-        throw duckdb::InvalidInputException(
-            "MATCH pattern '" + name +
-            "' does not match any vertex partition.");
-    }
-
-    uint64_t primary_graphlet = graphlet_oids.front();
-    std::vector<idx_t> sibling_graphlets;
-    for (size_t i = 1; i < graphlet_oids.size(); i++) {
-        sibling_graphlets.push_back((idx_t)graphlet_oids[i]);
-    }
-
-    auto &catalog = context_->db->GetCatalog();
-    if (node.GetPartitionIDs().size() == 1) {
-        auto pid = (idx_t)node.GetPartitionIDs()[0];
-        auto *part = static_cast<PartitionCatalogEntry *>(
-            catalog.GetEntry(*context_, DEFAULT_SCHEMA, pid));
-        if (part && !part->sub_partition_oids.empty()) {
-            for (auto sub_part_oid : part->sub_partition_oids) {
-                auto *sub_part = static_cast<PartitionCatalogEntry *>(
-                    catalog.GetEntry(*context_, DEFAULT_SCHEMA,
-                                     sub_part_oid));
-                if (!sub_part) {
-                    continue;
-                }
-                PropertySchemaID_vector sub_ps_ids;
-                sub_part->GetPropertySchemaIDs(sub_ps_ids);
-                for (auto ps_id : sub_ps_ids) {
-                    auto *ps = static_cast<PropertySchemaCatalogEntry *>(
-                        catalog.GetEntry(*context_, DEFAULT_SCHEMA, ps_id));
-                    if (!ps || ps->is_fake ||
-                        (uint64_t)ps_id == primary_graphlet) {
-                        continue;
-                    }
-                    sibling_graphlets.push_back((idx_t)ps_id);
-                }
-            }
-        }
-    }
-
-    std::sort(sibling_graphlets.begin(), sibling_graphlets.end());
-    sibling_graphlets.erase(
-        std::unique(sibling_graphlets.begin(), sibling_graphlets.end()),
-        sibling_graphlets.end());
-    if (!sibling_graphlets.empty()) {
-        multi_vertex_partitions_[(idx_t)primary_graphlet] = sibling_graphlets;
-    }
-
-    vector<uint64_t> single_graphlets{primary_graphlet};
-    const auto &prop_exprs = node.GetPropertyExpressions();
-    map<uint64_t, map<uint64_t, uint64_t>> mapping;
-    vector<int> used_col_idx;
-    BuildSchemaProjectionMapping(single_graphlets, prop_exprs,
-                                 node.IsWholeNodeRequired(), mapping,
-                                 used_col_idx, nullptr,
-                                 [&](int col_idx) {
-                                     return node.IsPropertyUsed(col_idx);
-                                 });
-
-    auto planned = ExprLogicalGetNodeOrEdge(
-        name, single_graphlets, used_col_idx, &mapping, nullptr);
-    CExpression *plan_expr = planned.first;
-    CColRefArray *colrefs = planned.second;
-
-    turbolynx::LogicalSchema schema;
-    GenerateNodeSchema(node, used_col_idx, colrefs, schema);
-    return make_owned<turbolynx::LogicalPlan>(plan_expr, schema);
-}
-
 turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanNodeScan(const BoundNodeExpression &node)
 {
     const string &name = node.GetUniqueName();
@@ -3934,7 +3827,59 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanNodeScan(const BoundNodeExpres
     // MPV expansion needed at the NodeScan level.
     graphlet_oids.assign(node.GetGraphletIDs().begin(), node.GetGraphletIDs().end());
 
-    if (node.GetPartitionIDs().size() > 1) {
+    if (graphlet_oids.empty()) {
+        // No graphlets for this node pattern. Most common cause: the
+        // workspace is empty, or no vertex partition exists for the
+        // requested label. Rather than assert, raise a clean exception
+        // so the shell reports it and stays alive.
+        throw duckdb::InvalidInputException(
+            "MATCH pattern '" + name + "' does not match any vertex partition. "
+            "The workspace has no matching labels yet — import data first or "
+            "create partitions via the C API.");
+    }
+
+    // ── DSI: Coalesce multiple graphlets into one representative group ──
+    std::vector<std::vector<uint64_t>> table_oids_in_groups;
+    bool use_dsi = false;
+#ifdef DYNAMIC_SCHEMA_INSTANTIATION
+    if (graphlet_oids.size() > 1) {
+        auto has_temporal_graphlet = [&]() {
+            auto &catalog = context_->db->GetCatalog();
+            for (auto graphlet_oid : graphlet_oids) {
+                auto *ps = static_cast<PropertySchemaCatalogEntry *>(
+                    catalog.GetEntry(*context_, DEFAULT_SCHEMA,
+                                     (idx_t)graphlet_oid, true));
+                if (!ps) {
+                    continue;
+                }
+                if (ps->is_fake ||
+                    ps->GetName().find(DEFAULT_TEMPORAL_INFIX) != string::npos) {
+                    return true;
+                }
+            }
+            return false;
+        };
+        if (!has_temporal_graphlet()) {
+            vector<uint64_t> prop_key_ids;  // empty → MERGEALL grouping
+
+            vector<idx_t> table_oids(graphlet_oids.begin(), graphlet_oids.end());
+            vector<idx_t> representative_oids;
+            vector<vector<uint64_t>> prop_location;
+            vector<bool> has_temp_table;
+
+            context_->db->GetCatalogWrapper().ConvertTableOidsIntoRepresentativeOids(
+                *context_, prop_key_ids, table_oids, provider_,
+                representative_oids, table_oids_in_groups,
+                prop_location, has_temp_table);
+
+            graphlet_oids.assign(representative_oids.begin(),
+                                 representative_oids.end());
+            use_dsi = true;
+        }
+    }
+#endif
+
+    if (!use_dsi && node.GetPartitionIDs().size() > 1) {
         // Record sibling partition info for IdSeek MPV expansion (NLJ inner side).
         // Key = first partition's first graphlet OID.
         auto &catalog = context_->db->GetCatalog();
@@ -3958,7 +3903,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanNodeScan(const BoundNodeExpres
                 multi_vertex_partitions_[(idx_t)(*ps_ids)[0]] = sibling_graphlets;
             }
         }
-    } else if (node.GetPartitionIDs().size() == 1) {
+    } else if (!use_dsi && node.GetPartitionIDs().size() == 1) {
         // Virtual unified vertex partition: single partition with sub_partition_oids
         // pointing to real sub-partitions (e.g., Message → Comment + Post).
         // ORCA sees one CLogicalGet (no UnionAll), but the physical planner needs
@@ -3987,63 +3932,7 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanNodeScan(const BoundNodeExpres
             }
         }
     }
-    if (graphlet_oids.empty()) {
-        // No graphlets for this node pattern. Most common cause: the
-        // workspace is empty, or no vertex partition exists for the
-        // requested label. Rather than assert, raise a clean exception
-        // so the shell reports it and stays alive.
-        throw duckdb::InvalidInputException(
-            "MATCH pattern '" + name + "' does not match any vertex partition. "
-            "The workspace has no matching labels yet — import data first or "
-            "create partitions via the C API.");
-    }
-
     const auto &prop_exprs = node.GetPropertyExpressions();
-
-    // ── DSI: Coalesce multiple graphlets into representative groups ──
-    // DSI applies ONLY within a single partition (multi-PropertySchema case, e.g. DBpedia
-    // with 1304 graphlets for NODE partition). Multi-partition cases (e.g. LDBC Message →
-    // Comment + Post) are already handled by the converter's MPV logic.
-    std::vector<std::vector<uint64_t>> table_oids_in_groups;
-    bool use_dsi = false;
-#ifdef DYNAMIC_SCHEMA_INSTANTIATION
-    if (graphlet_oids.size() > 1 && node.GetPartitionIDs().size() == 1) {
-        auto has_temporal_graphlet = [&]() {
-            auto &catalog = context_->db->GetCatalog();
-            for (auto graphlet_oid : graphlet_oids) {
-                auto *ps = static_cast<PropertySchemaCatalogEntry *>(
-                    catalog.GetEntry(*context_, DEFAULT_SCHEMA,
-                                     (idx_t)graphlet_oid, true));
-                if (!ps) {
-                    continue;
-                }
-                if (ps->is_fake ||
-                    ps->GetName().find(DEFAULT_TEMPORAL_INFIX) != string::npos) {
-                    return true;
-                }
-            }
-            return false;
-        };
-        if (has_temporal_graphlet()) {
-            use_dsi = false;
-        } else {
-        vector<uint64_t> prop_key_ids;  // empty → MERGEALL grouping
-
-        vector<idx_t> table_oids(graphlet_oids.begin(), graphlet_oids.end());
-        vector<idx_t> representative_oids;
-        vector<vector<uint64_t>> prop_location;
-        vector<bool> has_temp_table;
-
-        context_->db->GetCatalogWrapper().ConvertTableOidsIntoRepresentativeOids(
-            *context_, prop_key_ids, table_oids, provider_,
-            representative_oids, table_oids_in_groups,
-            prop_location, has_temp_table);
-
-        graphlet_oids.assign(representative_oids.begin(), representative_oids.end());
-        use_dsi = true;
-        }
-    }
-#endif
 
     map<uint64_t, map<uint64_t, uint64_t>> mapping;
     vector<int> used_col_idx;

--- a/src/converter/cypher2orca_converter.cpp
+++ b/src/converter/cypher2orca_converter.cpp
@@ -3820,11 +3820,11 @@ turbolynx::LogicalPlan *Cypher2OrcaConverter::PlanNodeScan(const BoundNodeExpres
     const string &name = node.GetUniqueName();
     vector<uint64_t> graphlet_oids;
 
-    // For multi-partition vertices (e.g., Message → Comment + Post), use ALL
-    // graphlet OIDs from all partitions.  ORCA's UnionAll handles per-partition
-    // NULL projection for missing columns (e.g., Post.imageFile absent in Comment).
-    // The physical planner translates each branch independently — no separate
-    // MPV expansion needed at the NodeScan level.
+    // Use ALL graphlet OIDs from all partitions (e.g., Message → Comment +
+    // Post). Multi-graphlet nodes normally coalesce into a single DSI
+    // instance-descriptor Get below; when DSI is skipped (temporal/fake
+    // graphlets) the node falls back to a UnionAll over the graphlets plus
+    // the MPV sibling registration.
     graphlet_oids.assign(node.GetGraphletIDs().begin(), node.GetGraphletIDs().end());
 
     if (graphlet_oids.empty()) {

--- a/src/include/catalog/coalescing.hpp
+++ b/src/include/catalog/coalescing.hpp
@@ -22,8 +22,6 @@ class Coalescing {
         vector<bool> &is_each_group_has_temporary_table)
     {
         D_ASSERT(table_oids.size() > 0);
-        // Get first property schema cat entry to get partition catalog
-        // Currently, we do not support multi label (i.e. multi partition) case
         auto &catalog = db.GetCatalog();
         PropertySchemaCatalogEntry *ps_cat =
             (PropertySchemaCatalogEntry *)catalog.GetEntry(
@@ -38,12 +36,22 @@ class Coalescing {
 
         // Get property locations using property expressions & prop_to_idx map
         vector<idx_t> property_locations;
-        auto *prop_to_idxmap = part_cat->GetPropertyToIdxMap();
-        for (auto i = 0; i < property_key_ids.size(); i++) {
-            D_ASSERT(prop_to_idxmap->find(property_key_ids[i]) !=
-                     prop_to_idxmap->end());
-            property_locations.push_back(
-                prop_to_idxmap->at(property_key_ids[i]));
+        if (!property_key_ids.empty()) {
+#ifdef DEBUG
+            for (auto oid : table_oids) {
+                auto *member_ps = (PropertySchemaCatalogEntry *)
+                    catalog.GetEntry(context, DEFAULT_SCHEMA, oid);
+                D_ASSERT(member_ps->GetPartitionOID() == part_oid &&
+                         "property-location lookup requires a single partition");
+            }
+#endif
+            auto *prop_to_idxmap = part_cat->GetPropertyToIdxMap();
+            for (auto i = 0; i < property_key_ids.size(); i++) {
+                D_ASSERT(prop_to_idxmap->find(property_key_ids[i]) !=
+                         prop_to_idxmap->end());
+                property_locations.push_back(
+                    prop_to_idxmap->at(property_key_ids[i]));
+            }
         }
 
         // TODO partition catalog should store tables groups for each column.
@@ -479,11 +487,14 @@ class Coalescing {
             auto *types = ps_cat->GetTypes();
             auto *key_ids = ps_cat->GetKeyIDs();
             auto *ndvs = ps_cat->GetNDVs();
+            auto *offset_infos_check = ps_cat->GetOffsetInfos();
             accumulated_ndvs_for_physical_id_col +=
                 ps_cat->GetNumberOfRowsApproximately();
             merged_num_tuples += ps_cat->GetNumberOfRowsApproximately();
 
-            has_histogram = has_histogram && ndvs->size() > 0;
+            has_histogram = has_histogram &&
+                            ndvs->size() >= key_ids->size() &&
+                            offset_infos_check->size() >= key_ids->size();
 
             /**
              * TODO: adding NDVs is seems wrong.

--- a/src/include/converter/cypher2orca_converter.hpp
+++ b/src/include/converter/cypher2orca_converter.hpp
@@ -204,13 +204,6 @@ private:
 
     // ---- graph scan planners ----
     turbolynx::LogicalPlan *PlanNodeScan(const BoundNodeExpression &node);
-    // Scan a multi-graphlet node as its primary graphlet only, registering the
-    // remaining graphlets as MPV siblings in multi_vertex_partitions_ so the
-    // physical scan expands them. Keeps the logical plan a single Get (instead
-    // of a UnionAll over all graphlets), which lets an edge adjacency index
-    // narrow the node instead of base-scanning every partition.
-    turbolynx::LogicalPlan *PlanPrimaryGraphletNodeScan(
-        const BoundNodeExpression &node);
     turbolynx::LogicalPlan *PlanEdgeScan(const BoundRelExpression &rel);
     // Scan only one partition of a multi-partition edge (by index into GetPartitionIDs).
     // Used with multi_edge_partitions_ for AdjIdxJoin sibling expansion.

--- a/src/optimizer/orca/gporca/libgpopt/base/CUtils.cpp
+++ b/src/optimizer/orca/gporca/libgpopt/base/CUtils.cpp
@@ -4345,6 +4345,7 @@ CExpression * CUtils::PexprCollapseColumnarProjects(CMemoryPool *mp,
 
 	CExpressionArray *pdrgpexprPrElChild = GPOS_NEW(mp) CExpressionArray(mp);
 	CExpressionArray *pdrgpexprPrEl = GPOS_NEW(mp) CExpressionArray(mp);
+	CExpressionArray *pdrgpexprPassThru = GPOS_NEW(mp) CExpressionArray(mp);
 
 	// Iterate parent projections
 	ULONG ulLenPr = pexprScalar->Arity();
@@ -4359,6 +4360,11 @@ CExpression * CUtils::PexprCollapseColumnarProjects(CMemoryPool *mp,
 
 		if (0 == ulIntersect) {
 			pdrgpexprPrElChild->Append(pexprPrE);
+			CColRef *pcrPushed =
+				CScalarProjectElement::PopConvert(pexprPrE->Pop())->Pcr();
+			pdrgpexprPassThru->Append(GPOS_NEW(mp) CExpression(
+				mp, GPOS_NEW(mp) CScalarProjectElement(mp, pcrPushed),
+				CUtils::PexprScalarIdent(mp, pcrPushed)));
 		} else {
 			pdrgpexprPrEl->Append(pexprPrE);
 		}
@@ -4379,6 +4385,7 @@ CExpression * CUtils::PexprCollapseColumnarProjects(CMemoryPool *mp,
 		// no candidate project element found for collapsing
 		pdrgpexprPrElChild->Release();
 		pdrgpexprPrEl->Release();
+		pdrgpexprPassThru->Release();
 		return NULL;
 	}
 
@@ -4391,9 +4398,13 @@ CExpression * CUtils::PexprCollapseColumnarProjects(CMemoryPool *mp,
 	if (0 == pdrgpexprPrEl->Size()) {
 		// no residual project elements, return only child project
 		pdrgpexprPrEl->Release();
+		pdrgpexprPassThru->Release();
 
 		return pexprProject;
 	}
+
+	CUtils::AppendArrayExpr(pdrgpexprPassThru, pdrgpexprPrEl);
+	pdrgpexprPassThru->Release();
 
 	// conditionally return parent project
 	return GPOS_NEW(mp) CExpression(


### PR DESCRIPTION
## Summary

DSI (single-partition multi-graphlet coalescing) and MPV (multi-partition sibling expansion) solve the same problem — N physical tables behind one logical node — at two different layers, and the physical operators (PhysicalNodeScan / IdSeek) already converge on identical per-schema arrays. This PR routes both cases through DSI instance descriptors.

### Changes

**1. `converter: unify multi-label planning under DSI instance descriptors`**
- `PlanNodeScan`: drop the `partition == 1` gate on DSI — any multi-graphlet node (DBpedia-style multi-PropertySchema **or** multi-label like `Message` → `Comment`+`Post`) coalesces into one instance-descriptor Get. No logical UnionAll remains, so adjacency indexes narrow the node and join-predicate colrefs propagate intact. MPV sibling registration stays as the fallback for temporal/fake graphlets only.
- `coalescing`: groups may span partitions (the merge reads each member's own catalog entry, so it was already partition-agnostic); guard histogram merging against members with partial stats (`ndvs`/`offset_infos` not covering every key column) — previously an out-of-range crash when an unlabeled node coalesced all partitions.
- Revert the June primary-graphlet bypasses (f3bf0fb36, 71d64e2f5) and delete `PlanPrimaryGraphletNodeScan`: with a single DSI Get there is no UnionAll left to work around (the q14 colref-drop and the OPTIONAL full-scan are both structurally gone).
- GEM's `SplitGraphlets` now receives instance-descriptor components in join queries (previously only standalone scans built them), so per-graphlet join-order optimization applies to traversals as designed.

**2. `orca: keep pushed-down columns visible when partially collapsing columnar projects`**
- `PexprCollapseColumnarProjects` moved parent project elements that don't depend on the child (bare constants) into the child's list, but a columnar project outputs only its project list — the moved column vanished from the parent's output and optimization failed with *"No plan has been computed for required properties"*.
- Hit by any projection mixing a table column with a bare constant over a multi-graphlet node (`RETURN p.name, 42`, `RETURN p.name, NULL`), including the Bug J idiom `COALESCE(p.unknown, ...)` since the binder lowers unknown properties to NULL constants. Pre-existing on main (reproduced on the base commit).
- Fix: append a pass-through ident element to the residual parent list for every element pushed into the child.

### Verification
- ctest 26/26
- LDBC mini **767/767** (2539 assertions), TPC-H mini **767/767** (1224 assertions) — includes the previously-failing crud Bug J
- DBpedia 2-hop count 587 with IndexNLJoin plans; Message `HAS_CREATOR` traversal = 2 IndexNLJoins, no UnionAll, count 4175 (= Comment 790 + Post 3385, cross-checked)
- `-j gem`: join components now carry `IsInstanceDescriptor=1`; plans/results match the default path

🤖 Generated with [Claude Code](https://claude.com/claude-code)