### PR TITLE
planner: fix numeric comparison truncation (rhs-to-lhs downcast)

### DIFF
--- a/src/planner/planner_physical.cpp
+++ b/src/planner/planner_physical.cpp
@@ -7296,6 +7296,20 @@ bool Planner::pIsFilterPushdownAbleIntoScan(CExpression *selection_expr)
               filter_pred_expr->operator[](1)->Pop()->Eopid() ==
                   COperator::EOperatorId::EopScalarConst;
 
+    if (ok) {
+        // The scan applies the literal (and the range sentinel built from the
+        // literal's type) after casting to the column's stored type. A lossy
+        // mismatch (e.g. INT32 column vs DOUBLE literal 5.5) would truncate
+        // the bound; keep such predicates in the generic Filter, which
+        // promotes both sides to the wider type instead.
+        CScalarIdent *ident_op =
+            (CScalarIdent *)filter_pred_expr->operator[](0)->Pop();
+        CScalarConst *const_op =
+            (CScalarConst *)filter_pred_expr->operator[](1)->Pop();
+        ok = ident_op->Pcr()->RetrieveType()->MDId()->Equals(
+            const_op->GetDatum()->MDId());
+    }
+
     return ok;
 }
 

--- a/src/planner/planner_physical_scalar.cpp
+++ b/src/planner/planner_physical_scalar.cpp
@@ -500,15 +500,77 @@ unique_ptr<duckdb::Expression> Planner::pTransformScalarConst(CExpression * scal
 	return nullptr;
 }
 
+// Common type for comparing two numeric types without truncation.
+// Float/decimal mixes resolve to DOUBLE; integer mixes resolve to the
+// narrowest signed/unsigned-safe integer that represents both sides.
+static duckdb::LogicalType pCmpPromotionType(const duckdb::LogicalType &l,
+                                             const duckdb::LogicalType &r) {
+	using duckdb::LogicalType;
+	using duckdb::LogicalTypeId;
+	auto is_float = [](LogicalTypeId t) {
+		return t == LogicalTypeId::FLOAT || t == LogicalTypeId::DOUBLE ||
+		       t == LogicalTypeId::DECIMAL;
+	};
+	if (is_float(l.id()) || is_float(r.id())) {
+		if (l.id() == LogicalTypeId::DECIMAL &&
+		    r.id() == LogicalTypeId::DECIMAL) {
+			return LogicalType::MaxLogicalType(l, r);
+		}
+		return LogicalType::DOUBLE;
+	}
+	auto is_unsigned = [](LogicalTypeId t) {
+		return t >= LogicalTypeId::UTINYINT && t <= LogicalTypeId::UBIGINT;
+	};
+	auto bit_width = [](LogicalTypeId t) -> int {
+		switch (t) {
+			case LogicalTypeId::TINYINT:
+			case LogicalTypeId::UTINYINT: return 8;
+			case LogicalTypeId::SMALLINT:
+			case LogicalTypeId::USMALLINT: return 16;
+			case LogicalTypeId::INTEGER:
+			case LogicalTypeId::UINTEGER: return 32;
+			case LogicalTypeId::BIGINT:
+			case LogicalTypeId::UBIGINT: return 64;
+			case LogicalTypeId::HUGEINT: return 128;
+			default: return 64;
+		}
+	};
+	bool lu = is_unsigned(l.id()), ru = is_unsigned(r.id());
+	if (lu == ru) {
+		return bit_width(l.id()) >= bit_width(r.id()) ? l : r;
+	}
+	// Mixed signedness: a signed type must fit the unsigned side's full range.
+	int unsigned_bits = bit_width(lu ? l.id() : r.id());
+	int signed_bits = bit_width(lu ? r.id() : l.id());
+	if (unsigned_bits >= 64 || signed_bits > 64) {
+		return LogicalType::HUGEINT;
+	}
+	return LogicalType::BIGINT;
+}
+
 unique_ptr<duckdb::Expression> Planner::pTransformScalarCmp(CExpression * scalar_expr, CColRefArray* lhs_child_cols, CColRefArray* rhs_child_cols) {
 
 	CScalarCmp* op = (CScalarCmp*)scalar_expr->Pop();
 
 	unique_ptr<duckdb::Expression> lhs = pTransformScalarExpr(scalar_expr->operator[](0), lhs_child_cols, rhs_child_cols);
 	unique_ptr<duckdb::Expression> rhs = pTransformScalarExpr(scalar_expr->operator[](1), lhs_child_cols, rhs_child_cols);
-	//try casting (rhs to lhs)
 	if (lhs->return_type != rhs->return_type) {
-		rhs = pGenScalarCast(move(rhs), lhs->return_type);
+		if (lhs->return_type.IsNumeric() && rhs->return_type.IsNumeric()) {
+			// Promote both sides to a common type that holds either side
+			// exactly. Casting rhs down to lhs's type truncates (e.g. INT32
+			// column < 5.5 became < 5), and LogicalTypeId ordering puts the
+			// unsigned ids above BIGINT/DOUBLE, so MaxLogicalType is not
+			// usable here either (UBIGINT vs -1 or vs 5.5 would pick UBIGINT).
+			auto target = pCmpPromotionType(lhs->return_type, rhs->return_type);
+			if (lhs->return_type != target) {
+				lhs = pGenScalarCast(move(lhs), target);
+			}
+			if (rhs->return_type != target) {
+				rhs = pGenScalarCast(move(rhs), target);
+			}
+		} else {
+			rhs = pGenScalarCast(move(rhs), lhs->return_type);
+		}
 	}
 
 	if (rhs->GetExpressionClass() == duckdb::ExpressionClass::BOUND_CONSTANT) {


### PR DESCRIPTION
## Summary
Comparison translation cast the RHS to the LHS type unconditionally, truncating values: `INT32 column < 5.5` executed as `< 5`. **TPC-H q17 returned 231,374.60 instead of 338,657.51** (verified against a DuckDB oracle built from the same .tbl data with identical query parameters). The bug dates to 2023 in this translation path — engine-vs-old-engine comparisons shared the lineage, so it was never caught until an independent oracle was used.

## Changes
1. `pTransformScalarCmp`: numeric comparisons promote both sides to a common type (DOUBLE for float/decimal mixes; max-width for same-signedness integers; BIGINT/HUGEINT for mixed signedness). `MaxLogicalType` is unusable here — its id ordering ranks UBIGINT above BIGINT *and* DOUBLE, which would break `id = -1` and `col < 5.5` on unsigned columns. Non-numeric pairs keep the existing rhs→lhs cast.
2. `pIsFilterPushdownAbleIntoScan`: scan range-filter pushdown now requires literal type == column stored type. The pushed-down bounds (including the `MinimumValue` sentinel of the literal's type) are cast to the column type at scan time — previously truncating the bound and overflowing on `-DBL_MAX → INT32`. Mismatched predicates stay in the generic Filter, which now compares correctly.

## Verification
- **TPC-H SF1: 22/22 match a DuckDB oracle** (was 20/22: q17 wrong value, q2 residual diff — both fixed)
- LDBC mini 768/768, TPC-H mini 768/768, ctest 26/26
- SF1 warm perf sanity: q1 142ms / q4 68ms / q6 40ms / q12 115ms / q14 92ms — unchanged or better than before the pushdown guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)